### PR TITLE
Fix airflow providers packages in requirements.txt

### DIFF
--- a/utilities/apache-spark-agents/spark-troubleshooting-agent-notification-integration/airflow-integration/requirements.txt
+++ b/utilities/apache-spark-agents/spark-troubleshooting-agent-notification-integration/airflow-integration/requirements.txt
@@ -1,5 +1,5 @@
 # Merge these requirements into your Airflow dependencies configuration
-airflow-providers-amazon
-airflow-providers-slack
+apache-airflow-providers-amazon
+apache-airflow-providers-slack
 strands-agents
 mcp-proxy-for-aws


### PR DESCRIPTION
This PR fixes the airflow providers packages in requirements.txt.

Packages `airflow-providers-amazon` and `airflow-providers-slack` are replaced with their true names, `apache-airflow-providers-amazon` and `apache-airflow-providers-slack`.