### PR TITLE
[powers] remove kiro fluff and hallucinations

### DIFF
--- a/utilities/apache-spark-agents/kiro-powers/spark-troubleshooting-agent/POWER.md
+++ b/utilities/apache-spark-agents/kiro-powers/spark-troubleshooting-agent/POWER.md
@@ -1,7 +1,7 @@
 ---
 name: "spark-troubleshooting-agent"
 displayName: "Troubleshoot Spark applications on AWS"
-description: "Troubleshoot Spark applications on AWS EMR, Glue, and SageMaker - analyze failures, identify bottlenecks, get code recommendations. For more info, please see: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/spark-troubleshoot.html"
+description: "Troubleshoot failed Spark applications on AWS EMR, Glue, and SageMaker Unified Studio - analyze failures, identify root causes, get code recommendations. For more info, please see: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/spark-troubleshoot.html"
 keywords: ["spark", "emr", "glue", "sagemaker", "troubleshooting", "pyspark", "scala", "performance", "debugging", "aws"]
 author: "AWS"
 ---
@@ -63,14 +63,13 @@ Region and role ARN will be in the outputs tab. These will be used in the next s
 
 # Overview
 
-Troubleshoot Apache Spark applications on Amazon EMR, AWS Glue, and Amazon SageMaker through natural language. The agent analyzes failed jobs, identifies performance bottlenecks, and provides code recommendations.
+Troubleshoot failed Apache Spark applications on Amazon EMR, AWS Glue, and Amazon SageMaker Unified Studio through natural language. The agent analyzes failed jobs, identifies root causes, and provides code recommendations.
 
 **Key capabilities:**
-- **Failure Analysis**: Analyze failed PySpark and Scala jobs
-- **Root Cause Identification**: Correlate telemetry and identify issues
-- **Performance Diagnostics**: Find bottlenecks and resource problems
-- **Code Recommendations**: Get specific fixes and optimizations
-- **Multi-Platform**: EMR EC2, EMR Serverless, Glue, SageMaker
+- **Failure Analysis**: Analyze failed PySpark and Scala jobs across platforms
+- **Root Cause Identification**: Analyze Spark event logs, error stack traces, resource metrics, query plans, and configurations to identify failure causes
+- **Code Recommendations**: Get specific code fixes for failed applications (EMR EC2, Glue, SageMaker Unified Studio)
+- **Multi-Platform**: EMR EC2, EMR Serverless, Glue, SageMaker Unified Studio
 
 **Note**: Preview service using cross-region inference for AI processing.
 
@@ -80,41 +79,41 @@ Troubleshoot Apache Spark applications on Amazon EMR, AWS Glue, and Amazon SageM
 **Connection:** MCP Proxy for AWS
 **Authentication:** AWS IAM role assumption
 **Timeout:** 180 seconds
+**Supported Platforms:** EMR EC2, EMR Serverless, AWS Glue, SageMaker Unified Studio
 
-Analyzes Spark application failures and identifies root causes through:
-- Feature extraction from Spark History Server logs
-- Telemetry data collection and analysis
-- Root cause identification using AI
-- Performance metric correlation
-- Error pattern recognition
+Analyzes failed Spark workloads by examining:
+- Spark event logs and error stack traces
+- Resource usage metrics (CPU, memory, I/O, network via CloudWatch)
+- Query plans and executor timelines
+- Spark configuration parameters
+- Provides root cause identification and diagnostic explanations
 
 ### sagemaker-unified-studio-mcp-code-rec
-**Connection:** MCP Proxy for AWS  
+**Connection:** MCP Proxy for AWS
 **Authentication:** AWS IAM role assumption
 **Timeout:** 180 seconds
+**Supported Platforms:** EMR EC2, AWS Glue, SageMaker Unified Studio
 
