### PR TITLE
Needs sudo rm -f

### DIFF
--- a/utilities/emr-ec2-custom-python3/custom-python/copy-python.sh
+++ b/utilities/emr-ec2-custom-python3/custom-python/copy-python.sh
@@ -6,4 +6,4 @@ PYTHON_ARCHIVE=$1
 # Copy and extract the Python archive into `/usr/local`
 sudo aws s3 cp "${PYTHON_ARCHIVE}" /usr/local/
 cd /usr/local/
-sudo tar -xf "$(basename "${PYTHON_ARCHIVE}")" && rm "$(basename "${PYTHON_ARCHIVE}")"
+sudo tar -xf "$(basename "${PYTHON_ARCHIVE}")" && sudo rm -f "$(basename "${PYTHON_ARCHIVE}")"


### PR DESCRIPTION
*Description of changes:*
I saw two messages on the EMR 7.1.0 master node like below
- `rm: remove write-protected regular file 'python3.11.9.tar.gz'?` : needs `-f`
- `rm: cannot remove 'python3.11.9.tar.gz': Permission denied` : needs `sudo`

The installation target is `/usr/local/` which needs the root permission to write.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
