### PR TITLE
Add dual-mode recommender with cost and performance optimization

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -345,13 +345,3 @@ Contributions are welcome! Please submit pull requests or open issues for:
 ## License
 
 This utility is licensed under the MIT-0 License. See the LICENSE file.
-
-## Authors
-
-- Suthan Phillips (suthan@amazon.com)
-- Arun Maniyan (amaniyan@amazon.com)
-
-## Acknowledgments
-
-- AWS EMR Serverless team for worker type specifications
-- Apache Spark community for event log format documentation

--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -208,6 +208,17 @@ python3 emr_recommender_dual_mode.py \
   --limit 100
 ```
 
+**Partition Size Impact:**
+
+| Size (MiB) | Effect | Use Case |
+|------------|--------|----------|
+| 2048 | Fewer partitions, fewer executors | Large data, less parallelism |
+| 1024 | Default (1 GB per partition) | Balanced (recommended) |
+| 512 | 2x partitions, 2x executors | Shuffle-heavy workloads |
+| 256 | 4x partitions, 4x executors | Extreme parallelism needed |
+
+**Example:** With 512 MiB partitions, a job with 1008 partitions becomes 2016 partitions, and executors increase from 22 to 44.
+
 **Parameters:**
 - `--s3-path`: S3 path to staging area (required)
 - `--region`: AWS region (default: us-east-1)

--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -14,9 +14,12 @@ This utility processes Spark event logs to extract performance metrics and autom
 ## Features
 
 - **Automated Pipeline**: End-to-end processing from event logs to recommendations
+- **Dual Optimization Modes**: Cost-optimized vs Performance-optimized configurations
 - **Parallel Processing**: Multi-threaded extraction with configurable workers
 - **S3 Integration**: Direct S3 read/write with streaming decompression
 - **Rolling Log Support**: Handles both single and rolling event logs
+- **Configurable Partition Size**: Adjust shuffle parallelism (default: 1GB)
+- **Job Config Format**: Optional output in deployment-ready format
 - **18 Metric Extractors**: Comprehensive analysis including:
   - Input/output data volumes
   - Shuffle read/write patterns
@@ -60,6 +63,31 @@ This utility processes Spark event logs to extract performance metrics and autom
 ```
 
 ## Algorithm
+
+### Optimization Modes
+
+#### Cost-Optimized Mode (Default)
+Conservative executor allocation based on resource pressure:
+```python
+pressure = mem_utilization * 0.4 + cpu_utilization * 0.4 + spill_ratio * 0.2
+scaling_factor = 0.5 + (pressure / 100) * 1.0  # Range: 0.5 to 1.5
+max_executors = base_requirement * scaling_factor
+```
+
+**Best for:** Budget-conscious workloads, development/testing environments
+
+#### Performance-Optimized Mode
+Aggressive scaling for high memory pressure (>75%):
+```python
+if memory_utilization > 75%:
+    scaling_factor = 1.0 + ((memory_utilization - 75) / 25) * 0.5  # Range: 1.0 to 1.5
+else:
+    # Use standard pressure calculation
+```
+
+**Best for:** Production SLA-critical workloads, jobs with memory pressure
+
+**Impact:** 5-21% more executors for memory-stressed jobs (>75% utilization)
 
 ### Stage 1: Metric Extraction (`spark_processor.py`)
 
@@ -148,7 +176,48 @@ This utility processes Spark event logs to extract performance metrics and autom
 
 ## Usage
 
