### PR TITLE
fix(config-advisor): revert to stable base + safe AQE and disk improvements

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -98,23 +98,6 @@ def _calculate_shuffle_ratio(input_gb, read_gb, write_gb) -> float:
     return round((read_gb + write_gb) / input_gb * 100.0, 2)
 
 
-def _parse_mem_to_mb(mem_str: str) -> int:
-    """Parse memory string like '20G' or '512m' to MB."""
-    if not mem_str:
-        return 0
-    mem_str = str(mem_str).strip().lower()
-    try:
-        if mem_str.endswith('g'):
-            return int(float(mem_str[:-1]) * 1024)
-        elif mem_str.endswith('m'):
-            return int(float(mem_str[:-1]))
-        elif mem_str.endswith('t'):
-            return int(float(mem_str[:-1]) * 1024 * 1024)
-        return int(mem_str)
-    except (ValueError, TypeError):
-        return 0
-
-
 def _select_worker_type(input_gb: float, shuffle_ratio: float,
                         mem_pct: float = 60.0, spill_gb: float = 0.0,
                         cpu_pct: float = 50.0, orig_mem_mb: int = 0,
@@ -163,11 +146,6 @@ def _select_worker_type(input_gb: float, shuffle_ratio: float,
         peak_per_core = max_peak_mem_gb / orig_cores
         mem_needed = int(peak_per_core * 1.5 * r["vcpu"])
         mem = max(r["min_mem"], min(r["max_mem"], mem_needed))
-    elif orig_mem_mb > 0 and orig_cores > 0:
-        # Scale original memory per core to new worker size, with 30% headroom for OOM safety
-        orig_mem_per_core = orig_mem_mb / 1024 / orig_cores
-        mem_needed = int(orig_mem_per_core * 1.3 * r["vcpu"])
-        mem = max(r["min_mem"], min(r["max_mem"], mem_needed))
     elif spill_gb > 0:
         mem = r["max_mem"]
     else:
@@ -210,14 +188,14 @@ def _compute_exec_limits(input_gb: float, vcpu: int, partitions: int = 0,
     # Uses actual observed task execution time to determine how many cores
     # are needed, independent of the original cluster size.
     if total_task_exec_hours > 0 and duration_hours > 0:
-        # Effective cores = actual parallelism used by the job
-        effective_cores = total_task_exec_hours / duration_hours
         if mode == "cost":
-            # Match source throughput with 1.2x scheduling headroom
-            cores_needed = effective_cores * 1.2
+            # Allow 3x original duration — trade time for fewer executors
+            target_hours = duration_hours * 3
         else:
-            # Performance: 1.8x for faster completion
-            cores_needed = effective_cores * 1.8
+            # Match original duration
+            target_hours = duration_hours
+
+        cores_needed = total_task_exec_hours / target_hours
         work_exec = max(2, int(cores_needed / vcpu))
 
         # Efficiency discount: when idle% is very high, the original run was
@@ -228,12 +206,6 @@ def _compute_exec_limits(input_gb: float, vcpu: int, partitions: int = 0,
             work_exec = max(2, int(work_exec * efficiency))
 
         max_exec = max(max_exec, work_exec)
-
-    # --- Starvation floor (for compute-starved jobs) ---
-    if cpu_pct > 85 and idle_pct < 15 and total_task_exec_hours > 0 and duration_hours > 0:
-        starved_cores = (total_task_exec_hours / duration_hours) * 1.5
-        starved_exec = max(2, int(starved_cores / vcpu))
-        max_exec = max(max_exec, starved_exec)
 
     # --- Fallback: original-run floor (only when task data is missing) ---
     elif orig_executors > 0 and orig_cores > 0:
@@ -282,18 +254,6 @@ def _compute_exec_limits(input_gb: float, vcpu: int, partitions: int = 0,
         max_exec = max(max_exec, starved_exec)
 
     min_exec = max(1, max_exec // 2)
-
-    # Cost mode guard: don't recommend more total vCPU-hours than original
-    if mode == "cost" and orig_executors > 0 and orig_cores > 0 and duration_hours > 0:
-        orig_vcpu_hours = orig_executors * orig_cores * duration_hours
-        # Estimate new vCPU-hours: more executors with larger cores running ~2x longer
-        est_duration = total_task_exec_hours / (max_exec * vcpu) if max_exec * vcpu > 0 else duration_hours
-        est_vcpu_hours = max_exec * vcpu * est_duration
-        if est_vcpu_hours > orig_vcpu_hours * 1.1:
-            # Scale down executors to match original vCPU budget
-            budget_exec = max(2, int(orig_vcpu_hours / (vcpu * est_duration)))
-            max_exec = min(max_exec, budget_exec)
-            min_exec = max(1, max_exec // 2)
 
     return max_exec, min_exec
 
@@ -588,7 +548,8 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
         )
         sp_cost = cap_partitions(sp_cost, max_exec_cost)
         # Ignore EC2 spill for disk when target executor has more memory
-        _actual_mem = orig_executor_mem_gb * mem_pct / 100 if orig_executor_mem_gb > 0 and mem_pct > 0 else 999
+        _orig_mem_gb = float(''.join(c for c in str(row.get('_spark_config_raw', {}).get('spark.executor.memory', '0g')).lower().replace('g','') if c.isdigit() or c == '.') or 0)
+        _actual_mem = _orig_mem_gb * mem_pct / 100 if _orig_mem_gb > 0 and mem_pct > 0 else 999
         _eff_disk_spill = 0 if _actual_mem < worker_cfg["memory"] * 0.8 else disk_spill_gb
         _eff_mem_spill = 0 if _actual_mem < worker_cfg["memory"] * 0.8 else spill_gb
         executor_disk_cost = _calculate_executor_disk(s_out_gb, _eff_disk_spill, _eff_mem_spill, max_exec_cost)
@@ -730,10 +691,6 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             cfg.update(_get_timeout_configs(i_in_gb, duration))
             cfg.update(_get_s3_retry_configs(i_in_gb, i_out_gb))
             cfg.update(_get_iceberg_configs())
-            # Only use shuffle_optimized disk when there's spill or heavy shuffle per executor
-            shuffle_per_exec = s_out_gb / max(max_exec, 1)
-            if disk_spill_gb > 0 or spill_gb > 0 or shuffle_per_exec > 50:
-                cfg["spark.emr-serverless.executor.disk.type"] = "shuffle_optimized"
             if sh_ratio > 30:
                 cfg.update({"spark.shuffle.compress": "true", "spark.shuffle.spill.compress": "true"})
             # Serverless storage: only when explicitly enabled and disk pressure is safe


### PR DESCRIPTION
Reverts broken worker selection/executor sizing from PRs #130-132. Keeps only safe improvements that produced cost savings in Batch 3.

## What this reverts
- Broken worker selection (caused OOM on supply-lodging, 2x cost on search-health-search)
- 1.2x executor sizing (caused over/under provisioning)
- Partition-based executor removal

## What this keeps (safe improvements)
1. **advisoryPartitionSizeInBytes preservation** — lets AQE optimize partitions per stage
2. **Remove explicit partitions when advisory is set** — AQE handles it better
3. **Disk fix** — ignore EC2 spill when Serverless has more memory per executor

## Expected results
- Regressed jobs (lodging-sort, search-health-search, supply-lodging) return to Batch 1 behavior
- Improved jobs keep their gains from AQE/disk fixes