### PR TITLE
corrected configuration.json file with right jmx-exporter agent path …

### DIFF
--- a/utilities/emr-observability/conf_files/configuration.json
+++ b/utilities/emr-observability/conf_files/configuration.json
@@ -1,1 +1,34 @@
-[{"classification":"yarn-env", "properties":{}, "configurations":[{"classification":"export", "properties":{"YARN_RESOURCEMANAGER_OPTS":"\"${YARN_RESOURCEMANAGER_OPTS} -javaagent:/etc/prometheus/jmx_prometheus_javaagent-0.17.0.jar=7005:/etc/hadoop/conf/yarn_jmx_config_resource_manager.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50111\"", "YARN_NODEMANAGER_OPTS":"\"${YARN_NODEMANAGER_OPTS} -javaagent:/etc/prometheus/jmx_prometheus_javaagent-0.17.0.jar=7005:/etc/hadoop/conf/yarn_jmx_config_node_manager.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50111\""}, "configurations":[]}]},{"classification":"hdfs-env", "properties":{}, "configurations":[{"classification":"export", "properties":{"HADOOP_DATANODE_OPTS":"\"${HADOOP_DATANODE_OPTS} -javaagent:/etc/prometheus/jmx_prometheus_javaagent-0.17.0.jar=7001:/etc/hadoop/conf/hdfs_jmx_config_datanode.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50103\"", "HADOOP_NAMENODE_OPTS":"\"${HADOOP_NAMENODE_OPTS} -javaagent:/etc/prometheus/jmx_prometheus_javaagent-0.17.0.jar=7001:/etc/hadoop/conf/hdfs_jmx_config_namenode.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50103\""}, "configurations":[]}]},{"classification":"spark-metrics", "properties":{"*.sink.jmx.class":"org.apache.spark.metrics.sink.JmxSink"}, "configurations":[]}]
+[
+  {
+    "Classification": "yarn-env",
+    "Configurations": [
+      {
+        "Classification": "export",
+        "Properties": {
+          "YARN_NODEMANAGER_OPTS": "\"${YARN_NODEMANAGER_OPTS} -javaagent:/usr/lib/prometheus/jmx_prometheus_javaagent-0.17.2.jar=7005:/etc/hadoop/conf/yarn_jmx_config_node_manager.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50111\"",
+          "YARN_RESOURCEMANAGER_OPTS": "\"${YARN_RESOURCEMANAGER_OPTS} -javaagent:/usr/lib/prometheus/jmx_prometheus_javaagent-0.17.2.jar=7005:/etc/hadoop/conf/yarn_jmx_config_resource_manager.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50111\""
+        }
+      }
+    ],
+    "Properties": {}
+  },
+  {
+    "Classification": "hdfs-env",
+    "Configurations": [
+      {
+        "Classification": "export",
+        "Properties": {
+          "HADOOP_DATANODE_OPTS": "\"${HADOOP_DATANODE_OPTS} -javaagent:/usr/lib/prometheus/jmx_prometheus_javaagent-0.17.2.jar=7001:/etc/hadoop/conf/hdfs_jmx_config_datanode.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50103\"",
+          "HADOOP_NAMENODE_OPTS": "\"${HADOOP_NAMENODE_OPTS} -javaagent:/usr/lib/prometheus/jmx_prometheus_javaagent-0.17.2.jar=7001:/etc/hadoop/conf/hdfs_jmx_config_namenode.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50103\""
+        }
+      }
+    ],
+    "Properties": {}
+  },
+  {
+    "Classification": "spark-metrics",
+    "Properties": {
+      "*.sink.jmx.class": "org.apache.spark.metrics.sink.JmxSink"
+    }
+  }
+]


### PR DESCRIPTION
…and version.

*Issue #, EMR configuration file has incorrect version and path of jmx-exporter jar :*

*Description of changes:*
Bootstrap action script `install_prometheus_v2.sh` download jmx-exporter jar `jmx_prometheus_javaagent-0.17.2.jar` and copy to `/usr/lib/prometheus` however EMR configuration file uses `/etc/prometheus/jmx_prometheus_javaagent-0.17.0.jar` path having incorrect location and jar.  
  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