-Generates code recommendations based on root cause analysis:
-- Code pattern analysis
-- Optimization recommendations
-- Configuration adjustments
-- Architectural improvements
-- Specific code fixes with examples
+**Note:** Code recommendations are **not available** for EMR Serverless. Use the troubleshooting server for EMR Serverless failure analysis.
+
+Generates code recommendations for failed PySpark applications:
+- Analyzes failed application code and provides specific code fixes
+- Returns a code diff with recommended changes
+- **PySpark only** — Scala workloads receive troubleshooting analysis but not code recommendations
 
 ## Usage Examples
 
 ### Basic Troubleshooting Request
 
 ```
-"My Spark job on EMR cluster j-XXXXX failed. 
-Application ID: application_1234567890_0001
+"My Spark job on EMR failed. Cluster ID: j-1234567890ABC, Step ID: s-1234567890ABC.
 Can you analyze what went wrong?"
 ```
 
 The agent will:
-1. Extract telemetry from Spark History Server
-2. Analyze error traces and logs
-3. Identify root cause
-4. Provide diagnostic explanation
+1. Analyze Spark event logs and error stack traces
+2. Identify root cause
+3. Provide diagnostic explanation
 
 ### Request Code Recommendations
 
@@ -123,66 +122,41 @@ The agent will:
 ```
 
 The agent will:
-1. Analyze code patterns
-2. Identify inefficient operations
-3. Provide specific code modifications
-4. Suggest configuration tuning
+1. Analyze the failed application code
+2. Provide a code diff with specific fixes
 
 ## Common Troubleshooting Scenarios
 
 ### OutOfMemory Errors
 
 ```
-"My EMR Serverless job app-XXXXX (job jr-XXXXX) is failing with OutOfMemoryError. 
-Can you analyze memory usage and suggest optimizations?"
+"My EMR Serverless job failed with OutOfMemoryError.
+Application ID: 00abcdef12345678, Job Run ID: 00abcdef87654321.
+Can you analyze what went wrong?"
 ```
 
 Agent analyzes:
-- Executor memory configuration
+- Executor memory configuration and resource metrics
 - Partition sizes and data skew
 - Memory-intensive operations
-- Provides memory tuning and code optimizations
+- Provides root cause analysis and diagnostic explanation
 
-### Slow Performance
+### Failed Glue Job
 
 ```