-### Option 1: Automated Pipeline (Recommended)
+### Option 1: Dual-Mode Recommender (Recommended)
+
+Generate both cost-optimized and performance-optimized recommendations:
+
+```bash
+python3 emr_recommender_dual_mode.py \
+  --s3-path s3://YOUR_BUCKET/staging/ \
+  --region us-east-1 \
+  --limit 100
+```
+
+**Output:**
+- `recommendations_cost_optimized.json` - Conservative executor allocation
+- `recommendations_performance_optimized.json` - Aggressive scaling for high-memory jobs
+- Comparison summary showing differences
+
+**Advanced Options:**
+
+```bash
+# Custom partition size (smaller = more parallelism)
+python3 emr_recommender_dual_mode.py \
+  --s3-path s3://YOUR_BUCKET/staging/ \
+  --target-partition-size 512 \
+  --limit 100
+
+# Generate deployment-ready job configs
+python3 emr_recommender_dual_mode.py \
+  --s3-path s3://YOUR_BUCKET/staging/ \
+  --format-job-config \
+  --limit 100
+```
+
+**Parameters:**
+- `--s3-path`: S3 path to staging area (required)
+- `--region`: AWS region (default: us-east-1)
+- `--limit`: Max applications to process (default: 100)
+- `--target-partition-size`: Shuffle partition size in MiB (default: 1024)
+- `--format-job-config`: Output in job configuration format
+- `--output-cost`: Cost-optimized output file
+- `--output-perf`: Performance-optimized output file
+
+### Option 2: Automated Pipeline (Original)
 
 Run the complete pipeline with a single command:
 

--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -348,7 +348,8 @@ This utility is licensed under the MIT-0 License. See the LICENSE file.
 
 ## Authors
 
-- Suthan Srinivasan - Initial development and testing
+- Suthan Phillips (suthan@amazon.com)
+- Arun Maniyan (amaniyan@amazon.com)
 
 ## Acknowledgments
 

--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -333,7 +333,6 @@ MAX_CONCURRENT_UPLOADS = 10  # Reduce from 20
 - Requires Spark event logs in JSON format
 - Does not analyze Spark UI or live applications
 - Recommendations based on historical patterns
-- Does not account for cost optimization (only performance)
 
 ## Contributing
 

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -85,34 +85,39 @@ def _select_worker_type(input_gb: float, shuffle_ratio: float) -> Tuple[str, Dic
 
 def _compute_exec_limits(input_gb: float, vcpu: int, partitions: int = 0, 
                         mem_pct: float = 60.0, cpu_pct: float = 50.0, 
-                        idle_pct: float = 50.0, spill_gb: float = 0.0) -> Tuple[int, int]:
+                        idle_pct: float = 50.0, spill_gb: float = 0.0,
+                        mode: str = "cost") -> Tuple[int, int]:
     """
-    Calculate executors using resource pressure (v13: fixed logic).
+    Calculate executors using resource pressure.
     
-    High pressure (mem/cpu/spill) = MORE executors needed
-    Low pressure = FEWER executors needed
+    mode: "cost" = conservative (existing logic)
+          "performance" = aggressive for high memory pressure
     """
     # Base calculations
     req_input = max(1, int(input_gb / 100))
     req_part = max(1, int((partitions / vcpu) / 3)) if partitions > 0 else 0
     base_req = max(req_input, req_part)
     
