### PR TITLE
spark upgrade agent: address upgrade template cfn high findings from …

### DIFF
--- a/utilities/apache-spark-agents/spark-upgrade-agent-cloudformation/spark-upgrade-mcp-setup.yaml
+++ b/utilities/apache-spark-agents/spark-upgrade-agent-cloudformation/spark-upgrade-mcp-setup.yaml
@@ -142,6 +142,7 @@ Resources:
     Condition: CreateS3KmsKey
     Properties:
       Description: KMS key for S3 staging bucket encryption
+      EnableKeyRotation: true
       KeyPolicy:
         Version: '2012-10-17'
         Statement:
@@ -308,7 +309,16 @@ Resources:
           - Sid: EMRServerlessPassRole
             Effect: Allow
             Action: 'iam:PassRole'
-            Resource: '*'
+            Resource: !If
+              - HasExistingRoleForS3Access
+              - !If
+                - IsExecutionRoleArn
+                - !Ref ExecutionRoleToGrantS3Access
+                - !Sub 'arn:aws:iam::${AWS::AccountId}:role/*${ExecutionRoleToGrantS3Access}'
+              - - !Sub 'arn:aws:iam::${AWS::AccountId}:role/*EMR*'
+                - !Sub 'arn:aws:iam::${AWS::AccountId}:role/*emr*'
+                - !Sub 'arn:aws:iam::${AWS::AccountId}:role/*Spark*'
+                - !Sub 'arn:aws:iam::${AWS::AccountId}:role/*spark*'
             Condition:
               StringLike:
                 'iam:PassedToService': 'emr-serverless.amazonaws.com'


### PR DESCRIPTION
…cfn_nag_scan

*Issue #, if available:*
 `cfn_nag_scan` identified two high findings in Spark upgrade agent example resource setup CFN template. 

*Description of changes:*
Addressed the findings and re-scan issue does not showing up.

After this change: 
1. if `ExecutionRoleToGrantS3Access` is passed in, use it for `iam:PassRole`. Otherwise, define general pattern matching based to scope down on certain keywords `EMR/emr/Spark/spark` - this does not guarantee to address all cases but a best effort to scope down the risk.
2. Enable KMS rotation by default if a new KMS key will be created.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
