### PR TITLE
EMR Serverless Config Advisor: Smart driver, serverless storage safety, IO-optimized mode

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -290,6 +290,9 @@ ORDER BY total_memory_spilled_gb DESC;
 | `--format-job-config` | Deployment-ready format | standard |
 | `--target-partition-size` | Shuffle partition size in MiB | 1024 |
 | `--limit` | Max applications | 100 |
+| `--serverless-storage` | Enable serverless storage recommendations | off |
+
+**Serverless storage** is disabled by default. When disabled, recommendations include attached executor disk (`spark.emr-serverless.executor.disk`). Pass `--serverless-storage` to enable it — serverless storage will only be recommended when the workload has zero disk spill and shuffle volume is within safe limits. This is because EMR Serverless local disk is fixed at 20GB and cannot be increased; any disk spill (shuffle sort spill, memory spill overflow) goes to local disk, not serverless storage, and can cause "No space left on device" failures.
 
 ### format_to_job_config.py
 

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -356,10 +356,22 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
         }
         
         # Build Spark configs
+        def _driver_sizing(partitions, max_exec, shuffle_gb):
+            """Scale driver based on coordination overhead."""
+            if partitions > 10000 or max_exec > 200 or shuffle_gb > 10000:
+                return 16, 100
+            elif partitions > 2000 or max_exec > 100 or shuffle_gb > 2000:
+                return 8, 54
+            elif partitions > 500 or max_exec > 50 or shuffle_gb > 500:
+                return 4, 28
+            else:
+                return 4, 14
+
         def build_spark_cfg(max_exec, min_exec, sp, executor_disk):
+            d_cores, d_mem = _driver_sizing(sp, max_exec, s_in_gb + s_out_gb)
             cfg = {
-                "spark.driver.cores": str(min(4, worker_cfg["vcpu"])),
-                "spark.driver.memory": f"{min(14, worker_cfg['memory'])}G",
+                "spark.driver.cores": str(d_cores),
+                "spark.driver.memory": f"{d_mem}G",
                 "spark.executor.cores": str(worker_cfg["vcpu"]),
                 "spark.executor.memory": f"{worker_cfg['memory']}g",
                 "spark.dynamicAllocation.enabled": "true",

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -358,8 +358,8 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
         # Build Spark configs
         def _driver_sizing(partitions, max_exec, shuffle_gb):
             """Scale driver based on coordination overhead."""
-            if partitions > 10000 or max_exec > 200 or shuffle_gb > 10000:
-                return 16, 100
+            if partitions > 10000 or max_exec > 500 or shuffle_gb > 10000:
+                return 16, 108
             elif partitions > 2000 or max_exec > 100 or shuffle_gb > 2000:
                 return 8, 54
             elif partitions > 500 or max_exec > 50 or shuffle_gb > 500:

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -229,7 +229,8 @@ def _get_iceberg_configs() -> Dict[str, str]:
 
 
 def generate_dual_recommendations(input_path: str, limit: int = 100,
-                                  target_partition_size_mib: int = 1024) -> Tuple[List[Dict], List[Dict]]:
+                                  target_partition_size_mib: int = 1024,
+                                  serverless_storage: bool = False) -> Tuple[List[Dict], List[Dict]]:
     """Generate both cost and performance recommendations."""
     
     # Load metrics
@@ -376,15 +377,13 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             cfg.update(_get_iceberg_configs())
             if sh_ratio > 30:
                 cfg.update({"spark.shuffle.compress": "true", "spark.shuffle.spill.compress": "true"})
-            # Serverless storage: shuffle fits in 200GB limit
-            # If recommended memory > peak memory with headroom, spill likely eliminated
-            spill_likely_gone = (max_peak_mem_gb > 0 and worker_cfg["memory"] >= max_peak_mem_gb * 1.3)
-            effective_spill = 0 if spill_likely_gone else (disk_spill_gb + spill_gb)
-            disk_spill_per_exec = effective_spill / max(max_exec, 1)
-            if max_stage_shuf_write <= 150 and disk_spill_per_exec <= 15:
-                cfg["spark.aws.serverlessStorage.enabled"] = "true"
-                cfg.pop("spark.emr-serverless.executor.disk", None)
-                cfg.pop("spark.emr-serverless.executor.disk.type", None)
+            # Serverless storage: only when explicitly enabled and disk pressure is safe
+            if serverless_storage:
+                disk_spill_per_exec = (disk_spill_gb + spill_gb) / max(max_exec, 1)
+                if disk_spill_gb == 0 and max_stage_shuf_write <= 150 and disk_spill_per_exec <= 15:
+                    cfg["spark.aws.serverlessStorage.enabled"] = "true"
+                    cfg.pop("spark.emr-serverless.executor.disk", None)
+                    cfg.pop("spark.emr-serverless.executor.disk.type", None)
             return cfg
         
         # Cost recommendation
