### PR TITLE
add docker build env setup for multi-platform

### DIFF
--- a/utilities/emr-on-eks-kyuubi/README.md
+++ b/utilities/emr-on-eks-kyuubi/README.md
@@ -77,6 +77,17 @@ aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --
 # create a new repository in your ECR, **ONE-OFF task**
 aws ecr create-repository --repository-name $ECR_URL/kyuubi-emr-eks --image-scanning-configuration scanOnPush=true
 
+# create a builder for multi-platform build
+docker buildx create --name kyuubi-builder --driver docker-container --bootstrap
+
+# make sure the docker daemon file(/etc/docker/daemon.json) has the following settings
+
+#{
+#	"features": {
+#		"containerd-snapshotter": true
+#	}
+#}
+
 # image build and push. It takes approx. 40mins
 docker buildx build --platform linux/amd64,linux/arm64 \
 -t $ECR_URL/kyuubi-emr-eks:emr6.15_kyuubi1.8 \
@@ -85,6 +96,7 @@ docker buildx build --platform linux/amd64,linux/arm64 \
 --build-arg KYUUBI_VERSION=1.8.0 \
 --build-arg SPARK_VERSION=3.4.1 \
 --build-arg RANGER_VERSION=2.4.0 \
+--builder kyuubi-builder \
 --push .
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

docker buildx build may failed if the docker is not configured properly like the following errors:

```
Admin:~/environment/aws-emr-utilities/utilities/emr-on-eks-kyuubi (main) $ docker buildx build --platform linux/amd64,linux/arm64 -t $ECR_URL/kyuubi-emr-eks:emr6.15_kyuubi1.8 -f dockers/kyuubi/Dockerfile --build-arg SPARK_BASE_IMAGE=755674844232.dkr.ecr.us-east-1.amazonaws.com/spark/emr-6.15.0 --build-arg KYUUBI_VERSION=1.8.0 --build-arg SPARK_VERSION=3.4.1 --build-arg RANGER_VERSION=2.4.0 --push .
[+] Building 0.0s (0/0)                                                                                                                                                                                           docker:default
ERROR: Multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
