### PR TITLE
Remove Glue PassRole Access permission from Troubleshooting CFN template

### DIFF
--- a/utilities/apache-spark-agents/spark-troubleshooting-agent-cloudformation/spark-troubleshooting-mcp-setup.yaml
+++ b/utilities/apache-spark-agents/spark-troubleshooting-agent-cloudformation/spark-troubleshooting-mcp-setup.yaml
@@ -235,14 +235,6 @@ Resources:
               - 'glue:GetQuery'
               - 'glue:GetDashboardUrl'
             Resource: '*'
-          
-          - Sid: GluePassRoleAccess
-            Effect: Allow
-            Action: 'iam:PassRole'
-            Resource: '*'
-            Condition:
-              StringLike:
-                'iam:PassedToService': 'glue.amazonaws.com'
   
   # KMS policy for CloudWatch Logs (if key provided)
   SparkTroubleshootingCloudWatchKmsPolicy:


### PR DESCRIPTION
upon scanning troubleshooting CFN template, one high finding is below

------------------------------------------------------------ spark-troubleshooting-mcp-setup.yaml
------------------------------------------------------------------------------------------------------------------------ | FAIL F39
|
| Resource: ["GluePolicy"]
| Line Numbers: [191]
|
| IAM policy should not allow * resource with PassRole action

PassRole is not needed to support Glue use case per investigation.

Re-run of cfn_nag_scan against the troubleshooting CFN shows only warning

Failures count: 0
Warnings count: 5


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