@@ -514,6 +513,8 @@ if __name__ == "__main__":
                         help="Generate only performance-optimized recommendations")
     parser.add_argument("--individual-files", action="store_true",
                         help="Generate individual JSON files per job (1-jobname.json, 2-jobname.json, ...)")
+    parser.add_argument("--serverless-storage", action="store_true",
+                        help="Enable serverless storage recommendations (disabled by default)")
     parser.add_argument("--write-to-iceberg-table",
                         help="Write recommendations to Iceberg table (catalog.database.table)")
     
@@ -523,7 +524,8 @@ if __name__ == "__main__":
     cost_recs, perf_recs = generate_dual_recommendations(
         args.input_path,
         args.limit,
-        args.target_partition_size
+        args.target_partition_size,
+        serverless_storage=args.serverless_storage
     )
     
     # Determine which recommendations to generate

--- a/utilities/EMR-Serverless-Config-Advisor/pipeline_wrapper.py
+++ b/utilities/EMR-Serverless-Config-Advisor/pipeline_wrapper.py
@@ -59,6 +59,7 @@ def main():
     parser.add_argument("--performance-optimized", action="store_true", help="Generate only performance-optimized recommendations")
     parser.add_argument("--individual-files", action="store_true", help="Generate individual JSON files per job")
     parser.add_argument("--write-to-iceberg-table", help="Write recommendations to Iceberg table (catalog.database.table)")
+    parser.add_argument("--serverless-storage", action="store_true", help="Enable serverless storage recommendations (disabled by default)")
     parser.add_argument("--skip-extraction", action="store_true", help="Skip extraction step (use existing data)")
 
     args = parser.parse_args()
@@ -114,6 +115,8 @@ def main():
         cmd.append("--individual-files")
     if args.write_to_iceberg_table:
         cmd.extend(["--write-to-iceberg-table", args.write_to_iceberg_table])
+    if args.serverless_storage:
+        cmd.append("--serverless-storage")
 
     if not run_command(cmd, "Stage 2: Generate recommendations"):
         sys.exit(1)

--- a/utilities/emr-hbase-reconfiguration-guard/README.md
+++ b/utilities/emr-hbase-reconfiguration-guard/README.md
@@ -1,0 +1,86 @@
+# EMR HBase Reconfiguration Guard
+
+Prevent HBase services from restarting when reconfiguring an EMR cluster.
+
+## Problem
+
+When you reconfigure an EMR HBase cluster (e.g., updating `hbase-site.xml` properties via `modify-instance-groups`), all HBase services — RegionServer, Master, Thrift, and REST — are automatically restarted. This causes unexpected downtime and disrupts in-flight operations.
+
+## Solution
+
+A bootstrap action that modifies the HBase Puppet manifest so that configuration changes are applied to disk without triggering automatic service restarts. This gives you full control over when HBase services are restarted.
+
+> **Important:** After reconfiguration, the config files on disk are updated but the running HBase services still use the previous settings. You must restart the services yourself for the new configuration to take effect.
+
+### Restarting HBase Services
+
+After reconfiguration, restart services on each node when you are ready:
+
+```bash
+# On core/task nodes
+sudo systemctl restart hbase-regionserver
+
+# On master node
+sudo systemctl restart hbase-master
+
+# If applicable
+sudo systemctl restart hbase-thrift
+sudo systemctl restart hbase-rest
+```
+
+You can perform a rolling restart — one RegionServer at a time — to minimize impact on your workload.
+
+## Setup
+
+1. Upload the modified `init.pp` to your S3 bucket:
+   ```bash
+   aws s3 cp init.pp s3://YOUR-BUCKET/stop_hbase_restart/init.pp
+   ```
+
+2. Update the S3 path in `replace_hbase_init_pp.sh` to point to your bucket.
+
+3. Upload the bootstrap script:
+   ```bash
+   aws s3 cp replace_hbase_init_pp.sh s3://YOUR-BUCKET/scripts/replace_hbase_init_pp.sh
+   ```
+
+4. Add the bootstrap action when creating your EMR cluster:
+   ```bash
+   aws emr create-cluster \
+     --bootstrap-actions '[{
+       "Name": "Stop HBase restart on Reconfiguration",
+       "Path": "s3://YOUR-BUCKET/scripts/replace_hbase_init_pp.sh"
+     }]' \
+     ...
+   ```
+
+## Artifacts
+
+| File | Description |
+|------|-------------|
+| `replace_hbase_init_pp.sh` | Bootstrap action script — backs up the original manifest and replaces it with the modified version |
+| `init.pp` | Modified Puppet manifest for HBase (EMR 7.12) |
+
+> **Note:** The `init.pp` file may differ between EMR versions. Always verify the original at `/var/aws/emr/bigtop-deploy/puppet/modules/hadoop_hbase/manifests/init.pp` on your target version before deploying.
+
+## Test Results — EMR 7.12
+
+Two EMR 7.12.0 clusters (m5.xlarge, 1 master + 1 core, HBase on S3). Reconfiguration added `hbase.rpc.timeout=120000` via `modify-instance-groups`.
+
+### Without Bootstrap Action
+
+| | Before | After |
+|---|---|---|
+| RegionServer PID | `12489` | `15499` **(changed)** |
+| hbase-site.xml updated | — | ✅ |
+
+HBase RegionServer was restarted automatically during reconfiguration.
+
+### With Bootstrap Action
+
+| | Before | After |
+|---|---|---|
+| RegionServer PID | `9457` | `9457` **(unchanged)** |
+| hbase-site.xml updated | — | ✅ |
+
+HBase RegionServer was **not** restarted. Config was applied to disk. Service continued running uninterrupted.

