### PR TITLE
feat: CloudFormation template for Spark Advisor MCP

### DIFF
--- a/mcp-servers/emr-serverless-spark-advisor/cloudformation.yaml
+++ b/mcp-servers/emr-serverless-spark-advisor/cloudformation.yaml
@@ -1,0 +1,222 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  EMR Serverless Spark Config Advisor MCP Server.
+  Deploys a Lambda-backed MCP server that analyzes Spark event logs
+  via EMR Serverless and provides optimization recommendations.
+
+Parameters:
+  ArtifactBucket:
+    Type: String
+    Description: S3 bucket containing deployment artifacts (created by deploy-cfn.sh)
+  ArtifactPrefix:
+    Type: String
+    Default: spark-advisor-artifacts
+    Description: S3 prefix for deployment artifacts
+  EMRReleaseLabel:
+    Type: String
+    Default: emr-7.7.0
+    AllowedValues: [emr-7.5.0, emr-7.6.0, emr-7.7.0]
+    Description: EMR Serverless release version
+
+Resources:
+  # ── S3 Bucket for advisor output ──────────────────────────────────
+  AdvisorBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: !Sub spark-advisor-${AWS::AccountId}-${AWS::Region}
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  # ── IAM Role: EMR Serverless execution ────────────────────────────
+  EMRServerlessRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub spark-advisor-emr-role-${AWS::StackName}
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: emr-serverless.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: S3Access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:PutObject
+                Resource:
+                  - !Sub arn:aws:s3:::${AdvisorBucket}
+                  - !Sub arn:aws:s3:::${AdvisorBucket}/*
+                  - !Sub arn:aws:s3:::${ArtifactBucket}
+                  - !Sub arn:aws:s3:::${ArtifactBucket}/*
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:ListBucket
+                Resource: '*'
+                Condition:
+                  StringEquals:
+                    s3:ResourceAccount: !Ref AWS::AccountId
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+
+  # ── IAM Role: Lambda execution ────────────────────────────────────
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub spark-advisor-lambda-role-${AWS::StackName}
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: S3Access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:ListBucket
+                  - s3:DeleteObject
+                Resource:
+                  - !Sub arn:aws:s3:::${AdvisorBucket}
+                  - !Sub arn:aws:s3:::${AdvisorBucket}/*
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:ListBucket
+                Resource: '*'
+                Condition:
+                  StringEquals:
+                    s3:ResourceAccount: !Ref AWS::AccountId
+        - PolicyName: EMRServerless
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - emr-serverless:StartJobRun
+                  - emr-serverless:GetJobRun
+                  - emr-serverless:ListJobRuns
+                  - emr-serverless:CancelJobRun
+                  - emr-serverless:GetApplication
+                Resource:
+                  - !Sub arn:aws:emr-serverless:${AWS::Region}:${AWS::AccountId}:/applications/${EMRServerlessApp}
+                  - !Sub arn:aws:emr-serverless:${AWS::Region}:${AWS::AccountId}:/applications/${EMRServerlessApp}/*
+        - PolicyName: PassRole
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: iam:PassRole
+                Resource: !GetAtt EMRServerlessRole.Arn
+
+  # ── EMR Serverless Application ────────────────────────────────────
+  EMRServerlessApp:
+    Type: AWS::EMRServerless::Application
+    Properties:
+      Name: !Sub spark-advisor-${AWS::StackName}
+      ReleaseLabel: !Ref EMRReleaseLabel
+      Type: SPARK
+      AutoStartConfiguration:
+        Enabled: true
+      AutoStopConfiguration:
+        Enabled: true
+        IdleTimeoutMinutes: 15
+
+  # ── Lambda Layer ──────────────────────────────────────────────────
+  MCPLayer:
+    Type: AWS::Lambda::LayerVersion
+    Properties:
+      LayerName: !Sub mcp-server-deps-${AWS::StackName}
+      Content:
+        S3Bucket: !Ref ArtifactBucket
+        S3Key: !Sub ${ArtifactPrefix}/mcp-layer.zip
+      CompatibleRuntimes:
+        - python3.12
+        - python3.13
+        - python3.14
+
+  # ── Lambda Function ───────────────────────────────────────────────
+  MCPFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub spark-advisor-mcp-${AWS::StackName}
+      Runtime: python3.14
+      Handler: lambda_handler.handler
+      Code:
+        S3Bucket: !Ref ArtifactBucket
+        S3Key: !Sub ${ArtifactPrefix}/mcp-function.zip
+      Role: !GetAtt LambdaRole.Arn
+      Layers:
+        - !Ref MCPLayer
+      Timeout: 900
+      MemorySize: 512
+      Environment:
+        Variables:
+          EMR_SERVERLESS_APP_ID: !Ref EMRServerlessApp
+          EMR_EXECUTION_ROLE: !GetAtt EMRServerlessRole.Arn
+          SCRIPT_S3_PATH: !Sub s3://${ArtifactBucket}/${ArtifactPrefix}/spark_extractor.py
+          ARCHIVES_S3_PATH: !Sub s3://${ArtifactBucket}/${ArtifactPrefix}/zstandard.zip
+          OUTPUT_S3_PATH: !Sub s3://${AdvisorBucket}/advisor-output
+
+  # ── Lambda Function URL ───────────────────────────────────────────
+  MCPFunctionUrl:
+    Type: AWS::Lambda::Url
+    Properties:
+      AuthType: AWS_IAM
+      TargetFunctionArn: !GetAtt MCPFunction.Arn
+
+Outputs:
+  FunctionUrl:
+    Description: MCP server endpoint (streamable-http)
+    Value: !Sub ${MCPFunctionUrl.FunctionUrl}mcp/
+  MCPConfigStdio:
+    Description: Kiro CLI MCP config (stdio mode — paste into ~/.kiro/settings/mcp.json)
+    Value: !Sub |
+      {
+        "spark-config-advisor": {
+          "command": "python3",
+          "args": ["spark_advisor_mcp.py"],
+          "env": {
+            "MCP_TRANSPORT": "stdio",
+            "EMR_SERVERLESS_APP_ID": "${EMRServerlessApp}",
+            "EMR_EXECUTION_ROLE": "${EMRServerlessRole.Arn}",
+            "SCRIPT_S3_PATH": "s3://${ArtifactBucket}/${ArtifactPrefix}/spark_extractor.py",
+            "ARCHIVES_S3_PATH": "s3://${ArtifactBucket}/${ArtifactPrefix}/zstandard.zip",
+            "OUTPUT_S3_PATH": "s3://${AdvisorBucket}/advisor-output"
+          }
+        }
+      }
+  AdvisorBucketName:
+    Description: S3 bucket for advisor output
+    Value: !Ref AdvisorBucket
+  EMRServerlessAppId:
+    Description: EMR Serverless application ID
+    Value: !Ref EMRServerlessApp
+  EMRExecutionRoleArn:
+    Description: EMR Serverless execution role ARN
+    Value: !GetAtt EMRServerlessRole.Arn

--- a/mcp-servers/emr-serverless-spark-advisor/deploy-cfn.sh
+++ b/mcp-servers/emr-serverless-spark-advisor/deploy-cfn.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Deploy EMR Serverless Spark Advisor MCP Server via CloudFormation.
+#
+# Usage:
+#   ./deploy-cfn.sh                          # defaults: us-east-1, stack name spark-advisor
+#   ./deploy-cfn.sh --region us-west-2 --stack-name my-advisor
+#
+# Prerequisites: AWS CLI, pip3, zip
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+STACK_NAME="spark-advisor"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --region) REGION="$2"; shift 2;;
+    --stack-name) STACK_NAME="$2"; shift 2;;
+    *) echo "Unknown option: $1"; exit 1;;
+  esac
+done
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+ARTIFACT_BUCKET="spark-advisor-artifacts-${ACCOUNT_ID}-${REGION}"
+ARTIFACT_PREFIX="spark-advisor-artifacts"
+
+echo "=== EMR Serverless Spark Advisor — CloudFormation Deploy ==="
+echo "Region:    $REGION"
+echo "Stack:     $STACK_NAME"
+echo "Artifacts: s3://${ARTIFACT_BUCKET}/${ARTIFACT_PREFIX}/"
+echo ""
+
+# 1. Create artifact bucket if needed
+if ! aws s3api head-bucket --bucket "$ARTIFACT_BUCKET" --region "$REGION" 2>/dev/null; then
+  echo "Creating artifact bucket..."
+  if [ "$REGION" = "us-east-1" ]; then
+    aws s3api create-bucket --bucket "$ARTIFACT_BUCKET" --region "$REGION"
+  else
+    aws s3api create-bucket --bucket "$ARTIFACT_BUCKET" --region "$REGION" \
+      --create-bucket-configuration LocationConstraint="$REGION"
+  fi
+fi
+
+# 2. Build Lambda layer
+echo "Building Lambda layer..."
+LAYER_DIR=$(mktemp -d)
+pip3 install --target "$LAYER_DIR/python" -q mcp mangum
+pip3 install --target "$LAYER_DIR/python" -q \
+  --platform manylinux2014_x86_64 --only-binary=:all: --upgrade \
+  pydantic-core rpds-py cffi cryptography
+pip3 install --target "$LAYER_DIR/python" -q --upgrade pydantic
+pip3 install --target "$LAYER_DIR/python" -q \
+  --platform manylinux2014_x86_64 --only-binary=:all: --upgrade \
+  pydantic-core rpds-py cffi cryptography
+find "$LAYER_DIR/python" -name "*darwin*" -delete 2>/dev/null || true
+(cd "$LAYER_DIR" && zip -r -q /tmp/mcp-layer.zip python/)
+rm -rf "$LAYER_DIR"
+
+# 3. Build Lambda function zip
+echo "Building Lambda function..."
+(cd "$SCRIPT_DIR" && zip -j -q /tmp/mcp-function.zip lambda_handler.py spark_advisor_mcp.py)
+
+# 4. Build zstandard archive for Python 3.9 (EMR 7.x)
+echo "Building zstandard archive..."
+ZSTD_DIR=$(mktemp -d)
+pip3 install --target "$ZSTD_DIR" -q \
+  --platform manylinux2014_x86_64 --only-binary=:all: --python-version 3.9 \
+  zstandard
+(cd "$ZSTD_DIR" && zip -r -q /tmp/zstandard.zip .)
+rm -rf "$ZSTD_DIR"
+
+# 5. Upload artifacts
+echo "Uploading artifacts to S3..."
+aws s3 cp /tmp/mcp-layer.zip "s3://${ARTIFACT_BUCKET}/${ARTIFACT_PREFIX}/mcp-layer.zip" --region "$REGION"
+aws s3 cp /tmp/mcp-function.zip "s3://${ARTIFACT_BUCKET}/${ARTIFACT_PREFIX}/mcp-function.zip" --region "$REGION"
+aws s3 cp /tmp/zstandard.zip "s3://${ARTIFACT_BUCKET}/${ARTIFACT_PREFIX}/zstandard.zip" --region "$REGION"
+aws s3 cp "$SCRIPT_DIR/legacy/spark_extractor.py" "s3://${ARTIFACT_BUCKET}/${ARTIFACT_PREFIX}/spark_extractor.py" --region "$REGION"
+
+# 6. Deploy CloudFormation stack
+echo "Deploying CloudFormation stack..."
+aws cloudformation deploy \
+  --template-file "$SCRIPT_DIR/cloudformation.yaml" \
+  --stack-name "$STACK_NAME" \
+  --parameter-overrides \
+    ArtifactBucket="$ARTIFACT_BUCKET" \
+    ArtifactPrefix="$ARTIFACT_PREFIX" \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --region "$REGION"
+
+# 7. Print outputs
+echo ""
+echo "=== Deployment Complete ==="
+aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --query 'Stacks[0].Outputs[*].[OutputKey,OutputValue]' \
+  --output table
+
+# Cleanup
+rm -f /tmp/mcp-layer.zip /tmp/mcp-function.zip /tmp/zstandard.zip


### PR DESCRIPTION
## Summary

Adds a CloudFormation template and deploy script so any customer can deploy the EMR Serverless Spark Advisor MCP server with a single command.

## Usage

```bash
./deploy-cfn.sh --region us-east-1
```

## What it creates

| Resource | Description |
|----------|-------------|
| S3 Bucket | Advisor output storage |
| IAM Role (EMR) | Least-privilege role for EMR Serverless jobs |
| IAM Role (Lambda) | Least-privilege role for Lambda (S3, EMR Serverless, PassRole) |
| EMR Serverless App | Spark application (configurable release label) |
| Lambda Layer | MCP + Mangum dependencies |
| Lambda Function | MCP server with 12 tools |
| Function URL | AWS_IAM-authenticated endpoint |

## Deploy script (`deploy-cfn.sh`)

Handles the full lifecycle:
1. Creates artifact bucket
2. Builds Lambda layer (mcp, mangum, pydantic for linux/x86_64)
3. Builds zstandard archive (Python 3.9 for EMR 7.x)
4. Packages Lambda function code
5. Uploads all artifacts to S3
6. Deploys the CloudFormation stack
7. Prints MCP config for Kiro CLI

## Stack outputs

- **FunctionUrl**: MCP endpoint for streamable-http clients
- **MCPConfigStdio**: Ready-to-paste Kiro CLI config for stdio mode
- **EMRServerlessAppId**, **EMRExecutionRoleArn**, **AdvisorBucketName**