### PR TITLE
Config Advisor: IO-bound perf mode keeps large workers with disk floor

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -550,18 +550,16 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             cost_recs[-1] = dict(io_rec)
             cost_recs[-1]["optimization_mode"] = "cost"
             # Perf mode: keep large workers if they already have enough disks.
-            # Otherwise, find the largest worker type that meets the disk target
-            # while preserving total core count.
+            # Otherwise, find the smallest worker type that meets the disk target
+            # while preserving total core count — smaller workers are cheaper.
             if max_exec_perf < io_max:
                 perf_orig_cores = max_exec_perf * worker_cfg["vcpu"]
-                # Try each size from Large down — pick the biggest that has enough disks
                 best = None
-                for try_type in ["Large", "Medium", "Small"]:
+                for try_type in ["Small", "Medium", "Large"]:
                     tr = WORKER_RANGES_IO[try_type]
                     need_exec = io_max  # must match cost disk count
                     total_cores = need_exec * tr["vcpu"]
                     if total_cores >= perf_orig_cores:
-                        # This size gives enough disks AND enough cores
                         per_task_mem = worker_cfg["memory"] / worker_cfg["vcpu"]
                         tmem = int(per_task_mem * tr["vcpu"])
                         tmem = max(tr["min_mem"], min(tr["max_mem"], tmem))

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -550,18 +550,9 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             # (the standard cost rec would just fail again)
             cost_recs[-1] = dict(io_rec)
             cost_recs[-1]["optimization_mode"] = "cost"
-            # Perf mode also needs enough disks — scale IO worker to perf executor count
-            perf_io_max = max_exec_perf * io_mult
-            perf_io_min = max(1, perf_io_max // 2)
-            perf_io_rec = dict(io_rec)
-            perf_io_rec["optimization_mode"] = "performance"
-            perf_io_rec["worker"] = dict(io_rec["worker"])
-            perf_io_rec["worker"]["max_executors"] = perf_io_max
-            perf_io_rec["worker"]["min_executors"] = perf_io_min
-            perf_io_rec["worker"]["total_vcpu_capacity"] = perf_io_max * io_r["vcpu"]
-            perf_io_rec["worker"]["total_memory_capacity"] = perf_io_max * io_mem
-            perf_io_rec["spark_configs"] = build_spark_cfg(perf_io_max, perf_io_min, sp_perf, io_disk, vcpu_override=io_r["vcpu"], mem_override=io_mem)
-            perf_recs[-1] = perf_io_rec
+            # Perf mode keeps original large workers — high executor count
+            # already provides enough disks, and larger workers give more
+            # vCPU per executor for faster task execution.
         # No IO rec for non-IO-bound jobs or already-Small workers
     
     # Process applications with no input data - recommend minimal config

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -378,13 +378,15 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             else:
                 return 4, 14
 
-        def build_spark_cfg(max_exec, min_exec, sp, executor_disk):
+        def build_spark_cfg(max_exec, min_exec, sp, executor_disk, vcpu_override=None, mem_override=None):
             d_cores, d_mem = _driver_sizing(sp, max_exec, s_in_gb + s_out_gb)
+            vcpu = vcpu_override or worker_cfg["vcpu"]
+            mem = mem_override or worker_cfg["memory"]
             cfg = {
                 "spark.driver.cores": str(d_cores),
                 "spark.driver.memory": f"{d_mem}G",
-                "spark.executor.cores": str(worker_cfg["vcpu"]),
-                "spark.executor.memory": f"{worker_cfg['memory']}g",
+                "spark.executor.cores": str(vcpu),
+                "spark.executor.memory": f"{mem}g",
                 "spark.dynamicAllocation.enabled": "true",
                 "spark.sql.adaptive.enabled": "true",
                 "spark.sql.files.maxPartitionBytes": _max_partition_bytes(i_in_gb),
@@ -558,7 +560,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             perf_io_rec["worker"]["min_executors"] = perf_io_min
             perf_io_rec["worker"]["total_vcpu_capacity"] = perf_io_max * io_r["vcpu"]
             perf_io_rec["worker"]["total_memory_capacity"] = perf_io_max * io_mem
-            perf_io_rec["spark_configs"] = build_spark_cfg(perf_io_max, perf_io_min, sp_perf, io_disk)
+            perf_io_rec["spark_configs"] = build_spark_cfg(perf_io_max, perf_io_min, sp_perf, io_disk, vcpu_override=io_r["vcpu"], mem_override=io_mem)
             perf_recs[-1] = perf_io_rec
         # No IO rec for non-IO-bound jobs or already-Small workers
     

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -547,12 +547,18 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             })
             worker_cfg, worker_type = saved_cfg, saved_type
             # For IO-bound jobs, the IO config IS the cost-efficient config
-            # (the standard cost rec would just fail again)
             cost_recs[-1] = dict(io_rec)
             cost_recs[-1]["optimization_mode"] = "cost"