-"My Glue job glue-job-XXXXX used to complete in 10 minutes but now takes 
-over an hour. Can you identify the bottleneck?"
+"My Glue job 'daily-etl' failed on run jr_abc123def456abc123def456abc12345.
+Can you analyze what went wrong?"
 ```
 
 Agent analyzes:
-- Stage execution times
-- Data skew in partitions
-- Shuffle operations
-- Resource utilization
-- Provides partitioning and optimization recommendations
+- Error stack traces and failure patterns
+- Stage execution issues
+- Resource utilization problems
+- Provides root cause analysis and suggested fixes
 
-### Data Skew
+### SageMaker Unified Studio
 
-```
-"My SageMaker Spark job has extreme data skew - most tasks finish quickly 
-but a few take forever. How can I fix this?"
-```
-
-Agent provides:
-- Skewed partition identification
-- Data distribution analysis
-- Salting techniques
-- Repartitioning strategies
-- Code examples
-
-### Performance Optimization
-
-```
-"Can you review my EMR job j-XXXXX configuration and suggest performance optimizations?"
-```
-
-Agent reviews:
-- Spark configuration settings
-- Resource allocation
-- Executor and driver sizing
-- Dynamic allocation settings
-- Shuffle operation tuning
+**Note:** SageMaker Unified Studio (SMUS) has built-in troubleshooting capabilities through its own UI, which provides richer context including session information. SMUS users should use the built-in assistant for the best experience. This power is primarily intended for **EMR EC2, EMR Serverless, and Glue** troubleshooting.
 
 ## Best Practices
 
@@ -226,20 +200,16 @@ Agent reviews:
 ### "Insufficient permissions"
 **Cause:** IAM role missing permissions
 **Solution:**
-- Verify CloudFormation stack created successfully
-- Check IAM permissions:
-  - EMR: `elasticmapreduce:Describe*`, `elasticmapreduce:List*`
-  - Glue: `glue:GetJobRun`, `glue:GetJobRuns`
-  - S3: `s3:GetObject` for logs
-  - CloudWatch: `logs:GetLogEvents`
-- Re-deploy CloudFormation if needed
+- Verify CloudFormation stack created successfully in the correct region
+- Check that the IAM role ARN in your `smus-mcp-profile` matches the stack outputs
+- Re-deploy the CloudFormation stack if needed — it defines all required permissions
 
 ### "No recommendations generated"
-**Cause:** No actionable improvements identified
+**Cause:** No actionable code fixes identified for the failure
 **Solution:**
-- Job may be well-optimized
-- Ask specific questions: "analyze memory usage"
-- Provide more context about expected vs actual performance
+- Ask more specific questions about the failure: "what caused the OutOfMemoryError?"
+- Provide additional context: error messages, data sizes, job configuration
+- Ensure you provided the correct job/step/run identifiers
 
 ## MCP Config Placeholders
 
@@ -280,35 +250,17 @@ Agent reviews:
 
 **Authentication:** AWS IAM role via CloudFormation stack
 
-**Required Permissions:**
-- EMR: `elasticmapreduce:Describe*`, `elasticmapreduce:List*`
-- Glue: `glue:GetJobRun`, `glue:GetJobRuns`
-- SageMaker: `sagemaker:DescribeProcessingJob`
-- S3: `s3:GetObject` (logs)
-- CloudWatch: `logs:GetLogEvents`
+**Required Permissions:** Managed by the CloudFormation stack deployed during onboarding. See the stack template for the full list of IAM permissions granted.
 
 **Supported Platforms:**
 - Amazon EMR on EC2
 - Amazon EMR Serverless
 - AWS Glue (Spark jobs)
-- Amazon SageMaker (Spark kernels)
+- Amazon SageMaker Unified Studio (%%pyspark notebook cells — primarily use the built-in SMUS assistant instead)
 
 **Supported Languages:**
 - PySpark (Python)
 - Scala
-
-## Tips
-
-1. **Be specific** - Include cluster ID, application ID, or job run ID
-2. **Provide context** - Explain expected vs. actual behavior  
-3. **Start with symptoms** - Describe what you're seeing
-4. **Ask follow-ups** - Dig deeper into recommendations
-5. **Test incrementally** - Apply one change at a time
-6. **Monitor results** - Track metrics after changes
-7. **Use natural language** - Explain in your own words
-8. **Request examples** - Ask for code samples
-9. **Consider costs** - Some optimizations use more resources
-10. **Review audit logs** - Check CloudTrail for compliance
 
 ---
 

--- a/utilities/apache-spark-agents/kiro-powers/spark-upgrade-agent/POWER.md
+++ b/utilities/apache-spark-agents/kiro-powers/spark-upgrade-agent/POWER.md
@@ -31,6 +31,11 @@ Before proceeding, ensure the following are installed:
     - You can do this with `echo ${AWS_PROFILE}`. No response likely means they are using the `default` profile
     - use this profile later when configuring the `spark-upgrade-profile`
 
+- **Local Spark project**: Your Spark application source code must be available on the local filesystem
+  - The upgrade agent reads and modifies files locally — it does not work on remote repositories directly
+  - Clone or check out your project to a local directory before starting
+  - **Recommended**: Commit your current code to version control before starting so you can easily review or revert changes
+
 **CRITICAL**: If any prerequisites are missing, DO NOT proceed. Install missing components first.
 
 ## Step 2: Deploy CloudFormation Stack
@@ -69,25 +74,27 @@ Before proceeding, ensure the following are installed:
 The Apache Spark Upgrade Agent for Amazon EMR is a conversational AI capability that accelerates Apache Spark version upgrades for your EMR applications. Traditional Spark upgrades require months of engineering effort to analyze API changes, resolve dependency conflicts, and validate functional correctness. The agent simplifies the upgrade process through natural language prompts, automated code transformation, and data quality validation.
 
 **Key capabilities:**
-- **Automated Code Transformation**: Automatically updates code for Spark version compatibility
-- **Dependency Resolution**: Resolves version conflicts and updates build configurations
+- **Upgrade Planning**: Analyzes project structure and generates a comprehensive upgrade plan
+- **Build & Dependency Updates**: Resolves version conflicts and updates build configurations
+- **Iterative Failure Fixing**: Analyzes build and runtime failures and suggests targeted fixes
 - **Validation Testing**: Submits and monitors remote validation jobs on EMR
-- **Data Quality Validation**: Ensures data integrity throughout the upgrade process
-- **Natural Language Interface**: Interact using conversational prompts
+- **Data Quality Validation**: Compares output between source and target Spark versions
 - **Multi-Platform Support**: EMR EC2 and EMR Serverless
 - **Multi-Language Support**: PySpark (Python) and Scala
 
 **Note**: Preview service using cross-region inference for AI processing.
 
-## Architecture Overview
+## How It Works
 
-The upgrade agent orchestrates the upgrade using specialized tools through these steps:
+The upgrade agent orchestrates a **chained workflow** — all tools are called sequentially, sharing a single `analysis_id` generated in the planning step. You provide a single prompt to start the upgrade, and the agent handles the entire process:
 
-1. **Planning**: Analyzes project structure and generates upgrade plans
-2. **Compile and Build**: Updates build environment, dependencies, and fixes build failures
-3. **Spark Code Edit Tools**: Applies targeted code updates for version compatibility
-4. **Execute & Validation**: Submits remote validation jobs to EMR and monitors execution
-5. **Observability**: Tracks upgrade progress and provides status updates
+1. **Planning** — Analyzes project structure, identifies dependencies, and generates a comprehensive upgrade plan
+2. **Build Configuration** — Updates build files (pom.xml, build.sbt, requirements.txt, etc.) and resolves dependency conflicts
+3. **Environment Setup** — Checks and updates Java or Python environment for the target Spark version
+4. **Build & Test** — Compiles the project, runs local tests, and iteratively fixes build failures
+5. **Validation Jobs** — Submits the upgraded application to EMR for remote validation and monitors execution
+6. **Data Quality** — Compares output between source and target Spark versions (when enabled)
+7. **Summary** — Generates a comprehensive upgrade report documenting all changes made
 
 ## Available MCP Server
 
@@ -96,225 +103,98 @@ The upgrade agent orchestrates the upgrade using specialized tools through these
 **Authentication:** AWS IAM role assumption via spark-upgrade-profile
 **Timeout:** 180 seconds
 
-Provides comprehensive Spark upgrade tools including:
-- Project analysis and upgrade planning
-- Automated code transformation
-- Build environment updates
-- Dependency resolution
-- Remote EMR job validation
-- Data quality validation
-- Progress tracking and observability
+Provides a set of chained upgrade tools including:
+- Upgrade plan generation and reuse
+- Build configuration and dependency updates
+- Java and Python environment checks
+- Build guidance and failure analysis
+- Remote validation job submission and status monitoring (EMR EC2, EMR Serverless)
+- Data quality comparison between source and target versions
+- Upgrade result tracking and history
 
-## Usage Examples
+## Usage
 
-### Start a Spark Upgrade Project
+The upgrade agent is designed as a **single-prompt workflow**. You describe your upgrade goal, and the agent orchestrates all the steps automatically. You do **not** need to call individual capabilities separately — the tools chain together from a single starting prompt.
 
+### Starting an Upgrade
+
+Provide your current version, target version, and project path. Optionally include your EMR cluster/application ID and S3 staging path:
+
+**PySpark example (EMR on EC2):**
 ```
