### PR TITLE
Added adjustable knobs for Managed Scaling

### DIFF
--- a/utilities/managed-scaling-dampener/MSdampener.sh
+++ b/utilities/managed-scaling-dampener/MSdampener.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/bash -e
 # Author: Suthan Phillips <suthan@amazon.com>
-# Usage: ./MSdampener.sh <node_group_conf> <Upper_max> <Initial_max> <Scale_increment_max> <Cool_down_period_to_initial_max> <minimum_cluster_size> <maximum_core_nodes> <maximum_on_demand>
-# Example usage: * * * * * sudo /home/hadoop/MSdampener.sh InstanceGroup 20 12 2 15 3 10 10 >> /home/hadoop/MSdampener_log.txt 2>&1
+# Usage: ./MSdampener.sh <node_group_conf> <Initial_max> <Scale_increment_max> <Cool_down_period_to_initial_max>
+# Example usage: * * * * * sudo /home/hadoop/MSdampener.sh InstanceGroup 11 3 60 >> /home/hadoop/MSdampener_log.txt 2>&1
 
 # Function to log entries with timestamps
 log_entry() {
@@ -24,7 +24,7 @@ log_containers_pending_metric() {
 check_containers_pending_log() {
   if [ ! -f "$CONTAINERS_PENDING_LOG" ]; then
     touch "$CONTAINERS_PENDING_LOG"
-    echo "0001-01-01 00:00:00 containersPending=1" >> "$CONTAINERS_PENDING_LOG"
+    echo "0001-01-01 00:00:00 containersPending=0" >> "$CONTAINERS_PENDING_LOG"
   fi
 }
 
@@ -35,15 +35,23 @@ create_log_directory() {
   fi
 }
 
+# Function to get AWS EMR managed scaling policy
+get_managed_scaling_policy() {
+  json_response=$(aws emr get-managed-scaling-policy --cluster-id "$CLUSTER_ID" --region "$REGION" || true)
+  
+  # Extract values and store in variables
+  minimum_capacity=$(echo "$json_response" | jq -r '.ManagedScalingPolicy.ComputeLimits.MinimumCapacityUnits')
+  unit_type=$(echo "$json_response" | jq -r '.ManagedScalingPolicy.ComputeLimits.UnitType')
+  maximum_capacity=$(echo "$json_response" | jq -r '.ManagedScalingPolicy.ComputeLimits.MaximumCapacityUnits')
+  maximum_core_capacity=$(echo "$json_response" | jq -r '.ManagedScalingPolicy.ComputeLimits.MaximumCoreCapacityUnits')
+  maximum_on_demand_capacity=$(echo "$json_response" | jq -r '.ManagedScalingPolicy.ComputeLimits.MaximumOnDemandCapacityUnits')
+}
+
 # User input values
 node_group_conf="$1"
-Upper_max="$2"
-Initial_max="$3"
-Scale_increment_max="$4"
-Cool_down_period_to_initial_max="$5"
-minimum_cluster_size="$6"
-maximum_core_nodes="$7"
-maximum_on_demand="$8"
+Initial_max="$2"
+Scale_increment_max="$3"
+Cool_down_period_to_initial_max="$4"
 
 # Set the log directory
 LOG_DIRECTORY="/var/log/MSdampener/"
@@ -61,7 +69,7 @@ CONTAINERS_PENDING_LOG="${LOG_DIRECTORY}containersPendingmetricdata.log"
 TIMESTAMP_FILE="${LOG_DIRECTORY}last_updated_timestamp.txt"
 
 # Get the region from the availability zone
-REGION=us-east-1
+REGION=us-west-2
 
 # Flag to turn off or on cooldown
 IGNORE_COOLDOWN=false
@@ -80,9 +88,13 @@ log_entry "Cluster ID: $CLUSTER_ID"
 ip_address=$(hostname -A | tr -d '[:space:]')
 log_entry "Master IP address: $ip_address"
 
+# Retrieve and log the managed scaling policy values
+get_managed_scaling_policy
+log_entry "Managed Scaling Policy Values - MinimumCapacity: $minimum_capacity, UnitType: $unit_type, MaximumCapacity: $maximum_capacity, MaximumCoreCapacity: $maximum_core_capacity, MaximumOnDemandCapacity: $maximum_on_demand_capacity"
+
 # Initialize variables
-Current_max=$Initial_max
 last_timestamp=0
+Current_max=$maximum_capacity
 
 # Check container pending value
 containersPending=$(curl -X GET "http://$ip_address:8088/ws/v1/cluster/metrics" | jq '.clusterMetrics.containersPending')
@@ -102,23 +114,71 @@ if [ "$containersPending" -eq 0 ]; then
     time_elapsed=$((current_timestamp - last_unix_timestamp))
 
     if [ $time_elapsed -ge $Cool_down_period_to_initial_max ]; then
-      Current_max=$Initial_max
-      log_entry "Cooldown period passed and containersPending is 0 for both current and last entry. Resetting Current_max to Initial_max: $Current_max"
+      # Check if time_elapsed is greater than 2,592,000 seconds (30 days)
+      if [ $time_elapsed -gt 2592000 ]; then
+        Current_max=$Initial_max
+        log_entry "Cooldown period passed and containersPending is 0 for both current and last entry, this is the first execution. Resetting Current_max to Initial_max: $Current_max"
+        echo "Minimum Capacity: $minimum_capacity" > "$LOG_DIRECTORY/originalMSconfiguration.txt"
+        echo "Unit Type: $unit_type" >> "$LOG_DIRECTORY/originalMSconfiguration.txt"
+        echo "Maximum Capacity: $maximum_capacity" >> "$LOG_DIRECTORY/originalMSconfiguration.txt"
+        echo "Maximum Core Capacity: $maximum_core_capacity" >> "$LOG_DIRECTORY/originalMSconfiguration.txt"
+        echo "Maximum On-Demand Capacity: $maximum_on_demand_capacity" >> "$LOG_DIRECTORY/originalMSconfiguration.txt"
+      else
+        Current_max=$Initial_max
+        log_entry "Cooldown period passed and containersPending is 0 for both current and last entry, Resetting Current_max to initial_max: $Current_max"
+      fi
     fi
   fi
 elif [ "$containersPending" -gt 0 ]; then
   Current_max=$((Current_max + Scale_increment_max))
   log_entry "Increasing Current_max due to containers pending. New Current_max: $Current_max"
+  if [ $time_elapsed -gt 2592000 ]; then
+	echo "Minimum Capacity: $minimum_capacity" > "$LOG_DIRECTORY/originalMSconfiguration.txt"
+        echo "Unit Type: $unit_type" >> "$LOG_DIRECTORY/originalMSconfiguration.txt"
+        echo "Maximum Capacity: $maximum_capacity" >> "$LOG_DIRECTORY/originalMSconfiguration.txt"
+        echo "Maximum Core Capacity: $maximum_core_capacity" >> "$LOG_DIRECTORY/originalMSconfiguration.txt"
+        echo "Maximum On-Demand Capacity: $maximum_on_demand_capacity" >> "$LOG_DIRECTORY/originalMSconfiguration.txt"
+  fi 
 fi
 
 # Set Managed scaling in EMR with the values computed
 if [ "$node_group_conf" == "InstanceFleet" ]; then
-  aws emr put-managed-scaling-policy --cluster-id $CLUSTER_ID --managed-scaling-policy "ComputeLimits={MinimumCapacityUnits=$minimum_cluster_size, MaximumCapacityUnits=$Current_max, MaximumOnDemandCapacityUnits=$maximum_on_demand, MaximumCoreCapacityUnits=3, UnitType=InstanceFleetUnits}" --region $REGION
-  log_entry "Setting Managed scaling policy for Instance Fleet with MaximumCapacityUnits: $Current_max"
+  maximum_capacity_org=$(grep "Maximum Capacity:" "$LOG_DIRECTORY/originalMSconfiguration.txt" | cut -d ':' -f 2 | tr -d '[:space:]')
+  maximum_on_demand_capacity_org=$(grep "Maximum On-Demand Capacity:" "$LOG_DIRECTORY/originalMSconfiguration.txt" | cut -d ':' -f 2 | tr -d '[:space:]')	
+  # For Instance Fleet
+  if [ "$maximum_on_demand_capacity_org" -gt "$Current_max" ]; then
+    maximum_on_demand_capacity=$Current_max
+  else
+    maximum_on_demand_capacity=$maximum_on_demand_capacity_org
+  fi
+  if [ "$maximum_core_capacity" -gt "$Current_max" ]; then
+    maximum_core_capacity=$Current_max
+  fi
+  if [ "$Current_max" -gt "$maximum_capacity_org" ]; then
+    Current_max="$maximum_capacity_org"
+    log_entry "Current_max exceeds maximum_capacity. Resetting Current_max to maximum_capacity: $Current_max"
+  fi
+  aws emr put-managed-scaling-policy --cluster-id "$CLUSTER_ID" --managed-scaling-policy "ComputeLimits={MinimumCapacityUnits=$minimum_capacity, MaximumCapacityUnits=$Current_max, MaximumOnDemandCapacityUnits=$maximum_on_demand_capacity, MaximumCoreCapacityUnits=$maximum_core_capacity, UnitType=InstanceFleetUnits}" --region "$REGION"
+  log_entry "Setting Managed scaling policy for Instance Fleet with MaximumCapacityUnits: $Current_max, MaximumOnDemandCapacityUnits: $maximum_on_demand_capacity"
 else
-  aws emr put-managed-scaling-policy --cluster-id $CLUSTER_ID --managed-scaling-policy "ComputeLimits={MinimumCapacityUnits=$minimum_cluster_size, MaximumCapacityUnits=$Current_max, MaximumOnDemandCapacityUnits=$maximum_on_demand, MaximumCoreCapacityUnits=$maximum_core_nodes, UnitType=Instances}" --region $REGION
-  log_entry "Setting Managed scaling policy for Instance Group with MaximumCapacityUnits: $Current_max"
+  maximum_capacity_org=$(grep "Maximum Capacity:" "$LOG_DIRECTORY/originalMSconfiguration.txt" | cut -d ':' -f 2 | tr -d '[:space:]')	
+  # For Instance Group
+  if [ "$maximum_on_demand_capacity_org" -gt "$Current_max" ]; then
+    maximum_on_demand_capacity=$Current_max
+  else
+    maximum_on_demand_capacity=$maximum_on_demand_capacity_org
+  fi
+  if [ "$maximum_core_capacity" -gt "$Current_max" ]; then
+    maximum_core_capacity=$Current_max
+  fi
+  if [ "$Current_max" -gt "$maximum_capacity_org" ]; then
+    Current_max="$maximum_capacity_org"
+    log_entry "Current_max exceeds maximum_capacity. Resetting Current_max to maximum_capacity: $Current_max"
+  fi
+  aws emr put-managed-scaling-policy --cluster-id "$CLUSTER_ID" --managed-scaling-policy "ComputeLimits={MinimumCapacityUnits=$minimum_capacity, MaximumCapacityUnits=$Current_max, MaximumOnDemandCapacityUnits=$maximum_on_demand_capacity, MaximumCoreCapacityUnits=$maximum_core_capacity, UnitType=Instances}" --region "$REGION"
+  log_entry "Setting Managed scaling policy for Instance Group with MaximumCapacityUnits: $Current_max, MaximumOnDemandCapacityUnits: $maximum_on_demand_capacity, MaximumCoreCapacityUnits: $maximum_core_capacity"
 fi
 
 log_entry "MSDampener Execution is completed"
+
 

--- a/utilities/managed-scaling-dampener/MSdampener.sh
+++ b/utilities/managed-scaling-dampener/MSdampener.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Author: Suthan Phillips <suthan@amazon.com>
+# Usage: ./MSdampener.sh <node_group_conf> <Upper_max> <Initial_max> <Scale_increment_max> <Cool_down_period_to_initial_max> <minimum_cluster_size> <maximum_core_nodes> <maximum_on_demand>
+# Example usage: * * * * * sudo /home/hadoop/MSdampener.sh InstanceGroup 20 12 2 15 3 10 10 >> /home/hadoop/MSdampener_log.txt 2>&1
+
+# Function to log entries with timestamps
+log_entry() {
+  echo "$(date +"%Y-%m-%d %H:%M:%S") $1" >> "$LOG_LOCATION"
+}
+
+# Function to check if the log file exists and create it if not
+check_log_file() {
+  if [ ! -f "$LOG_LOCATION" ]; then
+    touch "$LOG_LOCATION"
+  fi
+}
+
+# Function to log containersPending metric data with timestamps
+log_containers_pending_metric() {
+  echo "$(date +"%Y-%m-%d %H:%M:%S") containersPending=$1" >> "$CONTAINERS_PENDING_LOG"
+}
+
+# Function to check if the log file for containersPending data exists and create it with an initial entry if not
+check_containers_pending_log() {
+  if [ ! -f "$CONTAINERS_PENDING_LOG" ]; then
+    touch "$CONTAINERS_PENDING_LOG"
+    echo "0001-01-01 00:00:00 containersPending=1" >> "$CONTAINERS_PENDING_LOG"
+  fi
+}
+
+# Check and create the log directory if it doesn't exist
+create_log_directory() {
+  if [ ! -d "$LOG_DIRECTORY" ]; then
+    mkdir -p "$LOG_DIRECTORY"
+  fi
+}
+
+# User input values
+node_group_conf="$1"
+Upper_max="$2"
+Initial_max="$3"
+Scale_increment_max="$4"
+Cool_down_period_to_initial_max="$5"
+minimum_cluster_size="$6"
+maximum_core_nodes="$7"
+maximum_on_demand="$8"
+
+# Set the log directory
+LOG_DIRECTORY="/var/log/MSdampener/"
+
+# Set the log filename with timestamp
+LOG_FILENAME="scaling_log_$(date +"%Y%m%d%H").log"
+
+# Set the complete path for the log file
+LOG_LOCATION="${LOG_DIRECTORY}${LOG_FILENAME}"
+
+# Set the containersPending metric data log file
+CONTAINERS_PENDING_LOG="${LOG_DIRECTORY}containersPendingmetricdata.log"
+
+# Set the timestamp file path
+TIMESTAMP_FILE="${LOG_DIRECTORY}last_updated_timestamp.txt"
+
+# Get the region from the availability zone
+REGION=us-east-1
+
+# Flag to turn off or on cooldown
+IGNORE_COOLDOWN=false
+
+# Create the log directory
+create_log_directory
+
+# Check and create the containersPending log file if it doesn't exist
+check_containers_pending_log
+
+# Set CLUSTER_ID
+CLUSTER_ID=$(cat /mnt/var/lib/info/job-flow.json | grep -oP '(?<="jobFlowId": ")[^"]+')
+log_entry "Cluster ID: $CLUSTER_ID"
+
+# Set master_ip
+ip_address=$(hostname -A | tr -d '[:space:]')
+log_entry "Master IP address: $ip_address"
+
+# Initialize variables
+Current_max=$Initial_max
+last_timestamp=0
+
+# Check container pending value
+containersPending=$(curl -X GET "http://$ip_address:8088/ws/v1/cluster/metrics" | jq '.clusterMetrics.containersPending')
+
+# Log containersPending metric data with a timestamp
+log_containers_pending_metric $containersPending
+
+# Check containersPending and determine the values for $Current_max
+if [ "$containersPending" -eq 0 ]; then
+  last_entry=$(tail -n 2 "$CONTAINERS_PENDING_LOG" | head -n 1)
+  last_timestamp=$(echo "$last_entry" | cut -d ' ' -f 1-2)
+  last_unix_timestamp=$(date -d "$last_timestamp" +%s)
+  last_containers_pending=$(echo "$last_entry" | awk -F= '{print $2}')
+
+  if [ "$last_containers_pending" -eq 0 ]; then
+    current_timestamp=$(date +%s)
+    time_elapsed=$((current_timestamp - last_unix_timestamp))
+
+    if [ $time_elapsed -ge $Cool_down_period_to_initial_max ]; then
+      Current_max=$Initial_max
+      log_entry "Cooldown period passed and containersPending is 0 for both current and last entry. Resetting Current_max to Initial_max: $Current_max"
+    fi
+  fi
+elif [ "$containersPending" -gt 0 ]; then
+  Current_max=$((Current_max + Scale_increment_max))
+  log_entry "Increasing Current_max due to containers pending. New Current_max: $Current_max"
+fi
+
+# Set Managed scaling in EMR with the values computed
+if [ "$node_group_conf" == "InstanceFleet" ]; then
+  aws emr put-managed-scaling-policy --cluster-id $CLUSTER_ID --managed-scaling-policy "ComputeLimits={MinimumCapacityUnits=$minimum_cluster_size, MaximumCapacityUnits=$Current_max, MaximumOnDemandCapacityUnits=$maximum_on_demand, MaximumCoreCapacityUnits=3, UnitType=InstanceFleetUnits}" --region $REGION
+  log_entry "Setting Managed scaling policy for Instance Fleet with MaximumCapacityUnits: $Current_max"
+else
+  aws emr put-managed-scaling-policy --cluster-id $CLUSTER_ID --managed-scaling-policy "ComputeLimits={MinimumCapacityUnits=$minimum_cluster_size, MaximumCapacityUnits=$Current_max, MaximumOnDemandCapacityUnits=$maximum_on_demand, MaximumCoreCapacityUnits=$maximum_core_nodes, UnitType=Instances}" --region $REGION
+  log_entry "Setting Managed scaling policy for Instance Group with MaximumCapacityUnits: $Current_max"
+fi
+
+log_entry "MSDampener Execution is completed"
+

--- a/utilities/managed-scaling-dampener/README.md
+++ b/utilities/managed-scaling-dampener/README.md
@@ -3,30 +3,55 @@
 ### Introduction
 In certain scenarios, Managed Scaling clusters may be underutilized due to EMR constantly scaling to maximum capacity. This occurs when workloads demand a large number of containers, leading to EMR scaling up to meet these demands. The low utilization is a result of these containers running for a small duration (less than 30 seconds) and by the time the cluster scales up, all pending tasks are already completed. The EMR Managed Scaling algorithm is designed to scale up nodes to the maximum to minimize the impact of failures and optimize for SLA, which is a good fit for many customer use cases. But in some scenarios, when there is a preference to optimize it for cost, we would want it to scale up conservatively and scale down aggressively.
 
-To address this concern, this project introduces adjustable knobs for Managed Scaling in EMR providing customers with the control to define the Initial_max for Managed Scaling, gradually scale up to Upper_max, and efficiently revert back to Initial_max if the container_pending is zero for a specified Cool_down_period.
+To address this concern, this project introduces adjustable knobs for Managed Scaling in EMR providing customers with the control to define the Initial_max for Managed Scaling, gradually scale up to Managed Scaling Max, and efficiently revert back to Initial_max if the container_pending is zero for a specified Cool_down_period.
 
-### Running Directly on EMR Clusters
-This script can be executed as a cron job on the master node of an EMR cluster. The frequency of the cron job can be customized. Also, it logs the events to the configured location.
+### Execution on EMR Clusters
 
-### Instructions
-1. The user needs to pass the following 8 values as script arguments in the specified order:
+This involves two scripts:
 
-    * node_group_conf="$1": Specifies whether the node group is an Instance Fleet or Instance Group.
-    * Upper_max="$2": Sets the threshold for scaling up to the maximum, beyond which scaling will cease.
-    * Initial_max="$3": Establishes the initial threshold for scaling up.
-    * Scale_increment_max="$4": Determines the threshold for incrementing the maximum in Managed Scaling based on container pending.
-    * Cool_down_period_to_initial_max="$5": Sets the cooldown period in seconds. This period dictates the minimum time interval during which container pending should remain zero to reset to the initial max.
-    * minimum_cluster_size="$6": Represents the lower boundary of the cluster size.
-    * maximum_core_nodes="$7": Specifies the upper boundary of the core node group.
-    * maximum_on_demand="$8": Sets the upper boundary of the capacity to be provisioned from the On-Demand market.
+- **MSdampener.sh**: The primary script that manages Managed Scaling values based on user-provided input.
+- **run_continuously_s3.sh**: This script copies 'MSdampener.sh' from an S3 bucket to the Hadoop home directory, running it periodically to control Managed Scaling values.
 
-2. Schedule the script as a cron job and execute it every 5 minutes, add the following line to your crontab file:
+The latter script is executed as an EMR step on the cluster, with customizable execution frequency by adjusting the sleep command. It logs events to the configured location (default is '/var/log/MSdampener/').
 
+#### Instructions
+
+1. Save the scripts in an S3 location:
 ```bash
-* * * * * sudo /home/hadoop/MSdampener.sh InstanceGroup 20 12 2 15 3 10 10 >> /home/hadoop/MSdampener_log.txt 2>&1
+s3://suthan-emr-bda/scripts/new-2/MSdampener.sh
+s3://suthan-emr-bda/scripts/new-2/run_continuously_s3.sh
+```
+2. Modify 'run_continuously_s3.sh' by passing the following four values as arguments to 'MSdampener.sh' in the specified order:
+
+- **node_group_conf**="$1": Specifies if the node group is an Instance Fleet or Instance Group.
+- **Initial_max**="$2": Sets the initial threshold for scaling up.
+- **Scale_increment_max**="$3": Determines the threshold for incrementing the maximum in Managed Scaling based on container pending.
+- **Cool_down_period_to_initial_max**="$4": Sets the cooldown period in seconds, defining the minimum interval for container pending to remain zero to reset to the initial max.
+
+3. Run the modified 'run_continuously_s3.sh' script as an EMR step, for example:
+```bash
+--steps '[{"Name":"MSdampener","ActionOnFailure":"CONTINUE","Jar":"s3://us-west-2.elasticmapreduce/libs/script-runner/script-runner.jar","Properties":"","Args":["s3://suthan-emr-bda/scripts/new-2/run_continuously_s3.sh"],"Type":"CUSTOM_JAR"}]'
+```
+    
+### Details
+The following values will be taken from the Managed Scaling Configuration which you define in your EMR clusters
+    * maximum_capacity: Sets the threshold for scaling up to the maximum, beyond which scaling will cease.
+    * minimum_capacity: Represents the lower boundary of the cluster size.
+    * maximum_core_capacity: Specifies the upper boundary of the core node group.
+    * maximum_on_demand_capacity: Sets the upper boundary of the capacity to be provisioned from the On-Demand market.
+    
+You should be able to see these values stored in 'originalMSconfiguration.txt' file the MSDampener log directory. For example,
+
+```sh
+$ cat /var/log/MSdampener/originalMSconfiguration.txt
+Minimum Capacity: 4
+Unit Type: InstanceFleetUnits
+Maximum Capacity: 1600
+Maximum Core Capacity: 4
+Maximum On-Demand Capacity: 1600
 ```
 
-### Limitations
-1. The minimum cooldown period can be configured for 1 minute, which aligns with the shortest duration possible for an individual metric's cron job setting.
-2. Similarly, the script execution frequency cannot be more frequent than 1 minute due to the same constraint.
-3. Configuring this for multiple clusters within a single account may result in a high volume of Managed Scaling API calls to EMR.
+### Considerations
+1. Ensure that the cooldown period is either less than or equal to the script execution period specified by the sleep command in MSdampener.sh for it to be effective.
+2. Configuring this for multiple clusters within a single account may result in a high volume of Managed Scaling API calls to EMR.
+

--- a/utilities/managed-scaling-dampener/README.md
+++ b/utilities/managed-scaling-dampener/README.md
@@ -1,0 +1,32 @@
+# Managed Scaling Dampener
+
+### Introduction
+In certain scenarios, Managed Scaling clusters may be underutilized due to EMR constantly scaling to maximum capacity. This occurs when workloads demand a large number of containers, leading to EMR scaling up to meet these demands. The low utilization is a result of these containers running for a small duration (less than 30 seconds) and by the time the cluster scales up, all pending tasks are already completed. The EMR Managed Scaling algorithm is designed to scale up nodes to the maximum to minimize the impact of failures and optimize for SLA, which is a good fit for many customer use cases. But in some scenarios, when there is a preference to optimize it for cost, we would want it to scale up conservatively and scale down aggressively.
+
+To address this concern, this project introduces adjustable knobs for Managed Scaling in EMR providing customers with the control to define the Initial_max for Managed Scaling, gradually scale up to Upper_max, and efficiently revert back to Initial_max if the container_pending is zero for a specified Cool_down_period.
+
+### Running Directly on EMR Clusters
+This script can be executed as a cron job on the master node of an EMR cluster. The frequency of the cron job can be customized. Also, it logs the events to the configured location.
+
+### Instructions
+1. The user needs to pass the following 8 values as script arguments in the specified order:
+
+    * node_group_conf="$1": Specifies whether the node group is an Instance Fleet or Instance Group.
+    * Upper_max="$2": Sets the threshold for scaling up to the maximum, beyond which scaling will cease.
+    * Initial_max="$3": Establishes the initial threshold for scaling up.
+    * Scale_increment_max="$4": Determines the threshold for incrementing the maximum in Managed Scaling based on container pending.
+    * Cool_down_period_to_initial_max="$5": Sets the cooldown period in seconds. This period dictates the minimum time interval during which container pending should remain zero to reset to the initial max.
+    * minimum_cluster_size="$6": Represents the lower boundary of the cluster size.
+    * maximum_core_nodes="$7": Specifies the upper boundary of the core node group.
+    * maximum_on_demand="$8": Sets the upper boundary of the capacity to be provisioned from the On-Demand market.
+
+2. Schedule the script as a cron job and execute it every 5 minutes, add the following line to your crontab file:
+
+```bash
+* * * * * sudo /home/hadoop/MSdampener.sh InstanceGroup 20 12 2 15 3 10 10 >> /home/hadoop/MSdampener_log.txt 2>&1
+```
+
+### Limitations
+1. The minimum cooldown period can be configured for 1 minute, which aligns with the shortest duration possible for an individual metric's cron job setting.
+2. Similarly, the script execution frequency cannot be more frequent than 1 minute due to the same constraint.
+3. Configuring this for multiple clusters within a single account may result in a high volume of Managed Scaling API calls to EMR.

--- a/utilities/managed-scaling-dampener/run_continuously_s3.sh
+++ b/utilities/managed-scaling-dampener/run_continuously_s3.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+sudo aws s3 cp s3://suthan-emr-bda/scripts/new-2/MSdampener.sh /home/hadoop/
+
+while true; do
+  sudo sh /home/hadoop/MSdampener.sh InstanceFleet 400 400 60 >> /home/hadoop/MSdampener_log.txt 2>&1
+  sleep 240
+done &


### PR DESCRIPTION
*Issue #, if available:*
Customers reported that their clusters are underutilized because EMR Managed Scaling constantly scales to maximum capacity

*Description of changes:*
This script introduces adjustable knobs for Managed Scaling in EMR providing customers with the control to define the Initial_max for Managed Scaling, gradually scale up to Upper_max, and efficiently revert back to Initial_max if the container_pending is zero for a specified Cool_down_period.


