### PR TITLE
Add hbase cross region copy

### DIFF
--- a/utilities/hbase-cross-region-copy/hbase-cross-region-copy.sh
+++ b/utilities/hbase-cross-region-copy/hbase-cross-region-copy.sh
@@ -149,16 +149,11 @@ while true; do
     STATE=$(echo "$JOB_STATUS" | grep "State :" | awk '{print $3}')
     PROGRESS=$(echo "$JOB_STATUS" | grep "Progress :" | awk '{print $3}')
     
-    # Get mapper count
-    MAPPERS=$(ssh -i "$SSH_KEY" hadoop@"$SOURCE_CLUSTER_MASTER" \
-        "yarn application -status $APP_ID 2>&1 | grep -E 'Total Number of Mappers|Num Maps' | awk '{print \$NF}'" || echo "N/A")
-    
     if [ "$STATE" = "FINISHED" ] || [ "$STATE" = "FAILED" ] || [ "$STATE" = "KILLED" ]; then
         FINAL_STATE=$(echo "$JOB_STATUS" | grep "Final-State :" | awk '{print $3}')
         
         if [ "$FINAL_STATE" = "SUCCEEDED" ]; then
             echo "✓ Export job completed successfully (100%)"
-            echo "  Mappers used: $MAPPERS"
             break
         else
             echo "ERROR: Export job failed with state: $FINAL_STATE"
@@ -167,7 +162,7 @@ while true; do
         fi
     fi
     
-    echo "Progress: $PROGRESS% (State: $STATE, Mappers: $MAPPERS)"
+    echo "Progress: $PROGRESS% (State: $STATE)"
     sleep 10
 done
 echo ""

--- a/utilities/hbase-cross-region-copy/hbase-cross-region-copy.sh
+++ b/utilities/hbase-cross-region-copy/hbase-cross-region-copy.sh
@@ -149,11 +149,16 @@ while true; do
     STATE=$(echo "$JOB_STATUS" | grep "State :" | awk '{print $3}')
     PROGRESS=$(echo "$JOB_STATUS" | grep "Progress :" | awk '{print $3}')
     
+    # Get mapper count
+    MAPPERS=$(ssh -i "$SSH_KEY" hadoop@"$SOURCE_CLUSTER_MASTER" \
+        "yarn application -status $APP_ID 2>&1 | grep -E 'Total Number of Mappers|Num Maps' | awk '{print \$NF}'" || echo "N/A")
+    
     if [ "$STATE" = "FINISHED" ] || [ "$STATE" = "FAILED" ] || [ "$STATE" = "KILLED" ]; then
         FINAL_STATE=$(echo "$JOB_STATUS" | grep "Final-State :" | awk '{print $3}')
         
         if [ "$FINAL_STATE" = "SUCCEEDED" ]; then
             echo "✓ Export job completed successfully (100%)"
+            echo "  Mappers used: $MAPPERS"
             break
         else
             echo "ERROR: Export job failed with state: $FINAL_STATE"
@@ -162,7 +167,7 @@ while true; do
         fi
     fi
     
-    echo "Progress: $PROGRESS% (State: $STATE)"
+    echo "Progress: $PROGRESS% (State: $STATE, Mappers: $MAPPERS)"
     sleep 10
 done
 echo ""

--- a/utilities/hbase-cross-region-copy/hbase-cross-region-copy.sh
+++ b/utilities/hbase-cross-region-copy/hbase-cross-region-copy.sh
@@ -108,46 +108,61 @@ echo ""
 # Step 2: Export snapshot to destination bucket
 echo "[2/4] Exporting snapshot to destination bucket..."
 echo "This may take several minutes depending on data size..."
+
+# Run export in background and capture output
 ssh -i "$SSH_KEY" hadoop@"$SOURCE_CLUSTER_MASTER" \
-    "sudo -u hbase hbase snapshot export \
+    "sudo -u hbase nohup hbase snapshot export \
     -Dfs.s3a.etag.checksum.enabled=true \
     -snapshot $SNAPSHOT_NAME \
-    -copy-to $DEST_BUCKET_PATH" 2>&1 | tee /tmp/export-output.log
+    -copy-to $DEST_BUCKET_PATH > /tmp/export-$SNAPSHOT_NAME.log 2>&1 &"
 