-"I want to upgrade my PySpark application from Spark 3.3 to 3.5. 
-The project is located at /path/to/my/spark/project.
-Can you help me create an upgrade plan?"
-```
-
-The agent will:
-1. Analyze your project structure
-2. Identify current Spark version and dependencies
-3. Generate a comprehensive upgrade plan
-4. Outline required changes and validation steps
-
-### Automated Code Transformation
-
-```
-"Please apply the automated code transformations for my Spark 3.5 upgrade.
-Fix any API compatibility issues and update deprecated methods."
+"I want to upgrade my PySpark application from EMR 6.10.0 to 7.8.0.
+The project is at /path/to/my/spark/project.
+My EMR cluster is j-1234567890ABC.
+S3 staging path: s3://my-bucket/spark-upgrade/"
 ```
 
-The agent will:
-1. Scan your codebase for compatibility issues
-2. Apply automated code transformations
-3. Update deprecated API calls
-4. Fix build-time and runtime errors
-5. Maintain approval control over all changes
-
-### Build Environment Update
-
+**Scala example (EMR Serverless):**
 ```
-"Update my build configuration and dependencies for Spark 3.5.
-My project uses Maven/SBT and has custom dependencies."
+"I need to upgrade my Scala Spark application from EMR 6.0.0 to 7.0.0.
+The project is at /path/to/my/scala/project.
+I'm using EMR Serverless, application ID: 00abcdef12345678,
+execution role: arn:aws:iam::123456789012:role/my-emr-serverless-role.
+S3 staging path: s3://my-bucket/spark-upgrade/"
 ```
 
-The agent will:
-1. Update build files (pom.xml, build.sbt, etc.)
-2. Resolve dependency conflicts
-3. Update Spark and related library versions
-4. Compile the project and fix build failures
+### What the Agent Does Automatically
 
-### Remote Validation Testing
+Once you provide the starting prompt, the agent runs through the full workflow:
 
-```
-"Submit a validation job to EMR to test my upgraded application.
-Use my existing EMR cluster j-XXXXX or create a new one with Spark 3.5."
-```
+1. **Generates an upgrade plan** — Scans your project structure, identifies dependencies, detects build system (Maven, SBT, or Python), and creates a step-by-step upgrade plan
+2. **Updates build configuration** — Modifies build files and resolves dependency version conflicts for the target Spark version
+3. **Sets up environment** — Checks and updates your Java or Python environment as needed
+4. **Builds and tests** — Compiles the project, runs local tests if available, and iteratively fixes build failures using failure analysis
+5. **Submits validation jobs** — Packages and submits your application to EMR (EC2 or Serverless) for remote validation
+6. **Monitors execution** — Polls job status until completion, reporting progress
+7. **Validates data quality** — If enabled, runs your job on both source and target Spark versions and compares outputs (schema, row counts, statistical summaries)
+8. **Generates summary** — Produces a comprehensive report of all changes, validation results, and any remaining issues
 
-The agent will:
-1. Package your upgraded application
-2. Submit validation jobs to EMR
-3. Monitor job execution and logs
-4. Report on success/failure and performance
-5. Identify any runtime issues
+You will be asked to review and approve changes at key points throughout the process.
 
-### Data Quality Validation
+## Supported Scenarios
 
-```
-"Validate that my upgraded Spark job produces the same data quality results.
-Compare output between Spark 3.3 and 3.5 versions."
-```
+The upgrade agent works on a **single project** at a time. Provide your project path, current version, and target version.
 
-The agent will:
-1. Run data quality checks on both versions
-2. Compare output datasets
-3. Identify any data discrepancies
-4. Provide detailed validation reports
+**Supported upgrade paths:**
+- PySpark applications (Python) — with pip/requirements.txt, setup.py, pyproject.toml, or Pipfile
+- Scala/Java Spark applications — with Maven (pom.xml) or SBT (build.sbt)
 
-## Common Upgrade Scenarios
+**Supported validation platforms:**
+- Amazon EMR on EC2 (provide cluster ID)
+- Amazon EMR Serverless (provide application ID)
 
-### PySpark Application Upgrade
-
-```
-"I have a PySpark ETL pipeline that processes daily data on EMR.
-Current version: Spark 3.3, Target: Spark 3.5
-Can you help me upgrade and validate it?"
-```
-
-Agent provides:
-- Code compatibility analysis
-- Automated PySpark API updates
-- Dependency resolution
-- EMR job validation
-- Performance comparison
-
-### Scala Spark Application Upgrade
-
-```
-"My Scala Spark streaming application needs to be upgraded from 3.2 to 3.5.
-It uses structured streaming and custom serializers."
-```
-
-Agent handles:
-- Scala API compatibility
-- Structured streaming changes
-- Serialization updates
-- Build configuration updates
-- Streaming job validation
-
-### Multi-Module Project Upgrade
-
-```
-"I have a complex Spark project with multiple modules and shared libraries.
-How should I approach upgrading this to Spark 3.5?"
-```
-
-Agent provides:
-- Module dependency analysis
-- Phased upgrade planning
-- Shared library compatibility
-- Integration testing strategy
-- Coordinated validation approach
-
-### EMR Serverless Migration with Upgrade
-
-```
-"I want to upgrade my Spark application and migrate from EMR on EC2 to EMR Serverless.
-What's the best approach for this dual migration?"
-```
-
-Agent assists with:
-- Platform-specific considerations
-- Spark version compatibility
-- Resource configuration changes
-- Code modifications for serverless
-- Validation on both platforms
+**Note:** For complex projects with multiple modules or shared libraries, consider upgrading each module separately as individual projects.
 
 ## Best Practices
 
-### ✅ Do:
-
-- **Start with analysis** - Let the agent analyze your project first
-- **Review all changes** - Approve each automated transformation
-- **Test incrementally** - Validate changes step by step
-- **Use staging environment** - Test on non-production EMR clusters first
-- **Backup your code** - Commit changes to version control
-- **Monitor validation jobs** - Watch EMR job execution closely
-- **Validate data quality** - Ensure output correctness
-- **Document the process** - Keep track of changes made
-- **Plan for rollback** - Have a way to revert if needed
-- **Engage early** - Start upgrade planning well in advance
-
-### ❌ Don't:
-
-- **Skip project analysis** - Always let the agent analyze first
-- **Auto-approve all changes** - Review each transformation
-- **Rush the process** - Take time to validate each step
-- **Ignore build failures** - Fix compilation issues before proceeding
-- **Skip validation testing** - Always test on EMR before production
-- **Ignore data quality** - Validate output correctness
-- **Forget dependencies** - Check all third-party libraries
-- **Skip documentation** - Document your upgrade process
-- **Ignore warnings** - Address compatibility warnings
-- **Upgrade production directly** - Always test in staging first
+- **Review changes before approving** — The agent will propose code and build file modifications. Read the diffs before accepting them.
+- **Use a non-production EMR cluster with sample data** — Point validation jobs at a staging cluster, not your production environment. Use sample mock datasets that represent your production data but are smaller in size.
+- **Check third-party dependencies** — The agent updates Spark and related libraries, but verify that your other dependencies (e.g., custom JARs, internal libraries) are compatible with the target Spark version.
+- **Enable data quality validation** — If your job writes output data, enable the data quality check to compare results between source and target Spark versions.
 
 ## Troubleshooting
 
+The upgrade agent has **self-healing capability** — when it encounters build failures, code issues, or validation errors, it iteratively analyzes the failure and applies fixes automatically. The scenarios below are expected parts of the upgrade process, not terminal errors.
+
 ### "Project analysis failed"
 **Cause:** Unable to access or parse project structure
-**Solution:**
-- Verify project path is correct and accessible
-- Ensure project has valid build files (pom.xml, build.sbt, etc.)
-- Check file permissions
-- Provide more specific project information
+**Note:** This is the only scenario that requires user action — verify that the project path is correct, accessible, and contains valid build files (pom.xml, build.sbt, requirements.txt, etc.).
 
-### "Code transformation failed"
-**Cause:** Complex code patterns that require manual intervention
-**Solution:**
-- Review the specific transformation error
-- Apply manual fixes for complex cases
-- Break down large transformations into smaller steps
-- Consult Spark migration guides for specific patterns
+### Build failures, code errors, and validation failures
+**These are expected.** The agent will automatically:
+1. Analyze the failure using the upgrade tools
+2. Identify the root cause and relevant Spark migration rules
+3. Apply targeted fixes to your code or build configuration
+4. Re-build and re-test iteratively until the issue is resolved
 
-### "Build compilation failed"
-**Cause:** Dependency conflicts or incompatible versions
-**Solution:**
-- Review dependency version matrix
-- Update conflicting libraries
-- Check for Spark-specific dependency requirements
-- Consider excluding transitive dependencies
-
-### "EMR validation job failed"
-**Cause:** Runtime errors in upgraded application
-**Solution:**
-- Review EMR job logs for specific errors
-- Check Spark configuration compatibility
-- Verify data input formats and schemas
-- Test with smaller datasets first
-- Apply additional code fixes based on runtime errors
-
-### "Data quality validation failed"
-**Cause:** Output differences between Spark versions
-**Solution:**
-- Review data quality report details
-- Check for behavioral changes in Spark versions
-- Verify input data consistency
-- Adjust validation thresholds if appropriate
-- Investigate specific data discrepancies
+If the agent cannot resolve an issue after multiple attempts, it will surface the problem and ask for your input.
 
 ## Configuration
 
 **Authentication:** AWS IAM role via CloudFormation stack (spark-upgrade-profile)
 
-**Required Permissions:**
-- EMR: `elasticmapreduce:*` (for job submission and monitoring)
-- S3: `s3:GetObject`, `s3:PutObject` (for staging artifacts and logs)
-- IAM: `iam:PassRole` (for EMR job execution)
-- CloudWatch: `logs:*` (for log access and monitoring)
+**Required Permissions:** Managed by the CloudFormation stack deployed during onboarding. See the stack template for the full list of IAM permissions granted.
 
 **Supported Platforms:**
 - Amazon EMR on EC2
@@ -327,20 +207,7 @@ Agent assists with:
 **Supported Build Systems:**
 - Maven (pom.xml)
 - SBT (build.sbt)
-- Gradle (build.gradle)
-
-## Tips
-
-1. **Start with project analysis** - Always begin with "analyze my project"
-2. **Review each transformation** - Don't auto-approve all changes
-3. **Test incrementally** - Validate each step before proceeding
-4. **Use natural language** - Describe your upgrade goals clearly
-5. **Provide context** - Share project structure and requirements
-6. **Monitor validation jobs** - Watch EMR execution closely
-7. **Validate data quality** - Ensure output correctness
-8. **Document changes** - Keep track of modifications
-9. **Plan for rollback** - Have a revert strategy ready
-10. **Engage early** - Start planning upgrades well in advance
+- Python (requirements.txt, setup.py, pyproject.toml, Pipfile, poetry.lock, conda)
 
 ---
 


### PR DESCRIPTION
  Summary                                                                                                  
                         
  - Fact-checked both Spark troubleshooting and upgrade agent Kiro powers against actual MCP tool
  definitions and integration source code
  - Fixed 16 issues including hallucinated capabilities, wrong identifier formats, overpromised features,
  and incorrect architecture descriptions
  - Restructured upgrade agent from misleading individual-prompt examples to accurate single-prompt chained
   workflow (addresses team feedback that tools were never meant to be called individually)

  Troubleshooting Agent (spark-troubleshooting-agent/POWER.md)

  - Fixed wrong identifier formats in all usage examples (EMR EC2, EMR Serverless, Glue)
  - Removed unreleased "performance optimization" capability claims (tool only supports failed jobs)
  - Added note that code recommendations are not available for EMR Serverless
  - Replaced hallucinated MCP server capability descriptions with actual tool behavior
  - Removed hallucinated IAM permissions list — pointed to CFN stack as source of truth
  - Added caveat that SMUS troubleshooting is primarily done via the built-in SMUS UI
  - Removed unverified "configuration tuning" and "metrics/resource utilization" claims from code-rec
  descriptions

  Upgrade Agent (spark-upgrade-agent/POWER.md)

  - Restructured usage from 5 individual prompts to single-prompt chained workflow with analysis_id
  - Added "How It Works" section explaining the 7-step tool chain
  - Removed hallucinated "Automated Code Transformation" standalone capability
  - Removed fabricated "Multi-Module Project Upgrade" and "EMR Serverless Migration" scenarios
  - Removed unverified Gradle from supported build systems, added Python build tools
  - Added "Local Spark project" prerequisite (agent modifies files locally)
  - Trimmed 20-item Do/Don't list to 4 actionable, non-redundant best practices
  - Removed hallucinated IAM permissions, pointed to CFN stack

  Test plan

  - Reviewed all capability claims against MCP tool definitions and integration source code
  - Verified onboarding steps are unchanged and unaffected
  - Confirmed mcp.json files are unchanged and functional

Drafted by Claude, reviewed by tonyrusignuolo