-    # Resource pressure score (0-100)
-    # Higher = more stressed = need MORE executors
-    mem_pressure = mem_pct * 0.4  # 40% weight
-    cpu_pressure = cpu_pct * 0.4  # 40% weight (removed idle redundancy)
-    
-    # Spill pressure: relative to input size (0-20 points)
-    spill_ratio = (spill_gb / max(input_gb, 1)) * 100
-    spill_pressure = min(20, spill_ratio * 0.2)  # 20% weight
-    
-    pressure = mem_pressure + cpu_pressure + spill_pressure
-    pressure = max(0, min(100, pressure))
-    
-    # Scaling factor: 0.5 (low pressure) to 1.5 (high pressure)
-    # Low pressure (underutilized) -> reduce executors (0.5x)
-    # High pressure (overutilized) -> increase executors (1.5x)
-    factor = 0.5 + (pressure / 100) * 1.0  # Range: 0.5 to 1.5
+    if mode == "performance":
+        # Performance mode: aggressive scaling for high memory
+        if mem_pct > 75:
+            factor = 1.0 + ((mem_pct - 75) / 25) * 0.5  # 75-100% → 1.0-1.5x
+        else:
+            # Standard pressure calculation for lower memory
+            mem_pressure = mem_pct * 0.4
+            cpu_pressure = cpu_pct * 0.4
+            spill_ratio = (spill_gb / max(input_gb, 1)) * 100
+            spill_pressure = min(20, spill_ratio * 0.2)
+            pressure = max(0, min(100, mem_pressure + cpu_pressure + spill_pressure))
+            factor = 0.5 + (pressure / 100) * 1.0
+    else:
+        # Cost mode: existing conservative logic
+        mem_pressure = mem_pct * 0.4
+        cpu_pressure = cpu_pct * 0.4
+        spill_ratio = (spill_gb / max(input_gb, 1)) * 100
+        spill_pressure = min(20, spill_ratio * 0.2)
+        pressure = max(0, min(100, mem_pressure + cpu_pressure + spill_pressure))
+        factor = 0.5 + (pressure / 100) * 1.0
     
     max_exec = max(2, int(base_req * factor))
     min_exec = max(1, max_exec // 2)

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender_dual_mode.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender_dual_mode.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""
+EMR Serverless Recommender - Dual Mode (Cost + Performance)
+Generates two sets of recommendations from the same metrics.
+"""
+
+import sys
+import json
+from pathlib import Path
+
+# Import from the original module
+sys.path.insert(0, '/home/hadoop')
+from emr_recommender_v16_s3_patched import (
+    EmrRecommender, _select_worker_type, _calculate_shuffle_ratio,
+    _compute_exec_limits, _auto_tune_shuffles, _calculate_executor_disk,
+    _max_partition_bytes, _get_timeout_configs, _get_s3_retry_configs,
+    _get_iceberg_configs, _gb_to_gib, log
+)
+
+
+class DualModeRecommender(EmrRecommender):
+    """Extended recommender that generates both cost and performance recommendations."""
+    
+    def __init__(self, s3_paths, region, target_partition_size_mib=1024):
+        super().__init__(s3_paths, region)
+        self.target_partition_size_mib = target_partition_size_mib
+        log.info("Target partition size: %d MiB", target_partition_size_mib)
+    
+    def generate_dual(self, limit: int = 100):
+        """Generate both cost-optimized and performance-optimized recommendations."""
+        df = self._load_metrics_from_s3(limit)
+        
+        cost_recs = []
+        perf_recs = []
+        
+        for _, row in df.iterrows():
+            app_id = row.get('application_id', 'N/A')
+            name = row.get('application_name', 'N/A')
+            duration = float(row.get('total_run_duration_hours', 0) or 0)
+            i_in_gb = float(row.get('io_total_input_gb', 0) or 0)
+            s_in_gb = float(row.get('io_total_shuffle_read_gb', 0) or 0)
+            s_out_gb = float(row.get('io_total_shuffle_write_gb', 0) or 0)
+            
+            mem_pct = float(row.get('avg_memory_utilization_percent', 60.0) or 60.0)
+            cpu_pct = float(row.get('avg_cpu_utilization_percent', 50.0) or 50.0)
+            idle_pct = float(row.get('idle_core_percentage', 50.0) or 50.0)
+            spill_gb = float(row.get('total_memory_spilled_gb', 0.0) or 0.0)
+            disk_spill_gb = float(row.get('total_disk_spilled_gb', 0.0) or 0.0)
+            
+            sh_ratio = _calculate_shuffle_ratio(i_in_gb, s_in_gb, s_out_gb)
+            worker_type, worker_cfg = _select_worker_type(i_in_gb, sh_ratio)
+            
+            shuffle_data_gb = max(s_in_gb, s_out_gb)
+            shuffle_bytes = shuffle_data_gb * 1024 * 1024 * 1024
+            
+            # Override _auto_tune_shuffles to use configurable target size
+            def auto_tune_custom(shuffle_bytes, max_executors):
+                target_mib = self.target_partition_size_mib
+                if shuffle_bytes > 0:
+                    partitions = int((shuffle_bytes / (target_mib * 1024 * 1024)) + 0.5)
+                else:
+                    partitions = 200
+                if partitions % 2 != 0:
+                    partitions += 1
+                return partitions, target_mib
+            
+            # Generate COST-OPTIMIZED recommendation
+            max_exec_cost_init, min_exec_cost = _compute_exec_limits(
+                i_in_gb, worker_cfg["vcpu"], 0, mem_pct, cpu_pct, idle_pct, spill_gb, mode="cost"
+            )
+            sp_cost, target_mib_cost = auto_tune_custom(shuffle_bytes, max_exec_cost_init)
+            max_exec_cost, min_exec_cost = _compute_exec_limits(
+                i_in_gb, worker_cfg["vcpu"], sp_cost, mem_pct, cpu_pct, idle_pct, spill_gb, mode="cost"
+            )
+            executor_disk_cost = _calculate_executor_disk(s_out_gb, disk_spill_gb, spill_gb, max_exec_cost)
+            
+            # Generate PERFORMANCE-OPTIMIZED recommendation
+            max_exec_perf_init, min_exec_perf = _compute_exec_limits(
+                i_in_gb, worker_cfg["vcpu"], 0, mem_pct, cpu_pct, idle_pct, spill_gb, mode="performance"
+            )
+            sp_perf, target_mib_perf = auto_tune_custom(shuffle_bytes, max_exec_perf_init)
+            max_exec_perf, min_exec_perf = _compute_exec_limits(
+                i_in_gb, worker_cfg["vcpu"], sp_perf, mem_pct, cpu_pct, idle_pct, spill_gb, mode="performance"
+            )
+            executor_disk_perf = _calculate_executor_disk(s_out_gb, disk_spill_gb, spill_gb, max_exec_perf)
+            
+            # Build base metrics (same for both)
+            base_metrics = {
+                "input_gb": round(i_in_gb, 2),
+                "input_gib": _gb_to_gib(i_in_gb),
+                "shuffle_read_gb": round(s_in_gb, 2),
+                "shuffle_write_gb": round(s_out_gb, 2),
+                "shuffle_total_gb": round(s_in_gb + s_out_gb, 2),
+                "shuffle_ratio_percent": sh_ratio,
+                "duration_hours": round(duration, 2),
+                "avg_memory_utilization_percent": round(mem_pct, 2),
+                "avg_cpu_utilization_percent": round(cpu_pct, 2),
+                "idle_core_percentage": round(idle_pct, 2),
+                "total_memory_spilled_gb": round(spill_gb, 2),
+            }
+            
+            # Build Spark configs helper
+            def build_spark_cfg(max_exec, min_exec, sp, executor_disk):
+                cfg = {
+                    "spark.driver.cores": "8",
+                    "spark.driver.memory": "54G",
+                    "spark.executor.cores": str(worker_cfg["vcpu"]),
+                    "spark.executor.memory": f"{worker_cfg['memory']}g",
+                    "spark.dynamicAllocation.enabled": "true",
+                    "spark.sql.adaptive.enabled": "true",
+                    "spark.sql.files.maxPartitionBytes": _max_partition_bytes(i_in_gb),
+                    "spark.emr-serverless.executor.disk": executor_disk,
+                    "spark.emr-serverless.executor.disk.type": "shuffle_optimized",
+                    "spark.sql.shuffle.partitions": str(sp),
+                    "spark.dynamicAllocation.maxExecutors": str(max_exec),
+                    "spark.dynamicAllocation.minExecutors": str(min_exec),
+                    "spark.dynamicAllocation.initialExecutors": str(min_exec),
+                }
+                cfg.update(_get_timeout_configs(i_in_gb, duration))
+                cfg.update(_get_s3_retry_configs(i_in_gb))
+                cfg.update(_get_iceberg_configs())
+                if sh_ratio > 30:
+                    cfg.update({"spark.shuffle.compress": "true", "spark.shuffle.spill.compress": "true"})
+                return cfg
+            
+            # Cost-optimized recommendation
+            cost_rec = {
+                "application_id": app_id,
+                "application_name": name,
+                "optimization_mode": "cost",
+                "metrics": base_metrics,
+                "worker": {
+                    "type": worker_type,
+                    "vcpu": worker_cfg["vcpu"],
+                    "memory_gb": worker_cfg["memory"],
+                    "max_executors": max_exec_cost,
+                    "min_executors": min_exec_cost,
+                    "total_vcpu_capacity": max_exec_cost * worker_cfg["vcpu"],
+                    "total_memory_capacity": max_exec_cost * worker_cfg["memory"],
+                },
+                "spark_configs": build_spark_cfg(max_exec_cost, min_exec_cost, sp_cost, executor_disk_cost),
+                "shuffle_tuned": {
+                    "partitions": sp_cost,
+                    "target_partition_size_mib": target_mib_cost,
+                    "auto_tuned": True,
+                },
+            }
+            
+            # Performance-optimized recommendation
+            perf_rec = {
+                "application_id": app_id,
+                "application_name": name,
+                "optimization_mode": "performance",
+                "metrics": base_metrics,
+                "worker": {
+                    "type": worker_type,
+                    "vcpu": worker_cfg["vcpu"],
+                    "memory_gb": worker_cfg["memory"],
+                    "max_executors": max_exec_perf,
+                    "min_executors": min_exec_perf,
+                    "total_vcpu_capacity": max_exec_perf * worker_cfg["vcpu"],
+                    "total_memory_capacity": max_exec_perf * worker_cfg["memory"],
+                },
+                "spark_configs": build_spark_cfg(max_exec_perf, min_exec_perf, sp_perf, executor_disk_perf),
+                "shuffle_tuned": {
+                    "partitions": sp_perf,
+                    "target_partition_size_mib": target_mib_perf,
+                    "auto_tuned": True,
+                },
+            }
+            
+            cost_recs.append(cost_rec)
+            perf_recs.append(perf_rec)
+        
+        log.info("Generated %d cost-optimized and %d performance-optimized recommendations", 
+                 len(cost_recs), len(perf_recs))
+        return cost_recs, perf_recs
+
+
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Dual-mode EMR Serverless recommender")
+    parser.add_argument("--s3-path", required=True, help="S3 path to metrics")
+    parser.add_argument("--region", default="us-east-1", help="AWS region")
+    parser.add_argument("--limit", type=int, default=100, help="Max applications")
+    parser.add_argument("--target-partition-size", type=int, default=1024, 
+                        help="Target shuffle partition size in MiB (default: 1024 = 1GB)")
+    parser.add_argument("--format-job-config", action="store_true",
+                        help="Format output to job configuration format")
+    parser.add_argument("--output-cost", default="recommendations_cost_optimized.json", help="Cost output file")
+    parser.add_argument("--output-perf", default="recommendations_performance_optimized.json", help="Performance output file")
+    
+    args = parser.parse_args()
+    
+    # Convert single path to list
+    s3_paths = [args.s3_path] if isinstance(args.s3_path, str) else args.s3_path
+    
+    recommender = DualModeRecommender(s3_paths, args.region, args.target_partition_size)
+    cost_recs, perf_recs = recommender.generate_dual(args.limit)
+    
+    # Write cost-optimized
+    Path(args.output_cost).write_text(json.dumps(cost_recs, indent=2))
+    log.info("Cost-optimized recommendations written to %s", args.output_cost)
+    
+    # Write performance-optimized
+    Path(args.output_perf).write_text(json.dumps(perf_recs, indent=2))
+    log.info("Performance-optimized recommendations written to %s", args.output_perf)
+    
+    # Format to job config if requested
+    if args.format_job_config:
+        import sys
+        sys.path.insert(0, '/home/hadoop')
+        from format_to_job_config import format_to_job_config
+        
+        cost_jobs = [format_to_job_config(rec) for rec in cost_recs]
+        perf_jobs = [format_to_job_config(rec) for rec in perf_recs]
+        
+        cost_job_file = args.output_cost.replace('.json', '_job_config.json')
+        perf_job_file = args.output_perf.replace('.json', '_job_config.json')
+        
+        Path(cost_job_file).write_text(json.dumps(cost_jobs, indent=2))
+        Path(perf_job_file).write_text(json.dumps(perf_jobs, indent=2))
+        
+        log.info("Job config format written to %s and %s", cost_job_file, perf_job_file)
+    
+    print("\n" + "="*80)
+    print("COMPARISON SUMMARY")
+    print("="*80)
+    print(f"{'App Name':<40} | {'Mode':<11} | {'Max Exec':>8} | {'Total vCPU':>10}")
+    print("-"*80)
+    for cost, perf in zip(cost_recs[:10], perf_recs[:10]):
+        name = cost['application_name'][:38]
+        print(f"{name:<40} | {'Cost':<11} | {cost['worker']['max_executors']:>8} | {cost['worker']['total_vcpu_capacity']:>10}")
+        print(f"{'':<40} | {'Performance':<11} | {perf['worker']['max_executors']:>8} | {perf['worker']['total_vcpu_capacity']:>10}")
+        diff_exec = perf['worker']['max_executors'] - cost['worker']['max_executors']
+        diff_pct = (diff_exec / cost['worker']['max_executors'] * 100) if cost['worker']['max_executors'] > 0 else 0
+        print(f"{'':<40} | {'Difference':<11} | {diff_exec:>+8} | {diff_pct:>+9.1f}%")
+        print("-"*80)

--- a/utilities/EMR-Serverless-Config-Advisor/format_to_job_config.py
+++ b/utilities/EMR-Serverless-Config-Advisor/format_to_job_config.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Format EMR Serverless recommendations to job configuration format.
+"""
+
+import json
+import sys
+from pathlib import Path
+from datetime import datetime
+
+
+def format_to_job_config(recommendation: dict, job_name: str = None) -> dict:
+    """Convert recommendation to job configuration format."""
+    
+    app_name = recommendation.get('application_name', 'unknown-app')
+    if job_name is None:
+        job_name = f"{app_name}-job"
+    
+    spark_configs = recommendation.get('spark_configs', {})
+    
+    # Build job configuration
+    job_config = {
+        "job_name": job_name,
+        "job_id": None,
+        "ams_app_name": app_name,
+        "created_by": None,
+        "configuration": {
+            "config_name": f"{app_name}-config",
+            "ams_app_name": app_name,
+            "version": None,
+            "created_by": None,
+            "updated_by": None,
+            "stop_job_after_minutes": None,
+            "type": "spark",
+            "created_timestamp": datetime.utcnow().isoformat() + "Z",
+            "updated_timestamp": datetime.utcnow().isoformat() + "Z",
+            "schedule": {
+                "enabled": False
+            },
+            "vault_enabled": False,
+            "compute_platform": "EMR_SERVERLESS",
+            "compute_platform_properties": {
+                "gpu_enabled": False,
+                "spot_toleration": None,
+                "graviton_enabled": None,
+                "emr_serverless_application_label": None
+            },
+            "spark_conf": spark_configs,
+            "hadoop_conf": {},
+            "main_application_file": None,
+            "gpu_enabled": False,
+            "spot_toleration": None,
+            "main_class": None,
+            "language": None
+        },
+        "config_name": f"{app_name}-config",
+        "job_status": {
+            "status_descriptor": None,
+            "details": None,
+            "links": []
+        },
+        "job_created_at": None,
+        "job_deployed_at": None,
+        "job_ended_at": None,
+        "properties": {},
+        "create_namespace": False,
+        "job_priority": None
+    }
+    
+    return job_config
+
+
+def format_recommendations_file(input_file: Path, output_file: Path):
+    """Format all recommendations in a file to job config format."""
+    
+    with open(input_file) as f:
+        recommendations = json.load(f)
+    
+    formatted_jobs = []
+    for rec in recommendations:
+        app_name = rec.get('application_name', 'unknown-app')
+        job_name = f"{app_name}-recommended-job"
+        formatted = format_to_job_config(rec, job_name)
+        formatted_jobs.append(formatted)
+    
+    with open(output_file, 'w') as f:
+        json.dump(formatted_jobs, f, indent=2)
+    
+    print(f"✓ Formatted {len(formatted_jobs)} recommendations to {output_file}")
+
+
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Format recommendations to job config format")
+    parser.add_argument("--input", required=True, help="Input recommendations JSON file")
+    parser.add_argument("--output", required=True, help="Output job config JSON file")
+    
+    args = parser.parse_args()
+    
+    format_recommendations_file(Path(args.input), Path(args.output))


### PR DESCRIPTION
Description:
## Summary
Adds a dual-mode recommender that generates both cost-optimized and performance-optimized EMR Serverless configurations from the same event log analysis. This provides users with options to optimize for either cost efficiency or performance/stability.

## New Features

### 1. Dual Optimization Modes
- **Cost-Optimized**: Conservative executor allocation (matches original v16 algorithm)
- **Performance-Optimized**: Aggressive scaling for high memory pressure (>75% utilization)
- Generates both recommendations in a single run for easy comparison

### 2. Configurable Shuffle Partition Size
- Default: 1024 MiB (1 GB per partition)
- Configurable via `--target-partition-size` parameter
- Smaller partitions = more parallelism = more executors
- Example: 512 MiB doubles partitions and executors for shuffle-heavy jobs

### 3. Job Config Format Output
- Optional `--format-job-config` flag
- Outputs deployment-ready job configuration format
- Aligns with existing job deployment structure
- `compute_platform` hardcoded to "EMR_SERVERLESS"

## Files Added


utilities/EMR-Serverless-Config-Advisor/
├── emr_recommender_dual_mode.py    # Main dual-mode script (235 lines)
└── format_to_job_config.py         # Job config formatter (95 lines)

## Files Modified


utilities/EMR-Serverless-Config-Advisor/
├── emr_recommender.py              # Added mode parameter to computeexec_limits
└── README.md                       # Documented dual-mode usage and algorithms

## Usage Examples

### Basic Dual-Mode
bash
python3 emr_recommender_dual_mode.py \
 --s3-path s3://bucket/staging/ \
 --limit 100

**Output:**
- `recommendations_cost_optimized.json`
- `recommendations_performance_optimized.json`
- Comparison summary

### With Custom Partition Size
bash
python3 emr_recommender_dual_mode.py \
 --s3-path s3://bucket/staging/ \
 --target-partition-size 512 \
 --limit 100

### With Job Config Format
bash
python3 emr_recommender_dual_mode.py \
 --s3-path s3://bucket/staging/ \
 --format-job-config \
 --limit 100

## Algorithm Details

### Cost-Optimized Mode
python
pressure = mem_utilization  0.4 + cpuutilization  0.4 + spillratio  0.2
scalingfactor = 0.5 + (pressure / 100)  1.0  # Range: 0.5 to 1.5
maxexecutors = base_requirement  scalingfactor

### Performance-Optimized Mode
python
if memory_utilization > 75%:
   scaling_factor = 1.0 + ((memory_utilization - 75) / 25)  0.5  # Range: 1.0 to 1.5
else:
   # Use standard pressure calculation

## Testing Results

**Test Dataset:** 10 applications, 1,686 event log files

### Cost-Optimized Validation
✅ **100% match** with original v16 output:
- All executor counts match
- All shuffle partitions match
- All Spark configs match

### Performance-Optimized Results
| Memory % | Cost Executors | Perf Executors | Increase |
|----------|----------------|----------------|----------|
| 80.7% | 191 | 231 | +20.9% |
| 84.5% | 203 | 244 | +20.2% |
| 83.8% | 225 | 238 | +5.8% |
| 65.7% | 172 | 172 | 0% (no change) |
| 50.4% | 59 | 59 | 0% (no change) |

**Key Finding:** Performance mode only increases executors for jobs with >75% memory utilization, leaving cost-efficient jobs unchanged.

### Partition Size Impact (512 MiB vs 1024 MiB)
| Job | 1024 MiB | 512 MiB | Change |
|-----|----------|---------|--------|
| etl-incremental-job | 22 executors | 44 executors | +100% |
|  analytics-aggregation-job | 64 executors | 129 executors | +101% |
| Large batch job | 191 executors | 191 executors | 0% (input-driven) |

### Job Config Format Validation
Structure matches original deployment format
All Spark configs preserved (22 configs per job)
All recommendations identical to non-formatted output

## Use Cases

1. **Cost vs Performance Trade-off Analysis**: Generate both modes to compare cost impact
2. **Shuffle-Heavy Workloads**: Use smaller partition sizes for better parallelism
3. **Production Deployment**: Use `--format-job-config` for deployment-ready configs
4. **Memory-Stressed Jobs**: Performance mode provides 5-21% more executors

## Backward Compatibility

No changes to existing `pipeline_wrapper.py` or `spark_processor.py`
Original `emr_recommender.py` maintains backward compatibility (mode defaults to "cost")
New scripts are standalone additions

## Documentation

-  README updated with dual-mode usage
- Algorithm explanations for both modes
- Partition size impact table
- Job config format documentation
- Examples for all use cases

---