-            # Perf mode keeps original large workers — high executor count
-            # already provides enough disks, and larger workers give more
-            # vCPU per executor for faster task execution.
+            # Perf mode keeps original large workers for more vCPU per executor,
+            # but must have at least as many disks (executors) as cost mode.
+            if max_exec_perf < io_max:
+                max_exec_perf = io_max
+                min_exec_perf = max(1, max_exec_perf // 2)
+                perf_recs[-1]["worker"]["max_executors"] = max_exec_perf
+                perf_recs[-1]["worker"]["min_executors"] = min_exec_perf
+                perf_recs[-1]["worker"]["total_vcpu_capacity"] = max_exec_perf * worker_cfg["vcpu"]
+                perf_recs[-1]["worker"]["total_memory_capacity"] = max_exec_perf * worker_cfg["memory"]
+                perf_recs[-1]["spark_configs"] = build_spark_cfg(max_exec_perf, min_exec_perf, sp_perf, executor_disk_perf)
         # No IO rec for non-IO-bound jobs or already-Small workers
     
     # Process applications with no input data - recommend minimal config

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -549,16 +549,46 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             # For IO-bound jobs, the IO config IS the cost-efficient config
             cost_recs[-1] = dict(io_rec)
             cost_recs[-1]["optimization_mode"] = "cost"
-            # Perf mode keeps original large workers for more vCPU per executor,
-            # but must have at least as many disks (executors) as cost mode.
+            # Perf mode: keep large workers if they already have enough disks.
+            # Otherwise, find the largest worker type that meets the disk target
+            # while preserving total core count.
             if max_exec_perf < io_max:
-                max_exec_perf = io_max
-                min_exec_perf = max(1, max_exec_perf // 2)
-                perf_recs[-1]["worker"]["max_executors"] = max_exec_perf
-                perf_recs[-1]["worker"]["min_executors"] = min_exec_perf
-                perf_recs[-1]["worker"]["total_vcpu_capacity"] = max_exec_perf * worker_cfg["vcpu"]
-                perf_recs[-1]["worker"]["total_memory_capacity"] = max_exec_perf * worker_cfg["memory"]
-                perf_recs[-1]["spark_configs"] = build_spark_cfg(max_exec_perf, min_exec_perf, sp_perf, executor_disk_perf)
+                perf_orig_cores = max_exec_perf * worker_cfg["vcpu"]
+                # Try each size from Large down — pick the biggest that has enough disks
+                best = None
+                for try_type in ["Large", "Medium", "Small"]:
+                    tr = WORKER_RANGES_IO[try_type]
+                    need_exec = io_max  # must match cost disk count
+                    total_cores = need_exec * tr["vcpu"]
+                    if total_cores >= perf_orig_cores:
+                        # This size gives enough disks AND enough cores
+                        per_task_mem = worker_cfg["memory"] / worker_cfg["vcpu"]
+                        tmem = int(per_task_mem * tr["vcpu"])
+                        tmem = max(tr["min_mem"], min(tr["max_mem"], tmem))
+                        tmem = tmem - (tmem - tr["min_mem"]) % tr["mem_step"] if tmem < tr["max_mem"] else tr["max_mem"]
+                        best = (try_type, tr, need_exec, tmem)
+                        break
+                if best:
+                    btype, br, bexec, bmem = best
+                    bmin = max(1, bexec // 2)
+                    perf_recs[-1]["worker"] = {
+                        "type": btype, "vcpu": br["vcpu"], "memory_gb": bmem,
+                        "max_executors": bexec, "min_executors": bmin,
+                        "total_vcpu_capacity": bexec * br["vcpu"],
+                        "total_memory_capacity": bexec * bmem,
+                    }
+                    perf_recs[-1]["spark_configs"] = build_spark_cfg(
+                        bexec, bmin, sp_perf, executor_disk_perf,
+                        vcpu_override=br["vcpu"], mem_override=bmem)
+                else:
+                    # Fallback: inflate original workers to match disk count
+                    max_exec_perf = io_max
+                    min_exec_perf = max(1, max_exec_perf // 2)
+                    perf_recs[-1]["worker"]["max_executors"] = max_exec_perf
+                    perf_recs[-1]["worker"]["min_executors"] = min_exec_perf
+                    perf_recs[-1]["worker"]["total_vcpu_capacity"] = max_exec_perf * worker_cfg["vcpu"]
+                    perf_recs[-1]["worker"]["total_memory_capacity"] = max_exec_perf * worker_cfg["memory"]
+                    perf_recs[-1]["spark_configs"] = build_spark_cfg(max_exec_perf, min_exec_perf, sp_perf, executor_disk_perf)
         # No IO rec for non-IO-bound jobs or already-Small workers
     
     # Process applications with no input data - recommend minimal config


### PR DESCRIPTION
## Changes

For IO-bound jobs (>50% shuffle fetch wait), perf mode no longer downsizes workers. Instead it:

1. Keeps the largest worker type that meets both the disk target and core count
2. Ensures perf has at least as many disks (executors) as cost mode
3. Tries smallest worker first (Small → Medium → Large) for cost efficiency when downsizing is needed to match disk count
4. Fixes a bug where perf IO rec spark configs used the original worker type instead of the IO worker type

**Rationale:** Cost mode downsizes to smaller workers to get more disks cheaply. Perf mode already has high executor counts providing enough disks — downsizing wastes vCPU per executor. When perf needs more disks to match cost, it picks the smallest worker type that still preserves the original core count.

## Example: shuffle-heavy data processing job (28 TB shuffle, 77% fetch wait)

| Mode | Before | After |
|---|---|---|
| Cost | Small 4c/27G ×776 (3,104 cores, 776 disks) | Same |
| Perf | Small 4c/27G ×2896 (11,584 cores, 2896 disks) | **Large 16c/108G ×776** (12,416 cores, 776 disks) |

Perf now gets 4× more compute per executor with the same disk count.