### PR TITLE
EMR Serverless Config Advisor: IOPS-based IO-optimized mode

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -164,6 +164,7 @@ Each app produces a JSON with these sections:
 |------|----------|----------|
 | Cost | Conservative scaling (0.5–1.5× base) | Dev/test, budget workloads |
 | Performance | Aggressive scaling for memory-stressed jobs | Production SLA-critical |
+| IO-Optimized | Smaller workers, more disks for shuffle-bound jobs | Jobs with >50% shuffle fetch wait |
 
 ## Write to Iceberg Table
 
@@ -284,6 +285,7 @@ ORDER BY total_memory_spilled_gb DESC;
 | `--input-path` | Path with extracted metrics (local or S3) | *required* |
 | `--output-cost` | Output file for cost-optimized recs | — |
 | `--output-perf` | Output file for performance-optimized recs | — |
+| `--output-io` | Output file for IO-optimized recs (only for shuffle-bound jobs) | — |
 | `--cost-optimized` | Generate only cost recommendations | both |
 | `--performance-optimized` | Generate only performance recommendations | both |
 | `--individual-files` | One JSON per job | single file |

--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -285,7 +285,7 @@ ORDER BY total_memory_spilled_gb DESC;
 | `--input-path` | Path with extracted metrics (local or S3) | *required* |
 | `--output-cost` | Output file for cost-optimized recs | — |
 | `--output-perf` | Output file for performance-optimized recs | — |
-| `--output-io` | Output file for IO-optimized recs (only for shuffle-bound jobs) | — |
+| `--output-io` | Output file for IO-optimized recs (only for shuffle-bound jobs) | `recommendations_io_optimized.json` |
 | `--cost-optimized` | Generate only cost recommendations | both |
 | `--performance-optimized` | Generate only performance recommendations | both |
 | `--individual-files` | One JSON per job | single file |

--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -1,6 +1,31 @@
 # EMR Serverless Config Advisor
 
-Analyzes Spark event logs from EMR on EC2 or EMR Serverless and generates optimized configurations with cost and performance recommendations.
+Analyzes Spark event logs from EMR on EC2 or EMR Serverless and generates optimized EMR Serverless configurations. Produces cost-optimized and performance-optimized recommendations based on actual workload properties — input size, shuffle volume, memory utilization, disk spill, and shuffle I/O patterns.
+
+## How It Works
+
+The advisor extracts 80+ metrics from Spark event logs and uses them to calculate right-sized EMR Serverless configurations:
+
+1. **Extract** — Parse Spark event logs (compressed `.zst` or plain JSON) to produce per-application metrics: task counts, stage-level shuffle/spill, executor memory and CPU utilization, I/O timing breakdowns, and driver statistics.
+
+2. **Recommend** — Analyze extracted metrics to determine optimal worker size (Small/Medium/Large), executor count, shuffle partitions, disk configuration, and timeout settings. Two modes:
+   - **Cost-optimized**: Minimum resources to complete the job reliably
+   - **Performance-optimized**: Additional headroom for SLA-critical workloads
+
+3. **Format** — Convert recommendations into deployment-ready EMR Serverless `sparkSubmitParameters` JSON.
+
+### Key Sizing Decisions
+
+| Decision | Based On |
+|----------|----------|
+| Worker type (Small 4c / Medium 8c / Large 16c) | Peak memory per executor, memory utilization |
+| Executor memory | 1.5× observed peak memory, rounded to valid EMR Serverless increments |
+| Max executors | Shuffle volume ÷ target partition size (1 GB default) ÷ cores per worker |
+| Shuffle partitions | Total shuffle data ÷ 1 GB target partition size |
+| Driver sizing | Partition count, executor count, and shuffle volume thresholds |
+| Disk configuration | 500G shuffle-optimized attached disk (default) |
+| Timeout tuning | Input size + duration-based network and shuffle timeouts |
+| IO-aware scaling | For shuffle-bound jobs (>50% fetch wait), automatically switches to smaller workers with more disks to increase aggregate disk throughput |
 
 ## Architecture
 
