### PR TITLE
fix(config-advisor): proactive InferWindowGroupLimit exclusion for EC2→Serverless migrations

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -1094,6 +1094,38 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             },
         })
         
+        # EC2 → Serverless: proactively exclude InferWindowGroupLimit.
+        # The Spark 3.5.5+ codegen regression (broken WindowGroupLimit codegen
+        # → interpreted fallback, 10-50x slower window stages) CANNOT be
+        # detected from an EC2 source log — the source ran a Spark version
+        # where the rule doesn't exist or isn't broken. Skew-based detection
+        # only works for Serverless-source logs. Window functions are
+        # identified from window-shaped stage signatures (few-task stages
+        # with high skew are unreliable on EC2 logs, so gate only on source
+        # platform: the exclusion is a no-op on queries without window
+        # functions and removes a known crash-adjacent regression otherwise).
+        _wgl_rule = 'org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit'
+        if is_ec2 and not (window_skew_findings or window_coalesce_regression):
+            for _rec in (cost_rec, perf_rec):
+                _existing = _rec['spark_configs'].get('spark.sql.optimizer.excludedRules', '')
+                if _wgl_rule not in _existing:
+                    _rec['spark_configs']['spark.sql.optimizer.excludedRules'] = (
+                        f'{_existing},{_wgl_rule}' if _existing else _wgl_rule)
+            _wgl_note = {
+                'type': 'window_group_limit_proactive',
+                'severity': 'MEDIUM',
+                'message': ('EC2 source: InferWindowGroupLimit excluded proactively. '
+                            'EMR Serverless Spark 3.5.5+ has a codegen regression in '
+                            'WindowGroupLimitExec (interpreted fallback, 10-50x slower '
+                            'window stages). The source event log cannot exhibit this '
+                            'bug, so it is excluded preventively; no-op without window '
+                            'functions.'),
+                'recommendation': f'spark.sql.optimizer.excludedRules={_wgl_rule}',
+                'affected_stages': [],
+            }
+            cost_rec.setdefault('bottleneck_warnings', []).append(_wgl_note)
+            perf_rec.setdefault('bottleneck_warnings', []).append(_wgl_note)
+
         # Inject WindowGroupLimit recommendation if detected
         if window_skew_findings or window_coalesce_regression:
             excluded_rule = 'org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit'

--- a/utilities/EMR-Serverless-Config-Advisor/tests/golden_baseline.json
+++ b/utilities/EMR-Serverless-Config-Advisor/tests/golden_baseline.json
@@ -1,5 +1,16 @@
 {
- "history": [],
+ "history": [
+  {
+   "changed_lines": 4,
+   "changes": [
+    "ump/application_1780882631787_0001 [cost] spark_configs.spark.sql.optimizer.excludedRules: golden=None current='org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit'",
+    "ump/application_1780882631787_0001 [performance] spark_configs.spark.sql.optimizer.excludedRules: golden=None current='org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit'",
+    "ump/application_1780907816475_0003 [cost] spark_configs.spark.sql.optimizer.excludedRules: golden=None current='org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit'",
+    "ump/application_1780907816475_0003 [performance] spark_configs.spark.sql.optimizer.excludedRules: golden=None current='org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit'"
+   ],
+   "reason": "Proactive InferWindowGroupLimit exclusion for EC2->Serverless: source logs cannot exhibit the Spark 3.5.5+ codegen regression (source ran older Spark), so skew-based detection never fires on migrations; exclusion is a no-op without window functions"
+  }
+ ],
  "snapshot": {
   "b12": {
    "eventlog_v2_00g5r690ovjblo0b": {
@@ -326,6 +337,7 @@
      "spark_configs.spark.dynamicAllocation.minExecutors": "23",
      "spark_configs.spark.emr-serverless.executor.disk": "200G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
+     "spark_configs.spark.sql.optimizer.excludedRules": "org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit",
      "spark_configs.spark.sql.shuffle.partitions": "1000",
      "worker.max_executors": 71,
      "worker.memory_gb": 54,
@@ -338,6 +350,7 @@
      "spark_configs.spark.dynamicAllocation.minExecutors": "44",
      "spark_configs.spark.emr-serverless.executor.disk": "200G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
+     "spark_configs.spark.sql.optimizer.excludedRules": "org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit",
      "spark_configs.spark.sql.shuffle.partitions": "1000",
      "worker.max_executors": 134,
      "worker.memory_gb": 54,
@@ -352,6 +365,7 @@
      "spark_configs.spark.dynamicAllocation.minExecutors": "25",
      "spark_configs.spark.emr-serverless.executor.disk": "360G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
+     "spark_configs.spark.sql.optimizer.excludedRules": "org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit",
      "spark_configs.spark.sql.shuffle.partitions": "1852",
      "worker.max_executors": 76,
      "worker.memory_gb": 108,
@@ -364,6 +378,7 @@
      "spark_configs.spark.dynamicAllocation.minExecutors": "102",
      "spark_configs.spark.emr-serverless.executor.disk": "200G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
+     "spark_configs.spark.sql.optimizer.excludedRules": "org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit",
      "spark_configs.spark.sql.shuffle.partitions": "1852",
      "worker.max_executors": 306,
      "worker.memory_gb": 108,


### PR DESCRIPTION
## Problem

The EMR Serverless Spark 3.5.5+ codegen regression in `WindowGroupLimitExec` (broken codegen → interpreted fallback, 10-50× slower window stages) is **undetectable from EC2 source event logs** — the source ran a Spark version where `InferWindowGroupLimit` doesn't exist or isn't broken, so the recommender's skew-based detector never fires on exactly the path that needs it. Validated in production: a migrated job hit the regression on its first Serverless run (two window stages = 66% of job time) while the EC2 source log showed nothing.

## Change

Emit `spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit` proactively on **all EC2-source recommendations** (cost + perf), with a MEDIUM bottleneck warning documenting why. No-op for queries without window functions. Serverless-source paths unchanged — observed-skew detection still governs those.

## Validation

- Golden regression suite: 4 contract diffs, all confined to the two EC2-source fixtures (both modes); all 17 other fixture apps byte-identical. Baseline regenerated with reason recorded in its history.
- A/B perf benchmark on window-function TPC-DS queries (exclusion vs. not, EMR Serverless 3.5.6) in progress; results will be posted on this PR.

Stacked on #164.