### PR TITLE
Update copy-emr-client-deps.sh

### DIFF
--- a/utilities/emr-edge-node-creator/copy-emr-client-deps.sh
+++ b/utilities/emr-edge-node-creator/copy-emr-client-deps.sh
@@ -120,7 +120,8 @@ mkdir -p usr/share/aws
 cp -prL /usr/share/aws usr/share || true
 
 mkdir -p opt/aws
-cp -prL /opt/aws opt/
+#cp -prL /opt/aws opt/
+rsync -av --progress /opt/aws opt/ --exclude apitools
 
 CLUSTER_ID=$(ruby -e "puts \`grep jobFlowId  /emr/instance-controller/lib/info/job-flow.json\`.split.last[1..-3]")
 


### PR DESCRIPTION
*Issue #, if available:*
Fix issues with Linux1 AMIs, stop copying apitools from master, instead use yum install directly on edge node.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
