### PR TITLE
Recommender: raise Large worker min memory to 64GB

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -106,7 +106,7 @@ def _select_worker_type(input_gb: float, shuffle_ratio: float,
     WORKER_RANGES = {
         "Small":  {"vcpu": 4,  "min_mem": 8,  "max_mem": 27, "mem_step": 1},
         "Medium": {"vcpu": 8,  "min_mem": 16, "max_mem": 54, "mem_step": 4},
-        "Large":  {"vcpu": 16, "min_mem": 32, "max_mem": 108, "mem_step": 8},
+        "Large":  {"vcpu": 16, "min_mem": 64, "max_mem": 108, "mem_step": 8},
     }
 
     # Select worker size based on data volume and spill (workload properties)


### PR DESCRIPTION
Prevents under-provisioning that causes spill and disk space failures. 00g47i95 failed with 32GB (peak 28.76GB, 164GB spill) - 64GB floor gives sufficient headroom for all Large worker workloads.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