--- a/utilities/emr-hbase-reconfiguration-guard/init.pp
+++ b/utilities/emr-hbase-reconfiguration-guard/init.pp
@@ -1,0 +1,256 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class hadoop_hbase {
+
+  class deploy ($roles, $auxiliary = true) {
+    if ("hbase-server" in $roles) {
+      include hadoop_hbase::server
+    }
+
+    if ("hbase-master" in $roles) {
+      if ($auxiliary == true) {
+        include hadoop_zookeeper::server
+      }
+
+      include hadoop_hbase::master
+      Exec <| title == 'init hdfs' |> -> Service['hbase-master']
+    }
+
+    if ("hbase-client" in $roles) {
+      include hadoop_hbase::client
+      include hbase_operator_tools::library
+      include emr_wal_cli::library
+    }
+
+    if ("hbase-thrift-server" in $roles) {
+      include hadoop_hbase::thrift_server
+    }
+
+    if ("hbase-rest-server" in $roles) {
+      include hadoop_hbase::rest_server
+    }
+
+  }
+
+  class client_package  {
+    package { "hbase":
+      ensure => present,
+    }
+  }
+
+  class common_config (
+    $hdfsdir = hiera('bigtop::hadoop_namenode_uri'),
+    $rootdir,
+    $zookeeper_quorum,
+    $kerberos_realm = "",
+    $heap_size = "1024",
+    $hbase_site_overrides = {},
+    $hbase_env_overrides = {},
+    $hbase_log4j2_overrides = {},
+    $hbase_metrics_overrides = {},
+    $hbase_policy_overrides = {},
+    $on_s3 = false,
+    $hbase_data_dirs = suffix(hiera('emr::apps_mounted_dirs'), "/hbase"),
+    $use_phoenix_query_server = false,
+  ) {
+    include hadoop_hbase::client_package
+    if ($kerberos_realm and $kerberos_realm != "") {
+      require kerberos::client
+      kerberos::host_keytab { "hbase": 
+        spnego => true,
+        require => Package["hbase"],
+      }
+
+      file { "/etc/hbase/conf/jaas.conf":
+        content => template("hadoop_hbase/jaas.conf"),
+        require => Package["hbase"],
+      }
+    }
+
+    bigtop_file::site { "/etc/hbase/conf/hbase-site.xml":
+      content => template("hadoop_hbase/hbase-site.xml"),
+      overrides => $hbase_site_overrides,
+      require => Package["hbase"],
+    }
+
+    bigtop_file::env { "/etc/hbase/conf/hbase-env.sh":
+      content => template("hadoop_hbase/hbase-env.sh"),
+      overrides => $hbase_env_overrides,
+      require => Package["hbase"],
+    }
+
+    bigtop_file::properties { "/etc/hbase/conf/log4j2.properties":
+      source => '/etc/hbase/conf/log4j2.properties',
+      overrides => $hbase_log4j2_overrides,
+      require => Package["hbase"],
+    }
+
+    bigtop_file::properties { "/etc/hbase/conf/hadoop-metrics2-hbase.properties":
+      source => '/etc/hbase/conf/hadoop-metrics2-hbase.properties',
+      overrides => $hbase_metrics_overrides,
+      require => Package["hbase"],
+    }
+
+    bigtop_file::site { "/etc/hbase/conf/hbase-policy.xml":
+      source => '/etc/hbase/conf/hbase-policy.xml',
+      overrides => $hbase_policy_overrides,
+      require => Package["hbase"],
+    }
+
+    hadoop::create_storage_dir { $hadoop_hbase::common_config::hbase_data_dirs: } ->
+    file { $hadoop_hbase::common_config::hbase_data_dirs:
+      ensure => directory,
+      owner => hbase,
+      group => hbase,
+      mode => "0644",
+      require => [Package["hbase"]],
+    }
+  }
+
+  class client {
+    include hadoop_hbase::common_config
+  }
+
+  class server(
+    $use_adot_java_agent = false
+  ) {
+    include hadoop_hbase::common_config
+
+    unless !$hadoop_hbase::common_config::on_s3 and hiera('emr::node_type') == "task" {
+      package { "hbase-regionserver":
+        ensure => present,
+      }
+
+      if ($use_adot_java_agent) {
+        include emr_cluster_metrics::adot_java_agent
+        Bigtop_file::Properties[
+          "/etc/emr-cluster-metrics/adot-java-agent/conf/hbase-regionserver-java-agent.properties"] -> Bigtop_file::Env[
+          "/etc/hbase/conf/hbase-env.sh"]
+      }
+
+      service { "hbase-regionserver":
+        provider    => systemd,
+        ensure      => running,
+        enable      => true,
+        require     => [Package["hbase-regionserver"], Class["Hadoop_hbase::Common_config"],
+                      Bigtop_file::Site["/etc/hbase/conf/hbase-site.xml"],
+                      Bigtop_file::Env["/etc/hbase/conf/hbase-env.sh"],
+                      Bigtop_file::Properties["/etc/hbase/conf/log4j2.properties"],
+                      Bigtop_file::Properties["/etc/hbase/conf/hadoop-metrics2-hbase.properties"]],
+        hasrestart  => true,
+        hasstatus   => true,
+      }
+      Kerberos::Host_keytab <| title == "hbase" |> -> Service["hbase-regionserver"]
+      Bigtop_file::Site <| tag == "hadoop-plugin" |> ~> Service["hbase-regionserver"]
+    }
+  }
+
+  class master(
+    $use_adot_java_agent = false
+  ) {
+    include hadoop_hbase::common_config
+
+    package { "hbase-master":
+      ensure => present,
+    }
+
+    if ($use_adot_java_agent) {
+      include emr_cluster_metrics::adot_java_agent
+      Bigtop_file::Properties[
+        "/etc/emr-cluster-metrics/adot-java-agent/conf/hbase-master-java-agent.properties"] -> Bigtop_file::Env[
+        "/etc/hbase/conf/hbase-env.sh"]
+    }
+
+    service { "hbase-master":
+      provider  => systemd,
+      ensure    => running,
+      enable    => true,
+      require   => [Package["hbase-master"], Class["Hadoop_hbase::Common_config"],
+                    Bigtop_file::Site["/etc/hbase/conf/hbase-site.xml"],
+                    Bigtop_file::Env["/etc/hbase/conf/hbase-env.sh"],
+                    Bigtop_file::Properties["/etc/hbase/conf/log4j2.properties"],
+                    Bigtop_file::Properties["/etc/hbase/conf/hadoop-metrics2-hbase.properties"]],
+      hasrestart => true,
+      hasstatus  => true,
+    } 
+    Kerberos::Host_keytab <| title == "hbase" |> -> Service["hbase-master"]
+    Bigtop_file::Site <| tag == "hadoop-plugin" |> ~> Service["hbase-master"]
+  }
+
+  class thrift_server(
+    $use_adot_java_agent = false
+  ) {
+    include hadoop_hbase::common_config
+
+    package { "hbase-thrift":
+      ensure => present,
+    }
+
+    if ($use_adot_java_agent) {
+      include emr_cluster_metrics::adot_java_agent
+      Bigtop_file::Properties[
+        "/etc/emr-cluster-metrics/adot-java-agent/conf/hbase-thrift-java-agent.properties"] -> Bigtop_file::Env[
+        "/etc/hbase/conf/hbase-env.sh"]
+    }
+
+    service { "hbase-thrift":
+        provider    => systemd,
+        ensure      => running,
+        enable      => true,
+        require     => [Package["hbase-thrift"],
+                      Bigtop_file::Site["/etc/hbase/conf/hbase-site.xml"],
+                      Bigtop_file::Env["/etc/hbase/conf/hbase-env.sh"],
+                      Bigtop_file::Properties["/etc/hbase/conf/log4j2.properties"],
+                      Bigtop_file::Properties["/etc/hbase/conf/hadoop-metrics2-hbase.properties"]],
+        hasrestart  => true,
+        hasstatus   => true,
+    }
+    Kerberos::Host_keytab <| title == "hbase" |> -> Service["hbase-thrift"]
+    Bigtop_file::Site <| tag == "hadoop-plugin" |> ~> Service["hbase-thrift"]
+  }
+
+  class rest_server(
+    $use_adot_java_agent = false
+  ) {
+    include hadoop_hbase::common_config
+
+    package { "hbase-rest":
+      ensure => present,
+    }
+
+    if ($use_adot_java_agent) {
+      include emr_cluster_metrics::adot_java_agent
+      Bigtop_file::Properties[
+        "/etc/emr-cluster-metrics/adot-java-agent/conf/hbase-rest-java-agent.properties"] -> Bigtop_file::Env[
+        "/etc/hbase/conf/hbase-env.sh"]
+    }
+
+    service { "hbase-rest":
+        provider    => systemd,
+        ensure      => running,
+        enable      => true,
+        require     => [Package["hbase-rest"],
+                      Bigtop_file::Site["/etc/hbase/conf/hbase-site.xml"],
+                      Bigtop_file::Env["/etc/hbase/conf/hbase-env.sh"],
+                      Bigtop_file::Properties["/etc/hbase/conf/log4j2.properties"],
+                      Bigtop_file::Properties["/etc/hbase/conf/hadoop-metrics2-hbase.properties"]],
+        hasrestart  => true,
+        hasstatus   => true,
+    }
+    Kerberos::Host_keytab <| title == "hbase" |> -> Service["hbase-rest"]
+    Bigtop_file::Site <| tag == "hadoop-plugin" |> ~> Service["hbase-rest"]
+  }
+}

