### PR TITLE
fix(config-advisor): 8c workers, explicit partitions, skew handling, maxPartitionBytes

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -208,6 +208,9 @@ def _compute_exec_limits(input_gb: float, vcpu: int, partitions: int = 0,
             mult = max(0.5, 1.8 - eff * 3)
             io_boost = input_gb / 5 if shuf_ratio < 1 else 0
             cores = work * mult + io_boost + 30
+            # Sub-rule: high spill needs more parallelism for I/O throughput
+            if spill_gb > 5000:
+                cores = cores * 1.3
         else:
             cores = base_cores
     else:
@@ -553,8 +556,10 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
         sp_cost = cap_partitions(sp_cost, max_exec_cost)
 
         # Bump up worker size if too many executors (shuffle coordination overhead)
+        # Exception: if EC2 source used small executors (≤4 cores), the workload fits in Small
         # Always go Small→Medium→Large (never skip Medium)
-        if is_ec2 and max_exec_cost > 50 and worker_type == "Small":
+        _is_rule2_spill = is_ec2 and orig_executors > 150 and sh_ratio < 800 and spill_gb > 5000
+        if is_ec2 and max_exec_cost > 60 and worker_type == "Small" and not _is_rule2_spill:
             worker_type = "Medium"
             worker_cfg = {"vcpu": 8, "memory": 54}
             max_exec_cost = max(2, max_exec_cost * 4 // 8)  # preserve total cores
@@ -567,7 +572,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
 
         # Stage-level efficiency: no single stage should take > 60min
         # Uses total_task_time_sec (sum of all task exec times) as total work
-        # Apply 0.7x factor for I/O-bound stages (Serverless NVMe is faster than EC2)
+        # Apply 0.85x factor for I/O-bound stages (Serverless NVMe is faster than EC2)
         if is_ec2 and stages_raw:
             max_stage = max(stages_raw, key=lambda s: s.get('total_task_time_sec', 0) or 0)
             max_stage_work = max_stage.get('total_task_time_sec', 0) or 0


### PR DESCRIPTION
## Changes

- **Default 8c/54G workers**: Higher disk throughput (250 MiB/s vs 120 MiB/s on 4c). Custom uses 8c for most jobs.
- **Always set explicit partitions**: Avoids EMR initialPartitionNum=1000 cap. Spill-heavy (ratio>0.5): 1GB/partition. No-spill: 3GB/partition. Floor at 8 waves for parallelism.
- **Skew join threshold**: Set based on advisory size (advisory+10MB for large, advisory/2 for small). Enables AQE skew splitting.
- **rebalancePartitionsSmallPartitionFactor=0.5**: For jobs with large advisory (>=500MB).
- **maxPartitionBytes aligned with advisory**: 512m for advisory>=500MB, 128m otherwise. Falls back to input-size based when no advisory.
- **Stage-level efficiency**: No stage >60min (cost) / 30min (perf) using total_task_time_sec.
- **Rule 2 spill sub-rule**: 1.3x boost for over-provisioned clusters with high spill.
- **Disk min 200G**: Reverted from 500G (confirmed no throughput difference in 170-999GB tier).

## Rationale
- 8c workers: Fargate limits 4c to 120 MiB/s disk throughput vs 250 MiB/s for 8c
- Explicit partitions: B8 showed all jobs relying on AQE were 24-75% slower due to EMR 1000 cap
- Skew threshold: Custom uses it for all jobs with advisory. Enables partition splitting that gave Custom 1038 effective partitions vs our 1000
- maxPartitionBytes: Should align with advisory for consistent partition sizing through the pipeline