-# Check if export succeeded
-if grep -q "ERROR" /tmp/export-output.log; then
-    echo "ERROR: Export failed. Check /tmp/export-output.log for details"
-    exit 1
-fi
-echo "✓ Export initiated"
+# Wait a moment for job to start
+sleep 5
+
+# Get the YARN application ID
+echo "Waiting for export job to start..."
+for i in {1..30}; do
+    APP_ID=$(ssh -i "$SSH_KEY" hadoop@"$SOURCE_CLUSTER_MASTER" \
+        "yarn application -list 2>&1 | grep ExportSnapshot | tail -1 | awk '{print \$1}'" || echo "")
+    
+    if [ -n "$APP_ID" ]; then
+        echo "✓ Export job started: $APP_ID"
+        break
+    fi
+    
+    if [ $i -eq 30 ]; then
+        echo "ERROR: Export job did not start within expected time"
+        echo "Check logs: ssh to cluster and run: cat /tmp/export-$SNAPSHOT_NAME.log"
+        exit 1
+    fi
+    
+    sleep 2
+done
 echo ""
 
 # Step 3: Monitor export progress
 echo "[3/4] Monitoring export progress..."
-LAST_APP_ID=""
 while true; do
     JOB_STATUS=$(ssh -i "$SSH_KEY" hadoop@"$SOURCE_CLUSTER_MASTER" \
-        "yarn application -list 2>&1 | grep ExportSnapshot | tail -1" || echo "")
+        "yarn application -status $APP_ID 2>&1")
     
-    if [ -z "$JOB_STATUS" ]; then
-        # Check if job completed successfully
-        if [ -n "$LAST_APP_ID" ]; then
-            FINAL_STATE=$(ssh -i "$SSH_KEY" hadoop@"$SOURCE_CLUSTER_MASTER" \
-                "yarn application -status $LAST_APP_ID 2>&1 | grep 'Final-State' | awk '{print \$3}'")
-            if [ "$FINAL_STATE" = "SUCCEEDED" ]; then
-                echo "✓ Export job completed successfully"
-            else
-                echo "ERROR: Export job failed with state: $FINAL_STATE"
-                exit 1
-            fi
+    STATE=$(echo "$JOB_STATUS" | grep "State :" | awk '{print $3}')
+    PROGRESS=$(echo "$JOB_STATUS" | grep "Progress :" | awk '{print $3}')
+    
+    if [ "$STATE" = "FINISHED" ] || [ "$STATE" = "FAILED" ] || [ "$STATE" = "KILLED" ]; then
+        FINAL_STATE=$(echo "$JOB_STATUS" | grep "Final-State :" | awk '{print $3}')
+        
+        if [ "$FINAL_STATE" = "SUCCEEDED" ]; then
+            echo "✓ Export job completed successfully (100%)"
+            break
+        else
+            echo "ERROR: Export job failed with state: $FINAL_STATE"
+            echo "Check logs on cluster: cat /tmp/export-$SNAPSHOT_NAME.log"
+            exit 1
         fi
-        break
     fi
     
-    APP_ID=$(echo "$JOB_STATUS" | awk '{print $1}')
-    PROGRESS=$(echo "$JOB_STATUS" | awk '{print $8}')
-    LAST_APP_ID="$APP_ID"
-    echo "Progress: $PROGRESS (Job: $APP_ID)"
+    echo "Progress: $PROGRESS% (State: $STATE)"
     sleep 10
 done
 echo ""

--- a/utilities/hbase-cross-region-copy/hbase-cross-region-copy.sh
+++ b/utilities/hbase-cross-region-copy/hbase-cross-region-copy.sh
@@ -114,7 +114,8 @@ ssh -i "$SSH_KEY" hadoop@"$SOURCE_CLUSTER_MASTER" \
     "sudo -u hbase nohup hbase snapshot export \
     -Dfs.s3a.etag.checksum.enabled=true \
     -snapshot $SNAPSHOT_NAME \
-    -copy-to $DEST_BUCKET_PATH > /tmp/export-$SNAPSHOT_NAME.log 2>&1 &"
+    -copy-to $DEST_BUCKET_PATH \
+    -mappers 200 > /tmp/export-$SNAPSHOT_NAME.log 2>&1 &"
 
 # Wait a moment for job to start
 sleep 5


### PR DESCRIPTION
Description:
This PR adds a utility to copy HBase snapshots between AWS regions with data integrity validation.

## Features
- Cross-region HBase snapshot copy with ETag checksum validation
- Automatic snapshot creation if it doesn't exist
- Automated progress monitoring with real-time updates
- Companion import script for destination cluster setup
- Optimized with 200 mappers by default for high throughput
- Comprehensive error handling and logging

## Components
- `hbase-cross-region-copy.sh` - Main export script
- `hbase-import-snapshots.sh` - Companion import script for destination cluster
- `README.md` - Complete documentation with usage examples and troubleshooting

## Testing
Successfully tested with 1.5 TiB dataset:
- Transfer time: 9 minutes 31 seconds
- Transfer speed: 2.69 GB/s
- Source: us-east-1
- Destination: ap-south-1
- Data integrity: 100% validated with ETag checksums

## Documentation
Includes detailed README with:
- Prerequisites and setup instructions
- Usage examples for both HBase on S3 and HDFS
- Post-copy workflow for importing snapshots
- Performance tuning guidance
- Troubleshooting guide
