### PR TITLE
Config Advisor: fix driver memory for 4vCPU workers

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -374,7 +374,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             elif partitions > 2000 or max_exec > 100 or shuffle_gb > 2000:
                 return 8, 54
             elif partitions > 500 or max_exec > 50 or shuffle_gb > 500:
-                return 4, 28
+                return 4, 27
             else:
                 return 4, 14
 


### PR DESCRIPTION
Fix driver memory from 28G to 27G for the 4 vCPU driver tier.

With the default `memoryOverheadFactor` of 0.1, 28G + 2.8G overhead = 30.8G which exceeds the EMR Serverless 30G limit for 4 vCPU workers, causing deployment failure.

27G × 1.1 = 29.7G — safely under the 30G limit.