### PR TITLE
Fix failed_tasks count missing ExecutorLostFailure

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/python_extractor.py
+++ b/utilities/EMR-Serverless-Config-Advisor/python_extractor.py
@@ -462,9 +462,9 @@ def extract_task_summary(events):
 
             if reason == "Success":
                 task_stats["completed_tasks"] += 1
-            elif "Failed" in reason or "Exception" in reason:
+            elif "Failed" in reason or "Exception" in reason or "Failure" in reason:
                 task_stats["failed_tasks"] += 1
-            elif "Killed" in reason:
+            elif "Killed" in reason or "killed" in reason:
                 task_stats["killed_tasks"] += 1
 
     if task_stats["total_tasks"] > 0:


### PR DESCRIPTION
The task failure check only matched `Failed` and `Exception` in the Task End Reason, missing `Failure` (e.g. `ExecutorLostFailure`). This caused `failed_tasks` to report 0 when tasks failed due to executor loss.

Validated on 913MB v1 EC2 event log: now correctly reports 377 failed tasks (was 0), matching the spark_extractor output.