### PR TITLE
fix: default autoBroadcastJoinThreshold to 30MB for Medium/Large

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -826,18 +826,12 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             # A stage that reads shuffle, writes nothing (collect to driver),
             # and failed with maxResultSize indicates a broadcast join collecting
             # too much data through the driver. Recommend disabling auto-broadcast.
-            # Broadcast: preserve source value. Only disable if maxResultSize failure detected.
-            # When not set, use 256MB (Spark default 10MB is too conservative for 54G executors).
+            # Broadcast: set default 30MB for Medium/Large workers (sufficient for dimension tables
+            # without risking OOM from large broadcasts). Don't inherit source value.
             if _should_disable_broadcast(stages_raw, _spark_config_raw, s_out_gb, d_mem):
                 cfg["spark.sql.autoBroadcastJoinThreshold"] = "-1"
-            else:
-                src_val = _spark_config_raw.get('spark.sql.autoBroadcastJoinThreshold')
-                if src_val and str(src_val) not in ('', 'None'):
-                    cfg["spark.sql.autoBroadcastJoinThreshold"] = str(src_val)
-                elif is_ec2:
-                    # Don't override broadcast threshold — aggressive values can change
-                    # query plans and cause OOM from broadcast table memory pressure
-                    pass
+            elif worker_type in ("Medium", "Large"):
+                cfg["spark.sql.autoBroadcastJoinThreshold"] = "30m"
             # Advisory partition size: better than explicit shuffle.partitions (adaptive to data)
             # Skip for very large input (>3000GB) — spill is from volume, not skew
             # Skip AQE overrides for 16c workers — B1 proved simple partitioning works best


### PR DESCRIPTION
## Problem

The recommender inherited `spark.sql.autoBroadcastJoinThreshold` from the source EC2 config. EC2 clusters with large executor memory (63-108g) often set aggressive broadcast thresholds (512MB-1GB+) which can cause OOM on Serverless when multiple broadcast tables are held concurrently.

## Fix

Set a safe default of `30MB` for Medium (8c/54g) and Large (16c/108g) workers. Don't inherit source value.

- 30MB is sufficient for typical dimension table joins
- Avoids memory pressure from large concurrent broadcasts
- Broadcast disabled (`-1`) when maxResultSize failures detected
- 200m override preserved for large-input/low-shuffle/no-spill pattern

## Impact

All Medium/Large worker recommendations will now have a predictable, safe broadcast threshold instead of unpredictable inherited values.