### PR TITLE
fix(config-advisor): use max memory for EC2→Serverless migrations

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -182,21 +182,24 @@ def _select_worker_type(input_gb: float, shuffle_ratio: float,
 
     r = WORKER_RANGES[size]
 
-    # Memory right-sizing: use observed peak memory to pick appropriate memory level
-    # instead of always maxing out (which over-provisions and slows worker allocation)
-    if size == "Small":
-        # For Small workers: right-size based on observed peak memory
-        # 2x headroom for stability (prevents OOM under data growth)
+    # Memory right-sizing: only for Serverless-source jobs where peak memory
+    # was measured under the same hard cgroup enforcement.
+    # EC2-source jobs always get max memory because:
+    #   - YARN enforcement is soft (poll-based, executor leaks past container)
+    #   - EC2 peak metrics undercount actual Serverless memory needs
+    #   - First migration must succeed; right-size on the second run
+    if is_ec2:
+        mem = r["max_mem"]
+    elif size == "Small":
         if max_peak_mem_gb > 0 and peak_mem_pct > 0:
-            needed_mem = max_peak_mem_gb * 2.0  # 2x headroom for OOM safety
-            needed_mem = max(needed_mem, 8)  # minimum 8g
+            needed_mem = max_peak_mem_gb * 2.0
+            needed_mem = max(needed_mem, 8)
             mem = min(r["max_mem"], max(r["min_mem"], int(needed_mem + 0.99)))
         elif mem_pct > 0 and orig_mem_mb > 0:
             used_gb = (orig_mem_mb / 1024) * (mem_pct / 100)
             needed_mem = used_gb * 2.0
             mem = min(r["max_mem"], max(r["min_mem"], int(needed_mem + 0.99)))
         else:
-            # No data — use max (safe default)
             mem = r["max_mem"]
     elif size == "Medium":
         if max_peak_mem_gb > 0:


### PR DESCRIPTION
## Summary

- EC2→Serverless migrations now always use max memory for their worker tier (27G for Small, 54G for Medium, 108G for Large)
- Memory right-sizing (2x observed peak) is preserved for Serverless-source jobs only
- Fixes OOM failures where EC2 peak metrics undercount actual Serverless memory needs due to soft YARN enforcement vs hard cgroup limits

## Root Cause

A validated failure showed a job OOM'ing on Serverless with 8G executor memory (2x the 3.49G EC2 peak). The job died before the main stage even started — the 10% overhead budget (800M) is insufficient for the Serverless platform baseline (JVM metaspace, S3 SDK, EMRFS, Netty buffers).

On EC2, YARN enforcement is poll-based and executors leak past their container into node OS memory. On Serverless, cgroup limits are hard — immediate kill on first byte over.

## Changes

- `_select_worker_type()`: EC2-source jobs skip memory right-sizing, always use `max_mem` for the worker tier
- Serverless-source right-sizing logic unchanged (2x peak with min 8G)

## Test plan

- [x] Golden regression: PASS (18 apps, 2 fixture sets, zero golden changes)
- [x] Verified recommender output for the failing job: Small 4c/27G (was 4c/8G)
- [ ] Re-run the failed job with new config to confirm success