--- a/utilities/emr-hbase-reconfiguration-guard/replace_hbase_init_pp.sh
+++ b/utilities/emr-hbase-reconfiguration-guard/replace_hbase_init_pp.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Author: Suthan Phillips
+# Bootstrap action to replace HBase init.pp file to prevent hbase service restarts on re-configuration
+# Date: 03/19/2025
+# Version 2 - Updated for EMR 7.12+
+
+# Create backup of original file
+sudo cp /var/aws/emr/bigtop-deploy/puppet/modules/hadoop_hbase/manifests/init.pp /var/aws/emr/bigtop-deploy/puppet/modules/hadoop_hbase/manifests/init.pp.bak
+
+# Download the modified init.pp from S3
+# IMPORTANT: Modify the S3 path below to point to your S3 bucket location containing the init.pp file
+sudo aws s3 cp s3://YOUR-BUCKET/stop_hbase_restart/init.pp /var/aws/emr/bigtop-deploy/puppet/modules/hadoop_hbase/manifests/init.pp
+
+# Set correct permissions and ownership
+sudo chmod 644 /var/aws/emr/bigtop-deploy/puppet/modules/hadoop_hbase/manifests/init.pp
+sudo chown root:root /var/aws/emr/bigtop-deploy/puppet/modules/hadoop_hbase/manifests/init.pp

