### PR TITLE
fix: IO-based shuffle partition sizing for EMR Serverless

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -383,16 +383,17 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             return partitions, target_mib
 
         def cap_partitions(partitions, max_executors):
-            """Cap excessive partition counts to prevent N^2 shuffle
-            coordination overhead on Serverless.
-            Only triggers when partitions > 5000 AND P/E > 40.
-            Observed: 10006 parts / 156 exec (P/E=64) failed with 64% fetch wait;
-                      1304 parts / 124 exec (P/E=11) succeeded with 37% fetch wait.
-            Caps to P/E=24 (observed safe operating point)."""
-            if partitions > 6400 and max_executors > 0 and partitions / max_executors > 48:
-                partitions = max_executors * 24
-                if partitions % 2 != 0:
-                    partitions += 1
+            """Cap partitions based on executor IO concurrency, with a
+            data volume floor to prevent oversized partitions."""
+            io_ceiling = max(200, max_executors * 8)
+            # Data floor: ensure partitions don't exceed 3x memory per core
+            mem_per_core = worker_cfg["memory"] / worker_cfg["vcpu"]
+            max_gb_per_part = mem_per_core * 3
+            data_floor = max(2, int((s_in_gb + s_out_gb) / max_gb_per_part)) if max_gb_per_part > 0 else 200
+            # Apply: at least the data floor, at most the IO ceiling
+            partitions = max(data_floor, min(partitions, io_ceiling))
+            if partitions % 2 != 0:
+                partitions += 1
             return partitions
         
         # --- WindowGroupLimit skew detection ---


### PR DESCRIPTION
Replace the P/E > 48 partition cap with an IO concurrency model that balances two constraints:

1. IO ceiling (max_executors * 8): limits concurrent shuffle readers per executor to prevent disk throughput saturation and high fetch wait.

2. Data floor (shuffle_gb / (mem_per_core * 3)): ensures partitions don't exceed 3x memory-per-core, preventing excessive spill.

The partition count is: max(data_floor, min(shuffle_based, io_ceiling))

This replaces the previous fixed P/E threshold with a model derived from executor disk IO characteristics. The multiplier (8) can be adjusted if underlying storage throughput changes.

Evidence from shuffle-heavy workloads (4-5TB input, 20-25TB shuffle):
- P/E=8: completed in ~60 min, 0 failures, ~24% fetch wait
- P/E=16: completed in ~66 min, 0 failures, ~45% fetch wait
- P/E=24: failed at ~96 min, 76% fetch wait

Tested against 44 event logs: 0 regressions, 0 executor count changes.
Average partition reduction: 87% from baseline.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
