### PR TITLE
Add EMR Serverless Pricing Calculator

### DIFF
--- a/utilities/emr-serverless-pricing-calculator/README.md
+++ b/utilities/emr-serverless-pricing-calculator/README.md
@@ -1,0 +1,74 @@
+# EMR Serverless Pricing Calculator
+
+A simple command-line tool to estimate [Amazon EMR Serverless](https://aws.amazon.com/emr/serverless/) costs based on your vCPU, memory, and storage usage.
+
+## Features
+
+- Supports multiple AWS regions
+- Graviton and x86 architecture pricing
+- Optional service discount calculation
+- Detailed cost breakdown output
+
+## Usage
+
+```bash
+python3 emr-serverless-pricing-calculator.py
+```
+
+The script will prompt you for:
+
+1. **vCPU-hours** — total vCPU hours consumed
+2. **memoryGB-hours** — total memory GB hours consumed
+3. **storageGB-hours** — total storage GB hours consumed
+4. **Region** — AWS region (e.g., `us-east-1`)
+5. **Architecture** — `graviton` or `x86`
+6. **Discount %** — service discount percentage (enter `0` for none)
+
+## Example
+
+```
+==================================================
+  EMR Serverless Pricing Calculator
+==================================================
+
+Enter vCPU-hours: 2399.311
+Enter memoryGB-hours: 17994.833
+Enter storageGB-hours: 138542.617
+
+Available regions: us-east-1, us-east-2, us-west-1, us-west-2, eu-west-1, eu-central-1, ap-southeast-1, ap-northeast-1
+Enter region: us-east-1
+Architecture (graviton/x86): graviton
+
+              — Cost Breakdown —
+  Region: us-east-1 | Architecture: graviton
+  vCPU:     2399.311 hrs × $0.042094 = $    100.99
+  Memory:  17994.833 hrs × $0.004628 = $     83.28
+  Storage: 138542.617 hrs × $0.000111 = $     15.38
+  ------------------------------------------------
+  Total Estimated Cost: $199.65
+
+Service discount %? (0 for none): 28
+
+  Discount (28.0%): -$55.90
+  Final Cost After Discount: $143.75
+```
+
+## Supported Regions
+
+| Region | Graviton | x86 |
+|--------|----------|-----|
+| us-east-1 | ✅ | ✅ |
+| us-east-2 | ✅ | ✅ |
+| us-west-1 | ✅ | ✅ |
+| us-west-2 | ✅ | ✅ |
+| eu-west-1 | ✅ | ✅ |
+| eu-central-1 | ✅ | ✅ |
+| ap-southeast-1 | ✅ | ✅ |
+| ap-northeast-1 | ✅ | ✅ |
+
+> **Note:** Pricing is based on the [AWS EMR Pricing page](https://aws.amazon.com/emr/pricing/). Update the `PRICING` dictionary in the script to add more regions or reflect pricing changes.
+
+## Requirements
+
+- Python 3.6+
+- No external dependencies

--- a/utilities/emr-serverless-pricing-calculator/emr-serverless-pricing-calculator.py
+++ b/utilities/emr-serverless-pricing-calculator/emr-serverless-pricing-calculator.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""EMR Serverless Pricing Calculator"""
+
+# Pricing: {region: {arch: (vcpu, memory, storage)}}
+PRICING = {
+    "us-east-1":    {"graviton": (0.042094, 0.004628, 0.000111), "x86": (0.052624, 0.005786, 0.000111)},
+    "us-east-2":    {"graviton": (0.042094, 0.004628, 0.000111), "x86": (0.052624, 0.005786, 0.000111)},
+    "us-west-1":    {"graviton": (0.047494, 0.005222, 0.000111), "x86": (0.059374, 0.006530, 0.000111)},
+    "us-west-2":    {"graviton": (0.042094, 0.004628, 0.000111), "x86": (0.052624, 0.005786, 0.000111)},
+    "eu-west-1":    {"graviton": (0.046374, 0.005100, 0.000122), "x86": (0.057974, 0.006376, 0.000122)},
+    "eu-central-1": {"graviton": (0.049574, 0.005452, 0.000128), "x86": (0.061974, 0.006816, 0.000128)},
+    "ap-southeast-1": {"graviton": (0.047494, 0.005222, 0.000122), "x86": (0.059374, 0.006530, 0.000122)},
+    "ap-northeast-1": {"graviton": (0.052774, 0.005804, 0.000128), "x86": (0.065974, 0.007256, 0.000128)},
+}
+
+def main():
+    print("=" * 50)
+    print("  EMR Serverless Pricing Calculator")
+    print("=" * 50)
+
+    vcpu_hours = float(input("\nEnter vCPU-hours: "))
+    memory_hours = float(input("Enter memoryGB-hours: "))
+    storage_hours = float(input("Enter storageGB-hours: "))
+
+    print(f"\nAvailable regions: {', '.join(PRICING.keys())}")
+    region = input("Enter region: ").strip()
+    if region not in PRICING:
+        print(f"Error: Region '{region}' not found. Available: {', '.join(PRICING.keys())}")
+        return
+
+    arch = input("Architecture (graviton/x86): ").strip().lower()
+    if arch not in ("graviton", "x86"):
+        print("Error: Choose 'graviton' or 'x86'.")
+        return
+
+    vcpu_price, mem_price, stor_price = PRICING[region][arch]
+
+    vcpu_cost = round(vcpu_hours * vcpu_price, 2)
+    mem_cost = round(memory_hours * mem_price, 2)
+    stor_cost = round(storage_hours * stor_price, 2)
+    total = round(vcpu_cost + mem_cost + stor_cost, 2)
+
+    print(f"\n{'— Cost Breakdown —':^50}")
+    print(f"  Region: {region} | Architecture: {arch}")
+    print(f"  vCPU:    {vcpu_hours:>12.3f} hrs × ${vcpu_price:.6f} = ${vcpu_cost:>10.2f}")
+    print(f"  Memory:  {memory_hours:>12.3f} hrs × ${mem_price:.6f} = ${mem_cost:>10.2f}")
+    print(f"  Storage: {storage_hours:>12.3f} hrs × ${stor_price:.6f} = ${stor_cost:>10.2f}")
+    print(f"  {'':->48}")
+    print(f"  Total Estimated Cost: ${total:.2f}")
+
+    discount_input = input("\nService discount %? (0 for none): ").strip()
+    discount_pct = float(discount_input)
+
+    if discount_pct > 0:
+        discount_amt = round(total * discount_pct / 100, 2)
+        final = round(total - discount_amt, 2)
+        print(f"\n  Discount ({discount_pct}%): -${discount_amt:.2f}")
+        print(f"  Final Cost After Discount: ${final:.2f}")
+    else:
+        print(f"\n  Final Cost: ${total:.2f}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds a simple CLI tool to estimate Amazon EMR Serverless costs based on vCPU, memory, and storage usage.

## Features
- Supports multiple AWS regions (us-east-1, us-east-2, us-west-1, us-west-2, eu-west-1, eu-central-1, ap-southeast-1, ap-northeast-1)
- Graviton and x86 architecture pricing
- Optional service discount calculation
- Detailed cost breakdown output

## Files Added
- `utilities/emr-serverless-pricing-calculator/emr-serverless-pricing-calculator.py` — the calculator script
- `utilities/emr-serverless-pricing-calculator/README.md` — usage docs with examples

## Testing
- Verified script syntax and ran with sample inputs
- No external dependencies required (Python 3.6+)