--- a/utilities/hbase-benchmark/README.md
+++ b/utilities/hbase-benchmark/README.md
@@ -1,0 +1,67 @@
+# HBase Benchmark
+
+Run HBase benchmarks on Amazon EMR as a single EMR step.
+
+## Supported Benchmarks
+
+| Benchmark | Description |
+|-----------|-------------|
+| **YCSB** | Yahoo! Cloud Serving Benchmark — workloads A–F against HBase |
+
+## Setup (one-time)
+
+Copy the benchmark script to your S3 bucket:
+
+```bash
+aws s3 cp benchmarks/ycsb/run.sh s3://YOUR-BUCKET/scripts/hbase-benchmark/ycsb/run.sh
+```
+
+## Run Benchmark
+
+```bash
+aws emr add-steps \
+  --cluster-id j-XXXXXXXXXXXXX \
+  --steps '[{
+    "Type": "CUSTOM_JAR",
+    "Name": "ycsb-benchmark",
+    "Jar": "command-runner.jar",
+    "Args": [
+      "bash", "-c",
+      "aws s3 cp s3://YOUR-BUCKET/scripts/hbase-benchmark/ycsb/run.sh /tmp/ycsb_run.sh && chmod +x /tmp/ycsb_run.sh && bash /tmp/ycsb_run.sh --record-count 1000000 --operation-count 200000 --threads 64 --s3-results-path s3://YOUR-BUCKET/ycsb-results/$(date +%Y%m%d-%H%M%S)"
+    ],
+    "ActionOnFailure": "CONTINUE"
+  }]'
+```
+
+Replace:
+- `j-XXXXXXXXXXXXX` with your EMR cluster ID
+- `YOUR-BUCKET` with your S3 bucket
+
+### Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--record-count` | 1,000,000 | Total records to load |
+| `--operation-count` | 200,000 | Operations per workload |
+| `--threads` | 64 | Concurrent client threads |
+| `--n-splits` | 50 | HBase region pre-splits (10 × worker nodes) |
+| `--s3-results-path` | _(none)_ | S3 path for results upload |
+
+### Results
+
+```
+s3://YOUR-BUCKET/ycsb-results/20260311-190500/
+├── load_batch_*.txt
+├── workloada.txt      # 50% read, 50% update
+├── workloadb.txt      # 95% read, 5% update
+├── workloadc.txt      # 100% read
+├── workloadd.txt      # 95% read, 5% insert (read latest)
+├── workloade.txt      # 95% scan, 5% insert
+└── workloadf.txt      # 50% read, 50% read-modify-write
+```
+
+## Prerequisites
+
+- EMR cluster with HBase installed
+- Cluster EC2 instance profile needs `s3:GetObject` (script) and `s3:PutObject` (results) on the bucket
+- Cluster must have internet access (to clone YCSB from GitHub on first run)