@@ -43,29 +68,74 @@ Analyzes Spark event logs from EMR on EC2 or EMR Serverless and generates optimi
 └──────────────┘         └──────────────────────────────────────────────────────┘
 ```
 
-**Flow:**
-1. Lambda orchestrator lists event log apps in S3, submits one EMR Serverless job per app (parallel)
-2. Each `spark_extractor.py` job reads compressed event logs, extracts 80+ metrics per app
-3. `emr_recommender.py` reads extracted metrics, generates cost/performance Spark configs
-4. `write_to_iceberg.py` (optional) writes metrics + recommendations to an Iceberg table via Spark
-
 ## Scripts
 
 | Script | Purpose |
 |--------|---------|
-| `spark_extractor.py` | Extracts metrics from Spark event logs using PySpark |
-| `python_extractor.py` | Extracts metrics from Spark event logs using pure Python (no Spark required) |
+| `spark_extractor.py` | Extracts metrics from Spark event logs using PySpark (runs on EMR) |
+| `python_extractor.py` | Extracts metrics from Spark event logs using pure Python (runs anywhere) |
 | `pipeline_wrapper.py` | End-to-end orchestrator: extract → recommend → format (no Spark required) |
-| `lambda_orchestrator.py` | Lambda function that submits parallel EMR Serverless jobs |
-| `emr_recommender.py` | Generates cost/performance optimized Spark configurations |
-| `write_to_iceberg.py` | Writes metrics + recommendations to Iceberg table via Spark |
-| `format_to_job_config.py` | Formats recommendations into EMR Serverless job config format |
+| `emr_recommender.py` | Generates cost and performance optimized Spark configurations |
+| `format_to_job_config.py` | Converts recommendations into EMR Serverless `sparkSubmitParameters` format |
+| `lambda_orchestrator.py` | Lambda function that submits parallel EMR Serverless extraction jobs |
+| `write_to_iceberg.py` | Writes metrics and recommendations to an Iceberg table via Spark |
 
 ## Quick Start
 
-### Option 1: Lambda + EMR Serverless (recommended)
+### Option 1: Pure Python Pipeline (no Spark required)
 
-Deploy `lambda_orchestrator.py` as a Lambda function, then invoke:
+Run all three stages (extract → recommend → format) in one command on any machine with Python 3.7+:
+
+```bash
+python3 pipeline_wrapper.py \
+  --input s3://your-bucket/event-logs/ \
+  --output /tmp/advisor-output/ \
+  --format-job-config
+```
+
+This produces:
+- `task_stage_summary/*.json` — extracted metrics per application
+- `recommendations.json` — cost and performance recommendations
+- `job_config_*.json` — deployment-ready EMR Serverless configs
+
+To re-run recommendations on previously extracted data:
+
+```bash
+python3 pipeline_wrapper.py \
+  --input s3://your-bucket/event-logs/ \
+  --output /tmp/advisor-output/ \
+  --skip-extraction \
+  --format-job-config
+```
+
+### Option 2: Step-by-Step
+
+Extract metrics:
+
+```bash
+python3 python_extractor.py \
+  --input s3://your-bucket/event-logs/ \
+  --output /tmp/extracted/
+```
+
+Generate recommendations:
+
+```bash
+python3 emr_recommender.py \
+  --input-path /tmp/extracted/ \
+  --output-cost cost.json \
+  --output-perf perf.json
+```
+
+Format for deployment:
+
+```bash
+python3 format_to_job_config.py --input cost.json --output job_config.json
+```
+
+### Option 3: Lambda + EMR Serverless (at scale)
+
+For processing hundreds of applications, deploy `lambda_orchestrator.py` as a Lambda function:
 
 ```bash
 aws lambda invoke \
@@ -82,16 +152,7 @@ aws lambda invoke \
   output.json
 ```
 
-Then generate recommendations:
-
-```bash
-python3 emr_recommender.py \
-  --input-path s3://your-bucket/advisor-output/ \
-  --output-cost cost.json \
-  --output-perf perf.json
-```
-
-### Option 2: Direct spark-submit
+### Option 4: Direct spark-submit
 
 ```bash
 spark-submit --master local[*] --driver-memory 32g \
@@ -100,74 +161,52 @@ spark-submit --master local[*] --driver-memory 32g \
   --output /tmp/output/
 ```
 
-### Option 3: Pure Python (no Spark required)
-
-Run extraction on any machine with Python 3.7+ — no Spark or PySpark needed:
-
-```bash
-python3 python_extractor.py \
-  --input s3://your-bucket/event-logs/ \
-  --output /tmp/output/
-```
-
-For a single application:
-
-```bash
-python3 python_extractor.py \
-  --input s3://your-bucket/event-logs/app_123/ \
-  --output /tmp/output/ \
-  --single-app
-```
-
-Output format is identical to `spark_extractor.py` and works with `emr_recommender.py`.
-
-### Option 4: End-to-End Pipeline (no Spark required)
-
-Run all three stages (extract → recommend → format) in one command:
-
-```bash
-python3 pipeline_wrapper.py \
-  --input s3://your-bucket/event-logs/ \
-  --output s3://your-bucket/extracted/ \
-  --format-job-config
-```
-
-Skip extraction to re-run recommendations on existing data:
-
-```bash
-python3 pipeline_wrapper.py \
-  --input s3://your-bucket/event-logs/ \
-  --output s3://your-bucket/extracted/ \
-  --skip-extraction \
-  --format-job-config
-```
-
-## Extracted Metrics
-
-Each app produces a JSON with these sections:
-
-| Section | Key Fields |
-|---------|------------|
-| `task_summary` | total/completed/failed/killed tasks, success rate |
-| `stage_summary` | per-stage shuffle read/write, spill, duration, failure reasons |
-| `executor_summary` | 20 fields per executor: cores, memory, uptime, utilization, cost factor |
-| `io_summary` | total input/output/shuffle read/write in GB |
-| `spill_summary` | memory + disk spill totals and percentages |
-| `shuffle_data_summary` | peak stage shuffle write, EMR Serverless storage eligibility (200GB limit) |
-| `driver_metrics` | GC stats, off-heap memory, tasks/jobs/stages launched |
-| `job_details` | per-job duration, status, stage mapping |
-| `sql_metrics` | per-SQL execution plan, duration, status |
-
 ## Recommendation Modes
 
 | Mode | Strategy | Best For |
 |------|----------|----------|
-| Cost | Conservative scaling (0.5–1.5× base); for IO-bound jobs (>50% shuffle fetch wait), automatically uses smaller workers with more disks | Dev/test, budget workloads |
-| Performance | Aggressive scaling for memory-stressed jobs; for IO-bound jobs, uses smaller workers scaled to perf executor count | Production SLA-critical |
+| Cost | Minimum resources to complete reliably. For shuffle-bound jobs (>50% fetch wait), automatically uses smaller workers with more disks to increase I/O throughput without over-provisioning compute. | Dev/test, batch workloads, cost-sensitive production |
+| Performance | Additional executor headroom (1.5–2× cost). For shuffle-bound jobs, scales the IO-aware worker configuration to the higher executor count. | SLA-critical production, latency-sensitive jobs |
+
+### IO-Aware Scaling
+
+When a job spends more than 50% of its time waiting on shuffle fetches, the standard Large-worker configuration won't help — the bottleneck is disk I/O, not compute. The advisor automatically detects this and:
+
+- Switches to smaller workers (Medium 8c or Small 4c) to increase the number of independent disks
+- Keeps the same total vCPU and per-task memory (e.g., Large 16c/108G → Small 4c/27G = same 6.75 GB/task)
+- Limits the multiplier based on fleet size: jobs with >200 cost executors cap at 2× (Large→Medium) to avoid excessive shuffle network connections; smaller jobs allow up to 4× (Large→Small)
+
+This is applied transparently to both cost and performance outputs — no separate flag needed.
+
+## Extracted Metrics
+
+Each application produces a JSON with these sections:
+
+| Section | Key Fields |
+|---------|------------|
+| `task_summary` | Total/completed/failed/killed tasks, success rate |
+| `stage_summary` | Per-stage shuffle read/write, spill, duration, failure reasons |
+| `executor_summary` | Per-executor cores, memory, uptime, utilization, peak memory, cost factor |
+| `io_summary` | Total input/output/shuffle bytes, shuffle fetch wait %, GC %, write time % |
+| `spill_summary` | Memory and disk spill totals and percentages |
+| `shuffle_data_summary` | Peak stage shuffle write, EMR Serverless storage eligibility |
+| `driver_metrics` | GC stats, off-heap memory, tasks/jobs/stages launched |
+| `job_details` | Per-job duration, status, stage mapping |
+| `sql_metrics` | Per-SQL execution plan, duration, status |
+
+## Serverless Storage
+
+Serverless storage is **disabled by default**. Recommendations use attached executor disk (`spark.emr-serverless.executor.disk: 500G`).
+
+Pass `--serverless-storage` to enable it. Serverless storage will only be recommended when:
+- The workload has **zero disk spill**
+- Shuffle volume per stage is within safe limits
+
+This is because EMR Serverless local disk is fixed at 20GB and cannot be increased. Shuffle sort spill and memory spill overflow go to local disk, not serverless storage. Enabling serverless storage for spill-heavy jobs causes "No space left on device" failures.
 
 ## Write to Iceberg Table
 
-### Option A: Let the script create the table
+Optionally persist recommendations to an Iceberg table for tracking over time:
 
 ```bash
 spark-submit \
@@ -179,9 +218,7 @@ spark-submit \
   --warehouse s3://your-bucket/iceberg/
 ```
 
-### Option B: Create the table yourself first
-
-Use this DDL in Athena (V3 engine) or Spark SQL:
+The table can also be created manually via Athena (V3 engine) or Spark SQL:
 
 ```sql
 CREATE TABLE IF NOT EXISTS your_database.config_advisor (
@@ -210,18 +247,16 @@ USING iceberg
 LOCATION 's3://your-bucket/iceberg/your_database/config_advisor/'
 ```
 
-Then run `write_to_iceberg.py` — it will detect the existing table and append data.
-
-### Query Examples
+### Example Queries
 
 ```sql
 -- Latest recommendations
-SELECT job_id, application_name, input_gb, duration_hours,
-       peak_shuffle_write_per_stage, cost_factor
+SELECT job_id, application_name, optimization_mode, input_gb,
+       duration_hours, cost_factor
 FROM your_database.config_advisor
 ORDER BY created_at DESC;
 
--- Jobs exceeding Serverless storage limit (200GB)
+-- Jobs exceeding Serverless storage limit
 SELECT job_id, application_name, peak_shuffle_write_per_stage
 FROM your_database.config_advisor
 WHERE peak_shuffle_write_per_stage > 200;
@@ -236,16 +271,6 @@ ORDER BY total_memory_spilled_gb DESC;
 
 ## CLI Reference
 
-### spark_extractor.py
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--input` | S3 path or local path to event logs | *required* |
-| `--output` | Output path for extracted metrics | *required* |
-| `--limit` | Max applications to process | 100 |
-| `--single-app` | Input path is a single app (not a directory of apps) | false |
-| `--decompress-workers` | Parallel S3 download threads | 50 |
-
 ### python_extractor.py
 
 | Flag | Description | Default |
@@ -257,12 +282,27 @@ ORDER BY total_memory_spilled_gb DESC;
 | `--workers` | Parallel processing workers | 20 |
 | `--profile` | AWS profile name for S3 access | default |
 
+### emr_recommender.py
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--input-path` | Path with extracted metrics (local or S3) | *required* |
+| `--output-cost` | Output file for cost-optimized recommendations | `recommendations_cost_optimized.json` |
+| `--output-perf` | Output file for performance-optimized recommendations | `recommendations_performance_optimized.json` |
+| `--cost-optimized` | Generate only cost recommendations | both |
+| `--performance-optimized` | Generate only performance recommendations | both |
+| `--individual-files` | One JSON file per application | single file |
+| `--format-job-config` | Output in deployment-ready format | standard |
+| `--target-partition-size` | Target shuffle partition size in MiB | 1024 |
+| `--limit` | Max applications to process | 100 |
+| `--serverless-storage` | Enable serverless storage recommendations | off |
+
 ### pipeline_wrapper.py
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--input` | S3 or local path to event logs | *required* |
-| `--output` | Output path for extracted metrics (S3 or local) | *required* |
+| `--output` | Output path for extracted metrics | *required* |
 | `--limit` | Max applications to process | 100 |
 | `--workers` | Parallel workers for extraction | 20 |
 | `--profile` | AWS profile name | default |
@@ -270,29 +310,13 @@ ORDER BY total_memory_spilled_gb DESC;
 | `--region` | AWS region | us-east-1 |
 | `--target-partition-size` | Target shuffle partition size in MiB | 1024 |
 | `--results` | Output filename for recommendations | recommendations.json |
-| `--format-job-config` | Also format output to EMR Serverless job config JSON | false |
+| `--format-job-config` | Also produce EMR Serverless job config JSON | false |
 | `--cost-optimized` | Generate only cost-optimized recommendations | both |
 | `--performance-optimized` | Generate only performance-optimized recommendations | both |
-| `--individual-files` | Generate individual JSON files per job | single file |
-| `--write-to-iceberg-table` | Write recommendations to Iceberg table (`catalog.database.table`) | — |
-| `--skip-extraction` | Skip extraction step, use existing data in `--output` | false |
-
-### emr_recommender.py
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--input-path` | Path with extracted metrics (local or S3) | *required* |
-| `--output-cost` | Output file for cost-optimized recs | — |
-| `--output-perf` | Output file for performance-optimized recs | — |
-| `--cost-optimized` | Generate only cost recommendations | both |
-| `--performance-optimized` | Generate only performance recommendations | both |
-| `--individual-files` | One JSON per job | single file |
-| `--format-job-config` | Deployment-ready format | standard |
-| `--target-partition-size` | Shuffle partition size in MiB | 1024 |
-| `--limit` | Max applications | 100 |
+| `--individual-files` | Generate individual JSON files per application | single file |
+| `--write-to-iceberg-table` | Write to Iceberg table (`catalog.database.table`) | — |
+| `--skip-extraction` | Skip extraction, use existing data in `--output` | false |
 | `--serverless-storage` | Enable serverless storage recommendations | off |
-
-**Serverless storage** is disabled by default. When disabled, recommendations include attached executor disk (`spark.emr-serverless.executor.disk`). Pass `--serverless-storage` to enable it — serverless storage will only be recommended when the workload has zero disk spill and shuffle volume is within safe limits. This is because EMR Serverless local disk is fixed at 20GB and cannot be increased; any disk spill (shuffle sort spill, memory spill overflow) goes to local disk, not serverless storage, and can cause "No space left on device" failures.
 
 ### format_to_job_config.py
 
@@ -301,6 +325,16 @@ ORDER BY total_memory_spilled_gb DESC;
 | `--input` | Input recommendations JSON file | *required* |
 | `--output` | Output job config JSON file | *required* |
 
+### spark_extractor.py
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--input` | S3 path or local path to event logs | *required* |
+| `--output` | Output path for extracted metrics | *required* |
+| `--limit` | Max applications to process | 100 |
+| `--single-app` | Input path is a single app | false |
+| `--decompress-workers` | Parallel S3 download threads | 50 |
+
 ### write_to_iceberg.py
 
 | Flag | Description | Default |
@@ -308,17 +342,18 @@ ORDER BY total_memory_spilled_gb DESC;
 | `--rec-path` | Path to recommendation JSON | *required* |
 | `--extract-path` | Path containing `task_stage_summary/` | *required* |
 | `--table` | Iceberg table: `catalog.database.table` | *required* |
-| `--warehouse` | S3 warehouse location | `s3://suthan-event-logs/iceberg/` |
+| `--warehouse` | S3 warehouse location | — |
 
 ## Prerequisites
 
-- Python 3.7+, `pip install boto3 zstandard pandas`
-- For Spark extraction: EMR cluster or EMR Serverless application
-- For Iceberg: Glue Catalog access, Iceberg Spark runtime JAR
+- Python 3.7+
+- `pip install boto3 zstandard pandas`
+- For Spark-based extraction: EMR cluster or EMR Serverless application
+- For Iceberg writes: Glue Catalog access, Iceberg Spark runtime JAR
 
 ## Legacy Scripts
 
-Previous Python-based extraction scripts are in the `legacy/` folder. Both `spark_extractor.py` (PySpark) and `python_extractor.py` (pure Python) replace `legacy/spark_processor.py` with identical output format.
+Previous extraction scripts are in the `legacy/` folder. Both `spark_extractor.py` (PySpark) and `python_extractor.py` (pure Python) replace `legacy/spark_processor.py` with identical output format.
 
 ## License
 

--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -162,9 +162,9 @@ Each app produces a JSON with these sections:
 
 | Mode | Strategy | Best For |
 |------|----------|----------|
-| Cost | Conservative scaling (0.5–1.5× base) | Dev/test, budget workloads |
-| Performance | Aggressive scaling for memory-stressed jobs | Production SLA-critical |
-| IO-Optimized | Smaller workers, more disks for shuffle-bound jobs | Jobs with >50% shuffle fetch wait |
+| Cost | Conservative scaling (0.5–1.5× base); for IO-bound jobs (>50% shuffle fetch wait), automatically uses smaller workers with more disks | Dev/test, budget workloads |
+| Performance | Aggressive scaling for memory-stressed jobs; for IO-bound jobs, uses smaller workers scaled to perf executor count | Production SLA-critical |
+| IO-Optimized | Dedicated IO output with IOPS-based disk calculation for shuffle-bound jobs | Separate `--output-io` file for comparison |
 
 ## Write to Iceberg Table
 

--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -164,7 +164,6 @@ Each app produces a JSON with these sections:
 |------|----------|----------|
 | Cost | Conservative scaling (0.5–1.5× base); for IO-bound jobs (>50% shuffle fetch wait), automatically uses smaller workers with more disks | Dev/test, budget workloads |
 | Performance | Aggressive scaling for memory-stressed jobs; for IO-bound jobs, uses smaller workers scaled to perf executor count | Production SLA-critical |
-| IO-Optimized | Dedicated IO output with IOPS-based disk calculation for shuffle-bound jobs | Separate `--output-io` file for comparison |
 
 ## Write to Iceberg Table
 
@@ -285,7 +284,6 @@ ORDER BY total_memory_spilled_gb DESC;
 | `--input-path` | Path with extracted metrics (local or S3) | *required* |
 | `--output-cost` | Output file for cost-optimized recs | — |
 | `--output-perf` | Output file for performance-optimized recs | — |
-| `--output-io` | Output file for IO-optimized recs (only for shuffle-bound jobs) | `recommendations_io_optimized.json` |
 | `--cost-optimized` | Generate only cost recommendations | both |
 | `--performance-optimized` | Generate only performance recommendations | both |
 | `--individual-files` | One JSON per job | single file |

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -537,6 +537,10 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             })
             worker_cfg, worker_type = saved_cfg, saved_type
             io_recs.append(io_rec)
+            # For IO-bound jobs, the IO config IS the cost-efficient config
+            # (the standard cost rec would just fail again)
+            cost_recs[-1] = dict(io_rec)
+            cost_recs[-1]["optimization_mode"] = "cost"
         # No IO rec for non-IO-bound jobs or already-Small workers
     
     # Process applications with no input data - recommend minimal config

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -482,12 +482,13 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
                 disks_needed = int(total_shuf_mb / (5 * target_sec) + 0.5)
             else:
                 disks_needed = max_exec_cost
-            # Cap at 4x cost executors (Large->Small is max downsize)
-            io_exec_target = max(max_exec_cost, min(max_exec_cost * 4, disks_needed))
+            # Cap multiplier based on worker count: more workers = more N^2
+            # network overhead, so prefer fewer larger workers
+            max_allowed = 2 if max_exec_cost > 100 else 4
+            io_exec_target = max(max_exec_cost, min(max_exec_cost * max_allowed, disks_needed))
             io_mult = max(1, round(io_exec_target / max_exec_cost)) if max_exec_cost > 0 else 0
-            io_mult = min(io_mult, 4)  # cap at 4x
+            io_mult = min(io_mult, max_allowed)
             io_target = DOWNSIZE_MAP.get((worker_type, io_mult))
-            # If exact mult not in map, try lower
             if not io_target and io_mult > 2:
                 io_target = DOWNSIZE_MAP.get((worker_type, 4)) or DOWNSIZE_MAP.get((worker_type, 2))
                 io_mult = 4 if DOWNSIZE_MAP.get((worker_type, 4)) else 2

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -541,6 +541,18 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             # (the standard cost rec would just fail again)
             cost_recs[-1] = dict(io_rec)
             cost_recs[-1]["optimization_mode"] = "cost"
+            # Perf mode also needs enough disks — scale IO worker to perf executor count
+            perf_io_max = max_exec_perf * io_mult
+            perf_io_min = max(1, perf_io_max // 2)
+            perf_io_rec = dict(io_rec)
+            perf_io_rec["optimization_mode"] = "performance"
+            perf_io_rec["worker"] = dict(io_rec["worker"])
+            perf_io_rec["worker"]["max_executors"] = perf_io_max
+            perf_io_rec["worker"]["min_executors"] = perf_io_min
+            perf_io_rec["worker"]["total_vcpu_capacity"] = perf_io_max * io_r["vcpu"]
+            perf_io_rec["worker"]["total_memory_capacity"] = perf_io_max * io_mem
+            perf_io_rec["spark_configs"] = build_spark_cfg(perf_io_max, perf_io_min, sp_perf, io_disk)
+            perf_recs[-1] = perf_io_rec
         # No IO rec for non-IO-bound jobs or already-Small workers
     
     # Process applications with no input data - recommend minimal config

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -470,8 +470,30 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             "Medium": {"vcpu": 8,  "min_mem": 16, "max_mem": 54, "mem_step": 4},
             "Large":  {"vcpu": 16, "min_mem": 64, "max_mem": 108, "mem_step": 8},
         }
-        io_mult = 4 if shuffle_fetch_wait_pct > 80 else 2 if shuffle_fetch_wait_pct > 50 else 0
-        io_target = DOWNSIZE_MAP.get((worker_type, io_mult))
+        io_mult = 0
+        io_target = None
+        if shuffle_fetch_wait_pct > 50:
+            # IOPS-based: 5 MB/s effective per disk for shuffle random IO
+            # Target: shuffle IO completes within 30% of job duration
+            dur_sec = duration * 3600
+            total_shuf_mb = (s_in_gb + s_out_gb) * 1024
+            target_sec = dur_sec * 0.3
+            if target_sec > 0:
+                disks_needed = int(total_shuf_mb / (5 * target_sec) + 0.5)
+            else:
+                disks_needed = max_exec_cost
+            # Cap at 4x cost executors (Large->Small is max downsize)
+            io_exec_target = max(max_exec_cost, min(max_exec_cost * 4, disks_needed))
+            io_mult = max(1, round(io_exec_target / max_exec_cost)) if max_exec_cost > 0 else 0
+            io_mult = min(io_mult, 4)  # cap at 4x
+            io_target = DOWNSIZE_MAP.get((worker_type, io_mult))
+            # If exact mult not in map, try lower
+            if not io_target and io_mult > 2:
+                io_target = DOWNSIZE_MAP.get((worker_type, 4)) or DOWNSIZE_MAP.get((worker_type, 2))
+                io_mult = 4 if DOWNSIZE_MAP.get((worker_type, 4)) else 2
+            elif not io_target and io_mult > 1:
+                io_target = DOWNSIZE_MAP.get((worker_type, 2))
+                io_mult = 2
         if io_mult and io_target:
             io_type = io_target
             io_r = WORKER_RANGES_IO[io_type]

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -230,7 +230,7 @@ def _get_iceberg_configs() -> Dict[str, str]:
 
 def generate_dual_recommendations(input_path: str, limit: int = 100,
                                   target_partition_size_mib: int = 1024,
-                                  serverless_storage: bool = False) -> Tuple[List[Dict], List[Dict], List[Dict]]:
+                                  serverless_storage: bool = False) -> Tuple[List[Dict], List[Dict]]:
     """Generate cost, performance, and IO-optimized recommendations."""
     
     # Load metrics
@@ -280,7 +280,6 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
     
     cost_recs = []
     perf_recs = []
-    io_recs = []
     
     # Process applications with input data
     for _, row in df_with_data.iterrows():
@@ -536,7 +535,6 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
                 },
             })
             worker_cfg, worker_type = saved_cfg, saved_type
-            io_recs.append(io_rec)
             # For IO-bound jobs, the IO config IS the cost-efficient config
             # (the standard cost rec would just fail again)
             cost_recs[-1] = dict(io_rec)
@@ -600,11 +598,10 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
         
         cost_recs.append(minimal_rec)
         perf_recs.append(minimal_rec)
-        io_recs.append(minimal_rec)
     
-    log.info("Generated %d cost, %d performance, %d io-optimized recommendations",
-             len(cost_recs), len(perf_recs), len(io_recs))
-    return cost_recs, perf_recs, io_recs
+    log.info("Generated %d cost, %d performance recommendations",
+             len(cost_recs), len(perf_recs))
+    return cost_recs, perf_recs
 
 
 if __name__ == "__main__":
@@ -618,7 +615,6 @@ if __name__ == "__main__":
                         help="Target shuffle partition size in MiB (default: 1024 = 1GB)")
     parser.add_argument("--output-cost", default="recommendations_cost_optimized.json", help="Cost output file")
     parser.add_argument("--output-perf", default="recommendations_performance_optimized.json", help="Performance output file")
-    parser.add_argument("--output-io", default="recommendations_io_optimized.json", help="IO-optimized output file")
     parser.add_argument("--format-job-config", action="store_true",
                         help="Format output to job configuration format")
     parser.add_argument("--cost-optimized", action="store_true",
@@ -635,7 +631,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     
     # Generate recommendations
-    cost_recs, perf_recs, io_recs = generate_dual_recommendations(
+    cost_recs, perf_recs = generate_dual_recommendations(
         args.input_path,
         args.limit,
         args.target_partition_size,
@@ -694,10 +690,6 @@ if __name__ == "__main__":
         else:
             Path(args.output_perf).write_text(json.dumps(perf_recs, indent=2))
             log.info("Performance-optimized recommendations written to %s", args.output_perf)
-    
-    # Write IO-optimized recommendations
-    Path(args.output_io).write_text(json.dumps(io_recs, indent=2))
-    log.info("IO-optimized recommendations written to %s", args.output_io)
 
     # Write to Iceberg table if requested
     if args.write_to_iceberg_table:

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -484,7 +484,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
                 disks_needed = max_exec_cost
             # Cap multiplier based on worker count: more workers = more N^2
             # network overhead, so prefer fewer larger workers
-            max_allowed = 2 if max_exec_cost > 100 else 4
+            max_allowed = 2 if max_exec_cost > 200 else 4
             io_exec_target = max(max_exec_cost, min(max_exec_cost * max_allowed, disks_needed))
             io_mult = max(1, round(io_exec_target / max_exec_cost)) if max_exec_cost > 0 else 0
             io_mult = min(io_mult, max_allowed)

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -129,9 +129,9 @@ def _select_worker_type(input_gb: float, shuffle_ratio: float,
     else:
         mem = r["min_mem"]
 
-    # Round down to valid EMR Serverless memory increment (headroom already included)
+    # Round UP to valid EMR Serverless memory increment (preserve headroom)
     step = r["mem_step"]
-    mem = min(r["max_mem"], max(r["min_mem"], r["min_mem"] + ((mem - r["min_mem"]) // step) * step))
+    mem = min(r["max_mem"], max(r["min_mem"], r["min_mem"] + (-(-(mem - r["min_mem"]) // step)) * step))
     # If within one step of max, use max (e.g. 108GB for Large)
     if mem + step > r["max_mem"]:
         mem = r["max_mem"]
@@ -230,8 +230,8 @@ def _get_iceberg_configs() -> Dict[str, str]:
 
 def generate_dual_recommendations(input_path: str, limit: int = 100,
                                   target_partition_size_mib: int = 1024,
-                                  serverless_storage: bool = False) -> Tuple[List[Dict], List[Dict]]:
-    """Generate both cost and performance recommendations."""
+                                  serverless_storage: bool = False) -> Tuple[List[Dict], List[Dict], List[Dict]]:
+    """Generate cost, performance, and IO-optimized recommendations."""
     
     # Load metrics
     all_data = load_json_files(input_path, limit)
@@ -262,6 +262,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             'max_peak_memory_gb': util_data.get('max_peak_memory_gb', 0),
             'orig_executor_cores': int(data.get('spark_config', {}).get('spark.executor.cores', 0) or 0),
             'max_stage_shuffle_write_gb': data.get('shuffle_data_summary', {}).get('max_stage_shuffle_write_gb', 0),
+            'shuffle_fetch_wait_percent': io_data.get('shuffle_fetch_wait_percent', 0),
         }
         flattened.append(flat)
     
@@ -279,6 +280,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
     
     cost_recs = []
     perf_recs = []
+    io_recs = []
     
     # Process applications with input data
     for _, row in df_with_data.iterrows():
@@ -299,6 +301,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
         max_peak_mem_gb = float(row.get('max_peak_memory_gb', 0) or 0)
         orig_cores = int(row.get('orig_executor_cores', 0) or 0)
         max_stage_shuf_write = float(row.get('max_stage_shuffle_write_gb', 0) or 0)
+        shuffle_fetch_wait_pct = float(row.get('shuffle_fetch_wait_percent', 0) or 0)
         
         sh_ratio = _calculate_shuffle_ratio(i_in_gb, s_in_gb, s_out_gb)
         worker_type, worker_cfg = _select_worker_type(i_in_gb, sh_ratio, mem_pct, spill_gb, cpu_pct,
@@ -454,6 +457,64 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
         
         cost_recs.append(cost_rec)
         perf_recs.append(perf_rec)
+
+        # IO-optimized: only for shuffle I/O bound jobs (>50% time in fetch wait)
+        DOWNSIZE_MAP = {
+            # (current_type, multiplier) -> target_type
+            ("Large", 2): "Medium",
+            ("Large", 4): "Small",
+            ("Medium", 2): "Small",
+        }
+        WORKER_RANGES_IO = {
+            "Small":  {"vcpu": 4,  "min_mem": 8,  "max_mem": 27, "mem_step": 1},
+            "Medium": {"vcpu": 8,  "min_mem": 16, "max_mem": 54, "mem_step": 4},
+            "Large":  {"vcpu": 16, "min_mem": 64, "max_mem": 108, "mem_step": 8},
+        }
+        io_mult = 4 if shuffle_fetch_wait_pct > 80 else 2 if shuffle_fetch_wait_pct > 50 else 0
+        io_target = DOWNSIZE_MAP.get((worker_type, io_mult))
+        if io_mult and io_target:
+            io_type = io_target
+            io_r = WORKER_RANGES_IO[io_type]
+            # Keep same per-task memory: original_mem / original_vcpu * new_vcpu
+            per_task_mem = worker_cfg["memory"] / worker_cfg["vcpu"]
+            io_mem = int(per_task_mem * io_r["vcpu"])
+            io_mem = min(io_r["max_mem"], max(io_r["min_mem"],
+                         io_r["min_mem"] + (-(-(io_mem - io_r["min_mem"]) // io_r["mem_step"])) * io_r["mem_step"]))
+            io_max = max_exec_cost * io_mult
+            io_min = min_exec_cost * io_mult
+            io_disk = _calculate_executor_disk(s_out_gb, disk_spill_gb, spill_gb, io_max)
+            io_cfg = {"vcpu": io_r["vcpu"], "memory": io_mem}
+            # Temporarily swap worker_cfg for build_spark_cfg
+            saved_cfg, saved_type = worker_cfg, worker_type
+            worker_cfg, worker_type = io_cfg, io_type
+            io_rec = {
+                "application_id": app_id,
+                "application_name": name,
+                "optimization_mode": "io_optimized",
+                "metrics": base_metrics,
+            }
+            if job_id:
+                io_rec["job_id"] = job_id
+            io_rec.update({
+                "worker": {
+                    "type": io_type,
+                    "vcpu": io_r["vcpu"],
+                    "memory_gb": io_mem,
+                    "max_executors": io_max,
+                    "min_executors": io_min,
+                    "total_vcpu_capacity": io_max * io_r["vcpu"],
+                    "total_memory_capacity": io_max * io_mem,
+                },
+                "spark_configs": build_spark_cfg(io_max, io_min, sp_cost, io_disk),
+                "shuffle_tuned": {
+                    "partitions": sp_cost,
+                    "target_partition_size_mib": target_mib_cost,
+                    "auto_tuned": True,
+                },
+            })
+            worker_cfg, worker_type = saved_cfg, saved_type
+            io_recs.append(io_rec)
+        # No IO rec for non-IO-bound jobs or already-Small workers
     
     # Process applications with no input data - recommend minimal config
     for _, row in df_no_data.iterrows():
@@ -500,10 +561,11 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
         
         cost_recs.append(minimal_rec)
         perf_recs.append(minimal_rec)
+        io_recs.append(minimal_rec)
     
-    log.info("Generated %d cost-optimized and %d performance-optimized recommendations",
-             len(cost_recs), len(perf_recs))
-    return cost_recs, perf_recs
+    log.info("Generated %d cost, %d performance, %d io-optimized recommendations",
+             len(cost_recs), len(perf_recs), len(io_recs))
+    return cost_recs, perf_recs, io_recs
 
 
 if __name__ == "__main__":
@@ -517,6 +579,7 @@ if __name__ == "__main__":
                         help="Target shuffle partition size in MiB (default: 1024 = 1GB)")
     parser.add_argument("--output-cost", default="recommendations_cost_optimized.json", help="Cost output file")
     parser.add_argument("--output-perf", default="recommendations_performance_optimized.json", help="Performance output file")
+    parser.add_argument("--output-io", default="recommendations_io_optimized.json", help="IO-optimized output file")
     parser.add_argument("--format-job-config", action="store_true",
                         help="Format output to job configuration format")
     parser.add_argument("--cost-optimized", action="store_true",
@@ -533,7 +596,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     
     # Generate recommendations
-    cost_recs, perf_recs = generate_dual_recommendations(
+    cost_recs, perf_recs, io_recs = generate_dual_recommendations(
         args.input_path,
         args.limit,
         args.target_partition_size,
@@ -593,6 +656,10 @@ if __name__ == "__main__":
             Path(args.output_perf).write_text(json.dumps(perf_recs, indent=2))
             log.info("Performance-optimized recommendations written to %s", args.output_perf)
     
+    # Write IO-optimized recommendations
+    Path(args.output_io).write_text(json.dumps(io_recs, indent=2))
+    log.info("IO-optimized recommendations written to %s", args.output_io)
+
     # Write to Iceberg table if requested
     if args.write_to_iceberg_table:
         from write_to_iceberg import write_to_iceberg

--- a/utilities/EMR-Serverless-Config-Advisor/python_extractor.py
+++ b/utilities/EMR-Serverless-Config-Advisor/python_extractor.py
@@ -973,6 +973,10 @@ def extract_io_summary(events):
     total_output_bytes = 0
     total_shuffle_read_bytes = 0
     total_shuffle_write_bytes = 0
+    total_shuffle_fetch_wait_ms = 0
+    total_shuffle_write_time_ns = 0
+    total_gc_time_ms = 0
+    total_executor_run_time_ms = 0
     task_count = 0
     tasks_with_input = 0
     tasks_with_output = 0
@@ -986,6 +990,9 @@ def extract_io_summary(events):
 
             if not task_metrics:
                 continue
+
+            total_gc_time_ms += task_metrics.get("JVM GC Time", 0)
+            total_executor_run_time_ms += task_metrics.get("Executor Run Time", 0)
 
             # Input metrics
             input_metrics = task_metrics.get("Input Metrics")
@@ -1009,6 +1016,7 @@ def extract_io_summary(events):
                 remote_bytes = shuffle_read.get("Remote Bytes Read", 0)
                 local_bytes = shuffle_read.get("Local Bytes Read", 0)
                 total_read = remote_bytes + local_bytes
+                total_shuffle_fetch_wait_ms += shuffle_read.get("Fetch Wait Time", 0)
 
                 if total_read > 0:
                     total_shuffle_read_bytes += total_read
@@ -1018,10 +1026,12 @@ def extract_io_summary(events):
             shuffle_write = task_metrics.get("Shuffle Write Metrics")
             if shuffle_write:
                 bytes_written = shuffle_write.get("Shuffle Bytes Written", 0)
+                total_shuffle_write_time_ns += shuffle_write.get("Shuffle Write Time", 0)
                 if bytes_written > 0:
                     total_shuffle_write_bytes += bytes_written
                     tasks_with_shuffle_write += 1
 
+    total_run_sec = total_executor_run_time_ms / 1000 if total_executor_run_time_ms > 0 else 1
     return {
         "application_level": {
             "total_input_bytes": total_input_bytes,
@@ -1032,6 +1042,13 @@ def extract_io_summary(events):
             "total_shuffle_read_gb": round(total_shuffle_read_bytes / (1024 ** 3), 2),
             "total_shuffle_write_bytes": total_shuffle_write_bytes,
             "total_shuffle_write_gb": round(total_shuffle_write_bytes / (1024 ** 3), 2),
+            "total_shuffle_fetch_wait_sec": round(total_shuffle_fetch_wait_ms / 1000, 2),
+            "total_shuffle_write_time_sec": round(total_shuffle_write_time_ns / 1e9, 2),
+            "total_gc_time_sec": round(total_gc_time_ms / 1000, 2),
+            "total_executor_run_time_sec": round(total_run_sec, 2),
+            "shuffle_fetch_wait_percent": round(total_shuffle_fetch_wait_ms / (total_executor_run_time_ms or 1) * 100, 2),
+            "shuffle_write_time_percent": round(total_shuffle_write_time_ns / 1e6 / (total_executor_run_time_ms or 1) * 100, 2),
+            "gc_time_percent": round(total_gc_time_ms / (total_executor_run_time_ms or 1) * 100, 2),
             "tasks_analyzed": task_count,
             "tasks_with_input": tasks_with_input,
             "tasks_with_output": tasks_with_output,


### PR DESCRIPTION
## Changes

### IO-Aware Recommendations (built into cost and performance modes)
- Jobs with >50% shuffle fetch wait automatically get smaller workers with more disks
- IOPS-based disk calculation: uses effective throughput model to determine disk count
- Same total vCPU and per-task memory, just distributed across more independent disks
- Fleet-size-aware: >200 cost executors cap at 2x (Large→Medium), smaller fleets allow 4x (Large→Small)
- No separate flag needed — applied transparently to both `--output-cost` and `--output-perf`

### Shuffle IO Metrics (Extractor)
- Extracts shuffle fetch wait time, shuffle write time, GC time, executor run time from task metrics
- Computes `shuffle_fetch_wait_percent` to identify IO-bound jobs

### Removed
- `--output-io` flag removed — IO-aware configs are now built into cost and performance outputs

### README
- Rewritten with improved structure, key sizing decisions table, IO-aware scaling docs
- Reordered Quick Start: pure Python pipeline first
- Added Serverless Storage section explaining 20GB local disk risk
