### PR TITLE
Add HBase cross-region snapshot copy utility

### DIFF
--- a/utilities/hbase-cross-region-copy/README.md
+++ b/utilities/hbase-cross-region-copy/README.md
@@ -1,0 +1,159 @@
+# HBase Cross-Region Snapshot Copy
+
+A utility to copy HBase snapshots from one S3 bucket to another across AWS regions while preserving data integrity using ETag checksums.
+
+## Overview
+
+This script automates the process of copying HBase snapshots between AWS regions using the HBase snapshot export feature with ETag checksum validation. It ensures data integrity during cross-region transfers without requiring manual S3 sync operations or disabling checksum verification.
+
+## Features
+
+- Data Integrity: Uses ETag checksums to validate data during transfer
+- Cross-Region Support: Copy snapshots between any AWS regions
+- Progress Monitoring: Real-time progress tracking of the export job
+- Automatic Validation: Verifies snapshot exists before starting
+- Error Handling: Comprehensive error checking and reporting
+
+## Prerequisites
+
+- HBase 2.x running on Amazon EMR
+- Source cluster with HBase snapshot already created
+- SSH access to the source EMR cluster master node
+- AWS CLI configured with appropriate permissions
+- IAM permissions for S3 operations on both source and destination buckets
+
+## Usage
+
+```bash
+./hbase-cross-region-copy.sh <source_cluster_master> <source_bucket_path> <dest_bucket_path> <snapshot_name> [ssh_key]
+```
+
+### Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `source_cluster_master` | EMR master node hostname or IP address | Yes |
+| `source_bucket_path` | S3 path where HBase data currently resides | Yes |
+| `dest_bucket_path` | S3 path where data should be copied | Yes |
+| `snapshot_name` | Name of the HBase snapshot to copy | Yes |
+| `ssh_key` | SSH key to access EMR cluster | No (default: ~/.ssh/id_rsa) |
+
+### Example
+
+```bash
+./hbase-cross-region-copy.sh \
+  ec2-3-85-123-155.compute-1.amazonaws.com \
+  s3://source-bucket-us-east-1/hbase/ \
+  s3://dest-bucket-ap-south-1/hbase/ \
+  snap_20260302_151152 \
+  ~/.ssh/my-emr-key.pem
+```
+
+## How It Works
+
+1. **Validation**: Checks if the specified snapshot exists on the source cluster
+2. **Export**: Initiates HBase snapshot export with ETag checksum enabled
+3. **Monitoring**: Tracks the MapReduce job progress in real-time
+4. **Verification**: Confirms data was successfully copied to the destination
+
+The script uses the `-Dfs.s3a.etag.checksum.enabled=true` flag to ensure that S3 ETags are used for checksum validation, preventing the "checksum mismatch" errors that can occur with cross-region S3 operations.
+
+## Performance
+
+The script uses HBase's MapReduce-based snapshot export, which runs with parallel mappers for efficient data transfer.
+
+**Typical performance:**
+- Speed: 2-3 GB/s (varies based on data size, network conditions, and number of mappers)
+- Duration: ~10 minutes per 1.5 TiB of data
+
+**Tuning for better performance:**
+
+You can control the number of mappers to improve transfer speed by adding the `-mappers` flag:
+
+```bash
+# On the source cluster, modify the export command to use more mappers
+sudo -u hbase hbase snapshot export \
+  -Dfs.s3a.etag.checksum.enabled=true \
+  -snapshot snap_name \
+  -copy-to s3://dest-bucket/hbase/ \
+  -mappers 200
+```
+
+Increasing the number of mappers can significantly improve throughput for large datasets, depending on your cluster size and available resources. Start with 100-200 mappers and adjust based on your cluster capacity.
+
+## Next Steps After Copy
+
+Once the copy is complete, you can:
+
+1. Launch a new EMR cluster in the destination region
+2. Configure the cluster to use the destination S3 bucket as HBase root directory
+3. Import the snapshot on the new cluster:
+
+```bash
+hbase snapshot import \
+  -Dfs.s3a.etag.checksum.enabled=true \
+  -snapshot snap_20260302_151152 \
+  -copy-from s3://dest-bucket-ap-south-1/hbase/ \
+  -copy-to s3://dest-bucket-ap-south-1/hbase/
+```
+
+## Troubleshooting
+
+### Snapshot Not Found
+If the script reports that the snapshot doesn't exist:
+- Verify the snapshot name is correct
+- Check that you're connected to the correct cluster
+- List available snapshots: `echo "list_snapshots" | hbase shell`
+
+### Export Job Fails
+If the export job fails:
+- Check `/tmp/export-output.log` for detailed error messages
+- Verify IAM permissions for both source and destination buckets
+- Ensure the destination bucket exists and is accessible
+
+### SSH Connection Issues
+If you can't connect to the cluster:
+- Verify the SSH key path is correct
+- Check security group rules allow SSH access
+- Ensure the master node hostname/IP is correct
+
+## IAM Permissions Required
+
+The EMR cluster's IAM role needs the following S3 permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::source-bucket/*",
+        "arn:aws:s3:::source-bucket",
+        "arn:aws:s3:::dest-bucket/*",
+        "arn:aws:s3:::dest-bucket"
+      ]
+    }
+  ]
+}
+```
+
+## References
+
+- [AWS EMR HBase Best Practices - Data Integrity](https://aws.github.io/aws-emr-best-practices/docs/bestpractices/Applications/HBase/data_integrity)
+- [HBase Snapshot Documentation](https://hbase.apache.org/book.html#ops.snapshots)
+- [Amazon EMR HBase on S3](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-hbase-s3.html)
+
+## License
+
+This utility is licensed under the MIT-0 License. See the [LICENSE](../../LICENSE) file in the repository root.
+
+## Contributing
+
+Contributions are welcome! Please open an issue or submit a pull request.

--- a/utilities/hbase-cross-region-copy/hbase-cross-region-copy.sh
+++ b/utilities/hbase-cross-region-copy/hbase-cross-region-copy.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+#
+# HBase Cross-Region Snapshot Copy Script
+# 
+# This script copies an HBase snapshot from one S3 bucket to another across AWS regions
+# while preserving data integrity using ETag checksums.
+#
+# Requirements: HBase 2.x on Amazon EMR
+#
+# Usage: ./hbase-cross-region-copy.sh <source_cluster_master> <source_bucket_path> <dest_bucket_path> <snapshot_name> [ssh_key]
+#
+# Example:
+#   ./hbase-cross-region-copy.sh \
+#     ec2-3-85-123-155.compute-1.amazonaws.com \
+#     s3://source-bucket/hbase/ \
+#     s3://dest-bucket/hbase/ \
+#     snap_20260302_151152 \
+#     ~/.ssh/my-key.pem
+
+set -e
+
+# Arguments
+SOURCE_CLUSTER_MASTER="$1"
+SOURCE_BUCKET_PATH="$2"
+DEST_BUCKET_PATH="$3"
+SNAPSHOT_NAME="$4"
+SSH_KEY="${5:-~/.ssh/id_rsa}"
+
+# Validate arguments
+if [ -z "$SOURCE_CLUSTER_MASTER" ] || [ -z "$SOURCE_BUCKET_PATH" ] || [ -z "$DEST_BUCKET_PATH" ] || [ -z "$SNAPSHOT_NAME" ]; then
+    echo "Usage: $0 <source_cluster_master> <source_bucket_path> <dest_bucket_path> <snapshot_name> [ssh_key]"
+    echo ""
+    echo "Arguments:"
+    echo "  source_cluster_master  - EMR master node hostname or IP"
+    echo "  source_bucket_path     - S3 path where HBase data currently resides"
+    echo "  dest_bucket_path       - S3 path where data should be copied"
+    echo "  snapshot_name          - Name of the HBase snapshot to copy"
+    echo "  ssh_key                - SSH key to access EMR cluster (default: ~/.ssh/id_rsa)"
+    echo ""
+    echo "Example:"
+    echo "  $0 ec2-3-85-123-155.compute-1.amazonaws.com \\"
+    echo "     s3://source-bucket/hbase/ \\"
+    echo "     s3://dest-bucket/hbase/ \\"
+    echo "     snap_20260302_151152 \\"
+    echo "     ~/.ssh/my-key.pem"
+    exit 1
+fi
+
+echo "=========================================="
+echo "HBase Cross-Region Snapshot Copy"
+echo "=========================================="
+echo "Source Cluster: $SOURCE_CLUSTER_MASTER"
+echo "Source Path:    $SOURCE_BUCKET_PATH"
+echo "Dest Path:      $DEST_BUCKET_PATH"
+echo "Snapshot:       $SNAPSHOT_NAME"
+echo "SSH Key:        $SSH_KEY"
+echo "=========================================="
+echo ""
+
+# Step 1: Check if snapshot exists
+echo "[1/4] Checking if snapshot exists..."
+SNAPSHOT_EXISTS=$(ssh -i "$SSH_KEY" -o StrictHostKeyChecking=no hadoop@"$SOURCE_CLUSTER_MASTER" \
+    "echo \"list_snapshots '$SNAPSHOT_NAME'\" | hbase shell 2>&1 | grep -c '$SNAPSHOT_NAME' || echo 0")
+
+if [ "$SNAPSHOT_EXISTS" -eq 0 ]; then
+    echo "ERROR: Snapshot '$SNAPSHOT_NAME' not found on source cluster"
+    echo "Available snapshots:"
+    ssh -i "$SSH_KEY" hadoop@"$SOURCE_CLUSTER_MASTER" "echo 'list_snapshots' | hbase shell 2>&1 | grep -A 100 SNAPSHOT"
+    exit 1
+fi
+echo "✓ Snapshot exists"
+echo ""
+
+# Step 2: Export snapshot to destination bucket
+echo "[2/4] Exporting snapshot to destination bucket..."
+echo "This may take several minutes depending on data size..."
+ssh -i "$SSH_KEY" hadoop@"$SOURCE_CLUSTER_MASTER" \
+    "sudo -u hbase hbase snapshot export \
+    -Dfs.s3a.etag.checksum.enabled=true \
+    -snapshot $SNAPSHOT_NAME \
+    -copy-to $DEST_BUCKET_PATH" 2>&1 | tee /tmp/export-output.log
+
+# Check if export succeeded
+if grep -q "ERROR" /tmp/export-output.log; then
+    echo "ERROR: Export failed. Check /tmp/export-output.log for details"
+    exit 1
+fi
+echo "✓ Export initiated"
+echo ""
+
+# Step 3: Monitor export progress
+echo "[3/4] Monitoring export progress..."
+LAST_APP_ID=""
+while true; do
+    JOB_STATUS=$(ssh -i "$SSH_KEY" hadoop@"$SOURCE_CLUSTER_MASTER" \
+        "yarn application -list 2>&1 | grep ExportSnapshot | tail -1" || echo "")
+    
+    if [ -z "$JOB_STATUS" ]; then
+        # Check if job completed successfully
+        if [ -n "$LAST_APP_ID" ]; then
+            FINAL_STATE=$(ssh -i "$SSH_KEY" hadoop@"$SOURCE_CLUSTER_MASTER" \
+                "yarn application -status $LAST_APP_ID 2>&1 | grep 'Final-State' | awk '{print \$3}'")
+            if [ "$FINAL_STATE" = "SUCCEEDED" ]; then
+                echo "✓ Export job completed successfully"
+            else
+                echo "ERROR: Export job failed with state: $FINAL_STATE"
+                exit 1
+            fi
+        fi
+        break
+    fi
+    
+    APP_ID=$(echo "$JOB_STATUS" | awk '{print $1}')
+    PROGRESS=$(echo "$JOB_STATUS" | awk '{print $8}')
+    LAST_APP_ID="$APP_ID"
+    echo "Progress: $PROGRESS (Job: $APP_ID)"
+    sleep 10
+done
+echo ""
+
+# Step 4: Verify data copied
+echo "[4/4] Verifying data in destination bucket..."
+DEST_BUCKET=$(echo "$DEST_BUCKET_PATH" | sed 's|s3://||' | cut -d'/' -f1)
+DEST_PREFIX=$(echo "$DEST_BUCKET_PATH" | sed 's|s3://||' | cut -d'/' -f2-)
+DEST_REGION=$(aws s3api get-bucket-location --bucket "$DEST_BUCKET" --query 'LocationConstraint' --output text 2>/dev/null || echo "us-east-1")
+
+if [ "$DEST_REGION" = "None" ] || [ -z "$DEST_REGION" ]; then
+    DEST_REGION="us-east-1"
+fi
+
+DEST_SIZE=$(aws s3 ls "$DEST_BUCKET_PATH" --region "$DEST_REGION" --recursive --summarize 2>&1 | \
+    grep "Total Size" | awk '{print $3, $4}')
+
+if [ -z "$DEST_SIZE" ]; then
+    echo "WARNING: Could not verify destination size. Please check manually."
+else
+    echo "✓ Data copied to destination: $DEST_SIZE"
+fi
+echo ""
+
+echo "=========================================="
+echo "COPY COMPLETED SUCCESSFULLY"
+echo "=========================================="
+echo "Source:      $SOURCE_BUCKET_PATH"
+echo "Destination: $DEST_BUCKET_PATH"
+echo "Snapshot:    $SNAPSHOT_NAME"
+echo "Data Size:   $DEST_SIZE"
+echo ""
+echo "Next steps:"
+echo "1. Launch EMR cluster in destination region pointing to: $DEST_BUCKET_PATH"
+echo "2. Import snapshot on the new cluster using:"
+echo ""
+echo "   hbase snapshot import \\"
+echo "     -Dfs.s3a.etag.checksum.enabled=true \\"
+echo "     -snapshot $SNAPSHOT_NAME \\"
+echo "     -copy-from $DEST_BUCKET_PATH \\"
+echo "     -copy-to $DEST_BUCKET_PATH"
+echo ""
+echo "=========================================="


### PR DESCRIPTION
This PR adds a utility to copy HBase snapshots between AWS regions while preserving data integrity.

## Features
- Cross-region HBase snapshot copy with ETag checksum validation
- Automated progress monitoring
- Comprehensive error handling
- Performance tuning guidance

## Testing
Tested with 1.5 TiB dataset achieving ~2.7 GB/s transfer speed from us-east-1 to ap-south-1.

## Documentation
Includes detailed README with usage examples, prerequisites, and troubleshooting guide.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