--- a/utilities/hbase-benchmark/benchmarks/ycsb/run.sh
+++ b/utilities/hbase-benchmark/benchmarks/ycsb/run.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -e
+
+# Parse arguments passed via EMR step
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --record-count) RECORD_COUNT="$2"; shift 2;;
+    --operation-count) OPERATION_COUNT="$2"; shift 2;;
+    --threads) THREADS="$2"; shift 2;;
+    --n-splits) N_SPLITS="$2"; shift 2;;
+    --s3-results-path) S3_RESULTS_PATH="$2"; shift 2;;
+    *) shift;;
+  esac
+done
+
+RECORD_COUNT=${RECORD_COUNT:-1000000}
+OPERATION_COUNT=${OPERATION_COUNT:-200000}
+THREADS=${THREADS:-64}
+N_SPLITS=${N_SPLITS:-50}
+DB="hbase2"
+COLUMN_FAMILY="family"
+TABLE="usertable"
+RESULTS_DIR="/home/hadoop/ycsb_results"
+
+mkdir -p ${RESULTS_DIR}
+
+# Install and build YCSB if not present
+if [ ! -d "/home/hadoop/YCSB" ]; then
+  echo "Installing YCSB..."
+  yes | sudo yum install git maven
+  cd /home/hadoop
+  git clone https://github.com/brianfrankcooper/YCSB.git
+  cd YCSB
+  mvn -pl site.ycsb:hbase2-binding -am clean package -DskipTests=True
+fi
+
+# Create HBase table (ignore if exists)
+hbase shell <<EOF || true
+create 'usertable', 'family', {SPLITS => (1..${N_SPLITS}).map {|i| "user#{1000+i*(9999-1000)/${N_SPLITS}}"}}
+exit
+EOF
+
+cd /home/hadoop/YCSB/
+
+retry() {
+  local n=1 max=3 delay=5
+  while true; do
+    "$@" && break || {
+      if [[ $n -lt $max ]]; then ((n++)); echo "Attempt $n/$max:"; sleep $delay
+      else echo "Failed after $n attempts."; return 1; fi
+    }
+  done
+}
+
+# Load in parallel batches
+BATCHES=$((RECORD_COUNT / OPERATION_COUNT))
+for i in $(seq 0 $((BATCHES - 1))); do
+  INSERT_START=$((i * OPERATION_COUNT))
+  echo "Loading batch $i from $INSERT_START..."
+  retry bin/ycsb load ${DB} -P workloads/workloada \
+    -p recordcount=${OPERATION_COUNT} -p insertstart=${INSERT_START} \
+    -p threadcount=${THREADS} -p table=${TABLE} -p columnfamily=${COLUMN_FAMILY} \
+    -s > ${RESULTS_DIR}/load_batch_${i}.txt 2>&1 &
+done
+wait
+echo "Load phase completed."
+
+# Run workloads sequentially
+for WORKLOAD in workloada workloadb workloadc workloadf workloade workloadd; do
+  echo "Running ${WORKLOAD}..."
+  retry bin/ycsb run ${DB} -P workloads/${WORKLOAD} \
+    -p threadcount=${THREADS} -p recordcount=${RECORD_COUNT} \
+    -p operationcount=${OPERATION_COUNT} -p table=${TABLE} \
+    -p columnfamily=${COLUMN_FAMILY} -s > ${RESULTS_DIR}/${WORKLOAD}.txt 2>&1
+done
+
+echo "YCSB benchmark completed."
+
+# Upload results to S3
+if [[ -n "$S3_RESULTS_PATH" ]]; then
+  aws s3 cp ${RESULTS_DIR}/ ${S3_RESULTS_PATH}/ --recursive
+  echo "Results uploaded to ${S3_RESULTS_PATH}"
+fi


### PR DESCRIPTION
## Summary

Four improvements to the EMR Serverless Config Advisor recommender and extractor.

## Changes

### 1. Smart Driver Sizing (`emr_recommender.py`)
Driver scales dynamically instead of being hardcoded at 4c/14G:

| Threshold | Driver |
|---|---|
| partitions > 10K OR executors > 500 OR shuffle > 10TB | 16c / 108G |
| partitions > 2K OR executors > 100 OR shuffle > 2TB | 8c / 54G |
| partitions > 500 OR executors > 50 OR shuffle > 500GB | 4c / 28G |
| Everything else | 4c / 14G |

### 2. Serverless Storage Off by Default
- Recommends attached executor disk by default; `--serverless-storage` flag to opt in
- Only enables when safe: zero disk spill AND shuffle within limits
- Fixes 'No space left on device' failures from shuffle sort spill hitting the fixed 20GB local disk
- Removed incorrect `spill_likely_gone` prediction that zeroed out observed disk spill

### 3. IO-Optimized Recommendation Mode
New third recommendation for shuffle I/O bound jobs, based on `shuffle_fetch_wait_percent`:
- **>80% fetch wait**: 4x disks — Large(16c) → Small(4c), 4x executors
- **>50% fetch wait**: 2x disks — Large(16c) → Medium(8c), 2x executors
- Same per-task memory, same total vCPU, more aggregate disk throughput
- Only emitted when the job is actually I/O bound; no extra disk cost for compute-bound jobs

### 4. Shuffle I/O Timing Metrics (`python_extractor.py`)
New fields in `io_summary`:
- `total_shuffle_fetch_wait_sec` / `shuffle_fetch_wait_percent`
- `total_shuffle_write_time_sec` / `shuffle_write_time_percent`
- `total_gc_time_sec` / `gc_time_percent`
- `total_executor_run_time_sec`

### 5. Executor Memory Rounding Fix
Changed from floor to ceiling rounding when snapping to valid EMR Serverless memory increments, preserving the 1.5x headroom over peak observed memory.

## Files Changed
- `emr_recommender.py` — driver sizing, serverless storage, IO-optimized mode, memory rounding
- `python_extractor.py` — shuffle/GC timing metrics
- `pipeline_wrapper.py` — `--serverless-storage` passthrough
- `README.md` — `--serverless-storage` flag docs

## Testing
Validated across 8 applications (14 runs), 56GB to 23.5TB input:
- IO-optimized correctly triggers only for shuffle-bound jobs (92% fetch wait → 4x disks, 0.4% → skipped)
- Driver sizing matches actual production configs (16c/108G for 22TB shuffle jobs)
- Serverless storage correctly blocked when disk spill > 0