### PR TITLE
feat(config-advisor): add opt-in AI/ML feedback layer

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/backlog-pipeline/07_benchmark_runner.py
+++ b/utilities/EMR-Serverless-Config-Advisor/backlog-pipeline/07_benchmark_runner.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+Benchmark Runner — submits workloads with recommended configs and captures results.
+
+Runs each registered workload with both cost and perf configs, waits for completion,
+then extracts the resulting event log into the feedback pipeline.
+
+Usage:
+  python3 07_benchmark_runner.py \
+    --application-id APP_ID \
+    --execution-role ROLE_ARN \
+    --config-table glue_catalog.db.serverless_config_advisor_v2 \
+    --output-prefix s3://bucket/config-advisor/benchmark-results/ \
+    --workloads search-health,sup-trvlr-bml,vrbo-new-property
+"""
+import argparse
+import json
+import time
+import logging
+import sys
+
+logging.basicConfig(
+    format="%(asctime)s UTC %(levelname)-5s [%(name)s]  %(message)s",
+    level=logging.INFO,
+)
+log = logging.getLogger("benchmark-runner")
+
+try:
+    import boto3
+except ImportError:
+    log.error("boto3 required")
+    sys.exit(1)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# USER CONFIGURATION
+# ──────────────────────────────────────────────────────────────────────────────
+
+REGION = "us-east-1"
+POLL_INTERVAL_SEC = 60
+MAX_WAIT_MIN = 360
+
+# Workload registry: each entry defines the query script and data path.
+# The recommended config is pulled from the Iceberg recommendations table.
+WORKLOAD_REGISTRY = {
+    "search-health": {
+        "script": "s3://BUCKET/synthetic/regression-suite/search-health/scripts/query.py",
+        "data": "s3://BUCKET/synthetic/regression-suite/search-health/data/",
+        "output": "s3://BUCKET/config-advisor/benchmark-results/search-health/",
+    },
+    "sup-trvlr-bml": {
+        "script": "s3://BUCKET/synthetic/regression-suite/sup_trvlr_bml/scripts/query.py",
+        "data": "s3://BUCKET/synthetic/regression-suite/sup_trvlr_bml/data-fullscale/",
+        "output": "s3://BUCKET/config-advisor/benchmark-results/sup-trvlr-bml/",
+    },
+    "vrbo-new-property": {
+        "script": "s3://BUCKET/synthetic/regression-suite/vrbo_new_property/scripts/query.py",
+        "data": "s3://BUCKET/synthetic/regression-suite/vrbo_new_property/data-fullscale/",
+        "output": "s3://BUCKET/config-advisor/benchmark-results/vrbo-new-property/",
+    },
+    "lodging-sort-be": {
+        "script": "s3://BUCKET/synthetic/regression-suite/lodging_sort_be/scripts/query.py",
+        "data": "s3://BUCKET/synthetic/regression-suite/lodging_sort_be/data-fullscale/",
+        "output": "s3://BUCKET/config-advisor/benchmark-results/lodging-sort-be/",
+    },
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _build_spark_submit_params(config: dict) -> str:
+    """Convert a spark_configs dict into a sparkSubmitParameters string."""
+    params = ""
+    for key, value in config.items():
+        if value and key.startswith("spark."):
+            params += f" --conf {key}={value}"
+    return params.strip()
+
+
+def _submit_job(emr_client, app_id, role_arn, workload_name, mode, script_path,
+                data_path, output_path, spark_configs):
+    """Submit a single benchmark job."""
+    run_id = f"{workload_name}-{mode}-{int(time.time())}"
+    spark_params = _build_spark_submit_params(spark_configs)
+
+    resp = emr_client.start_job_run(
+        applicationId=app_id,
+        executionRoleArn=role_arn,
+        name=f"bench-{run_id}",
+        jobDriver={
+            "sparkSubmit": {
+                "entryPoint": script_path,
+                "entryPointArguments": [
+                    "--input", data_path,
+                    "--output", f"{output_path}{run_id}/",
+                ],
+                "sparkSubmitParameters": spark_params,
+            }
+        },
+        configurationOverrides={
+            "monitoringConfiguration": {
+                "s3MonitoringConfiguration": {
+                    "logUri": f"{output_path}logs/{run_id}/"
+                },
+                "managedPersistenceMonitoringConfiguration": {"enabled": True},
+            }
+        },
+    )
+    job_run_id = resp["jobRunId"]
+    log.info("Submitted %s: %s", run_id, job_run_id)
+    return job_run_id, run_id
+
+
+def _wait_for_jobs(emr_client, app_id, jobs: dict) -> dict:
+    """Poll until all jobs complete. Returns {job_run_id: final_state}."""
+    pending = set(jobs.keys())
+    results = {}
+    elapsed_min = 0
+
+    while pending and elapsed_min < MAX_WAIT_MIN:
+        time.sleep(POLL_INTERVAL_SEC)
+        elapsed_min += POLL_INTERVAL_SEC / 60
+
+        for jid in list(pending):
+            resp = emr_client.get_job_run(applicationId=app_id, jobRunId=jid)
+            state = resp["jobRun"]["state"]
+            if state in ("SUCCESS", "FAILED", "CANCELLED"):
+                results[jid] = {
+                    "state": state,
+                    "name": jobs[jid],
+                    "duration_sec": (
+                        resp["jobRun"].get("totalExecutionDurationSeconds", 0)
+                    ),
+                    "created": str(resp["jobRun"].get("createdAt", "")),
+                }
+                pending.discard(jid)
+                log.info("  %s → %s (%.1f min)", jobs[jid], state,
+                         results[jid]["duration_sec"] / 60)
+
+    for jid in pending:
+        results[jid] = {"state": "TIMEOUT", "name": jobs[jid]}
+        log.warning("  %s TIMED OUT after %d min", jobs[jid], MAX_WAIT_MIN)
+
+    return results
+
+
+def _load_recommendation(s3_client, config_table, workload_name, mode):
+    """Load the latest recommendation for a workload from the Iceberg table.
+    Falls back to reading a JSON file from S3 if Iceberg query is not available.
+    """
+    # For now, load from S3 JSON (pipeline writes recs as JSON alongside Iceberg)
+    # TODO: Query Iceberg table directly via Spark/Athena
+    log.info("Loading %s recommendation for %s (from config table: %s)",
+             mode, workload_name, config_table)
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run benchmark workloads with recommended configs")
+    parser.add_argument("--application-id", required=True, help="EMR Serverless application ID")
+    parser.add_argument("--execution-role", required=True, help="IAM execution role ARN")
+    parser.add_argument("--config-table", default="glue_catalog.data_processing.serverless_config_advisor_v2")
+    parser.add_argument("--output-prefix", required=True, help="S3 prefix for benchmark results")
+    parser.add_argument("--workloads", required=True, help="Comma-separated workload names")
+    parser.add_argument("--modes", default="cost,performance", help="Comma-separated optimization modes")
+    parser.add_argument("--rec-file", help="Path to recommendations JSON (overrides table lookup)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    emr = boto3.client("emr-serverless", region_name=REGION)
+    s3 = boto3.client("s3", region_name=REGION)
+
+    workloads = [w.strip() for w in args.workloads.split(",")]
+    modes = [m.strip() for m in args.modes.split(",")]
+
+    # Load recommendations
+    recs_by_workload = {}
+    if args.rec_file:
+        with open(args.rec_file) as f:
+            all_recs = json.load(f)
+        for rec in all_recs:
+            name = rec.get("application_name", "").lower().replace(" ", "-")
+            recs_by_workload[name] = rec.get("spark_configs", {})
+
+    # Submit jobs
+    jobs = {}
+    for workload_name in workloads:
+        if workload_name not in WORKLOAD_REGISTRY:
+            log.warning("Unknown workload: %s (skipping)", workload_name)
+            continue
+
+        wl = WORKLOAD_REGISTRY[workload_name]
+        for mode in modes:
+            spark_configs = recs_by_workload.get(workload_name, {})
+            if not spark_configs:
+                spark_configs = _load_recommendation(s3, args.config_table, workload_name, mode)
+                if not spark_configs:
+                    log.warning("No recommendation found for %s/%s — using defaults", workload_name, mode)
+                    spark_configs = {
+                        "spark.executor.cores": "8",
+                        "spark.executor.memory": "54g",
+                        "spark.dynamicAllocation.maxExecutors": "50",
+                        "spark.sql.shuffle.partitions": "1000",
+                        "spark.sql.adaptive.enabled": "true",
+                    }
+
+            if args.dry_run:
+                log.info("[DRY-RUN] Would submit %s/%s with config: %s",
+                         workload_name, mode, json.dumps(spark_configs, indent=2))
+                continue
+
+            jid, run_name = _submit_job(
+                emr, args.application_id, args.execution_role,
+                workload_name, mode, wl["script"], wl["data"], wl["output"],
+                spark_configs,
+            )
+            jobs[jid] = run_name
+
+    if args.dry_run or not jobs:
+        return
+
+    # Wait for all jobs
+    log.info("Waiting for %d benchmark jobs...", len(jobs))
+    results = _wait_for_jobs(emr, args.application_id, jobs)
+
+    # Write summary
+    summary = {
+        "run_timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "application_id": args.application_id,
+        "results": results,
+    }
+    summary_path = f"{args.output_prefix.rstrip('/')}/run-summary-{int(time.time())}.json"
+    bucket, key = summary_path.replace("s3://", "").split("/", 1)
+    s3.put_object(Bucket=bucket, Key=key, Body=json.dumps(summary, indent=2, default=str))
+    log.info("Summary written to %s", summary_path)
+
+    # Report
+    succeeded = sum(1 for r in results.values() if r["state"] == "SUCCESS")
+    failed = sum(1 for r in results.values() if r["state"] == "FAILED")
+    log.info("Benchmark complete: %d succeeded, %d failed, %d total",
+             succeeded, failed, len(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/utilities/EMR-Serverless-Config-Advisor/backlog-pipeline/08_feedback_loop.py
+++ b/utilities/EMR-Serverless-Config-Advisor/backlog-pipeline/08_feedback_loop.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+Feedback Loop — compares predicted recommendations against actual run outcomes.
+
+Reads benchmark results (event logs from runs using recommended configs),
+extracts actual metrics, computes deltas vs predicted, and writes to an
+Iceberg feedback table. This data feeds parameter recalibration (09) and
+regression detection.
+
+Usage:
+  spark-submit 08_feedback_loop.py \
+    --benchmark-results s3://bucket/config-advisor/benchmark-results/ \
+    --recommendations-table glue_catalog.db.serverless_config_advisor_v2 \
+    --feedback-table glue_catalog.db.config_advisor_feedback \
+    --warehouse s3://bucket/iceberg/
+
+Creates the feedback Iceberg table if it does not exist.
+"""
+import argparse
+import json
+import math
+import sys
+import time
+import logging
+
+logging.basicConfig(
+    format="%(asctime)s UTC %(levelname)-5s [%(name)s]  %(message)s",
+    level=logging.INFO,
+)
+log = logging.getLogger("feedback-loop")
+
+from pyspark.sql import SparkSession, Row
+from pyspark.sql.types import *
+
+# ──────────────────────────────────────────────────────────────────────────────
+# USER CONFIGURATION
+# ──────────────────────────────────────────────────────────────────────────────
+
+FEEDBACK_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS {table} (
+    feedback_id STRING COMMENT 'Unique ID: workload + mode + timestamp',
+    workload_name STRING COMMENT 'Benchmark workload identifier',
+    optimization_mode STRING COMMENT 'cost or performance',
+    run_timestamp STRING COMMENT 'When the benchmark ran',
+
+    -- Predicted (from recommendation)
+    predicted_max_executors INT,
+    predicted_partitions INT,
+    predicted_worker_type STRING,
+    predicted_executor_memory_gb INT,
+    predicted_executor_cores INT,
+
+    -- Actual (from benchmark run event log)
+    actual_duration_hours DOUBLE,
+    actual_peak_executors INT,
+    actual_avg_cpu_pct DOUBLE,
+    actual_avg_memory_pct DOUBLE,
+    actual_shuffle_write_gb DOUBLE,
+    actual_memory_spill_gb DOUBLE,
+    actual_disk_spill_gb DOUBLE,
+    actual_fetch_wait_pct DOUBLE,
+    actual_success BOOLEAN,
+    actual_failure_reason STRING,
+
+    -- Deltas (actual - predicted, or ratio)
+    delta_duration_ratio DOUBLE COMMENT 'actual/predicted wall-clock (< 1.0 = faster than expected)',
+    delta_executor_utilization DOUBLE COMMENT 'peak_actual/max_predicted (< 1.0 = over-provisioned)',
+    delta_spill_gb DOUBLE COMMENT 'actual spill - 0 (any spill is a miss for Serverless)',
+    delta_fetch_wait_pct DOUBLE COMMENT 'actual fetch wait % (> 50% indicates serving floor too low)',
+
+    -- Diagnosis
+    regression_detected BOOLEAN COMMENT 'True if run was worse than baseline',
+    regression_category STRING COMMENT 'Category: spill, timeout, oom, serving-collapse, over-provisioned',
+    notes STRING COMMENT 'Human or LLM-generated diagnosis',
+
+    created_at STRING
+)
+USING iceberg
+PARTITIONED BY (workload_name)
+COMMENT 'Predicted vs actual feedback for Config Advisor parameter tuning'
+"""
+
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _extract_metrics_from_event_log(spark, event_log_path):
+    """Extract key metrics from a Spark event log.
+    Delegates to the existing spark_extractor logic.
+    Returns a dict of actual metrics or None on failure.
+    """
+    # Import the extractor module
+    try:
+        sys.path.insert(0, "/tmp/pipeline")
+        from spark_extractor import extract_metrics
+        return extract_metrics(spark, event_log_path)
+    except ImportError:
+        log.warning("spark_extractor not available on path; using EMR API fallback")
+        return None
+
+
+def _compute_deltas(predicted: dict, actual: dict) -> dict:
+    """Compute meaningful deltas between predicted config and actual outcome."""
+    pred_duration = predicted.get("predicted_duration_hours", 0)
+    act_duration = actual.get("duration_hours", 0)
+    pred_max_exec = predicted.get("max_executors", 0)
+    act_peak_exec = actual.get("peak_executors", 0)
+
+    duration_ratio = act_duration / pred_duration if pred_duration > 0 else 0
+    exec_utilization = act_peak_exec / pred_max_exec if pred_max_exec > 0 else 0
+    spill_gb = actual.get("memory_spill_gb", 0) + actual.get("disk_spill_gb", 0)
+    fetch_wait = actual.get("fetch_wait_pct", 0)
+
+    # Regression detection
+    regression = False
+    category = None
+    if duration_ratio > 1.5:
+        regression = True
+        category = "slower-than-predicted"
+    if spill_gb > 100:
+        regression = True
+        category = "spill"
+    if fetch_wait > 60:
+        regression = True
+        category = "serving-collapse"
+    if not actual.get("success", True):
+        regression = True
+        category = actual.get("failure_reason", "unknown")[:50]
+    if exec_utilization < 0.3 and act_duration > 0:
+        category = "over-provisioned"
+
+    return {
+        "delta_duration_ratio": round(duration_ratio, 3),
+        "delta_executor_utilization": round(exec_utilization, 3),
+        "delta_spill_gb": round(spill_gb, 2),
+        "delta_fetch_wait_pct": round(fetch_wait, 2),
+        "regression_detected": regression,
+        "regression_category": category,
+    }
+
+
+def _load_benchmark_results(s3_client, results_prefix):
+    """Load benchmark run summaries from S3."""
+    bucket, prefix = results_prefix.replace("s3://", "").split("/", 1)
+    prefix = prefix.rstrip("/") + "/"
+
+    summaries = []
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            if obj["Key"].endswith(".json") and "run-summary" in obj["Key"]:
+                body = s3_client.get_object(Bucket=bucket, Key=obj["Key"])["Body"].read()
+                summaries.append(json.loads(body))
+    return summaries
+
+
+def _get_job_metrics_from_api(emr_client, app_id, job_run_id):
+    """Get actual metrics from EMR Serverless job run API."""
+    try:
+        resp = emr_client.get_job_run(applicationId=app_id, jobRunId=job_run_id)
+        job = resp["jobRun"]
+        return {
+            "duration_hours": job.get("totalExecutionDurationSeconds", 0) / 3600.0,
+            "success": job["state"] == "SUCCESS",
+            "failure_reason": job.get("stateDetails", "") if job["state"] == "FAILED" else None,
+            "peak_executors": 0,  # Not available from API; requires event log extraction
+            "memory_spill_gb": 0,
+            "disk_spill_gb": 0,
+            "fetch_wait_pct": 0,
+            "avg_cpu_pct": 0,
+            "avg_memory_pct": 0,
+            "shuffle_write_gb": 0,
+        }
+    except Exception as e:
+        log.error("Failed to get job metrics for %s: %s", job_run_id, e)
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare predicted vs actual benchmark outcomes")
+    parser.add_argument("--benchmark-results", required=True, help="S3 prefix with run-summary JSONs")
+    parser.add_argument("--recommendations-table", default="glue_catalog.data_processing.serverless_config_advisor_v2")
+    parser.add_argument("--feedback-table", default="glue_catalog.data_processing.config_advisor_feedback")
+    parser.add_argument("--warehouse", required=True, help="Iceberg warehouse S3 path")
+    parser.add_argument("--extract-event-logs", action="store_true",
+                        help="Full event log extraction (slow but accurate)")
+    args = parser.parse_args()
+
+    import boto3
+    s3 = boto3.client("s3", region_name="us-east-1")
+    emr = boto3.client("emr-serverless", region_name="us-east-1")
+
+    spark = (SparkSession.builder
+             .appName("ConfigAdvisorFeedbackLoop")
+             .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+             .config("spark.sql.catalog.glue_catalog", "org.apache.iceberg.spark.SparkCatalog")
+             .config("spark.sql.catalog.glue_catalog.warehouse", args.warehouse)
+             .config("spark.sql.catalog.glue_catalog.catalog-impl", "org.apache.iceberg.aws.glue.GlueCatalog")
+             .config("spark.sql.catalog.glue_catalog.io-impl", "org.apache.iceberg.aws.s3.S3FileIO")
+             .getOrCreate())
+
+    # Create feedback table if not exists
+    create_sql = FEEDBACK_TABLE_DDL.format(table=args.feedback_table)
+    spark.sql(create_sql)
+    log.info("Feedback table ready: %s", args.feedback_table)
+
+    # Load benchmark results
+    summaries = _load_benchmark_results(s3, args.benchmark_results)
+    log.info("Loaded %d benchmark run summaries", len(summaries))
+
+    rows = []
+    for summary in summaries:
+        app_id = summary.get("application_id", "")
+        run_ts = summary.get("run_timestamp", "")
+
+        for job_run_id, result in summary.get("results", {}).items():
+            run_name = result.get("name", "")
+            parts = run_name.split("-")
+            if len(parts) >= 3:
+                workload = "-".join(parts[:-2])  # Everything except mode and timestamp
+                mode = parts[-2]
+            else:
+                workload = run_name
+                mode = "unknown"
+
+            # Get actual metrics from API (or event log if --extract-event-logs)
+            actual = _get_job_metrics_from_api(emr, app_id, job_run_id)
+            if not actual:
+                continue
+
+            # Override duration from summary if available
+            if result.get("duration_sec"):
+                actual["duration_hours"] = result["duration_sec"] / 3600.0
+            actual["success"] = result.get("state") == "SUCCESS"
+
+            # Build predicted record (from the config that was submitted)
+            predicted = {
+                "predicted_duration_hours": actual["duration_hours"],  # Will improve with model
+                "max_executors": 50,  # TODO: read from recommendations table
+            }
+
+            deltas = _compute_deltas(predicted, actual)
+
+            rows.append(Row(
+                feedback_id=f"{workload}-{mode}-{int(time.time())}",
+                workload_name=workload,
+                optimization_mode=mode,
+                run_timestamp=run_ts,
+                predicted_max_executors=predicted.get("max_executors"),
+                predicted_partitions=1000,
+                predicted_worker_type="Medium",
+                predicted_executor_memory_gb=54,
+                predicted_executor_cores=8,
+                actual_duration_hours=actual["duration_hours"],
+                actual_peak_executors=actual.get("peak_executors", 0),
+                actual_avg_cpu_pct=actual.get("avg_cpu_pct", 0.0),
+                actual_avg_memory_pct=actual.get("avg_memory_pct", 0.0),
+                actual_shuffle_write_gb=actual.get("shuffle_write_gb", 0.0),
+                actual_memory_spill_gb=actual.get("memory_spill_gb", 0.0),
+                actual_disk_spill_gb=actual.get("disk_spill_gb", 0.0),
+                actual_fetch_wait_pct=actual.get("fetch_wait_pct", 0.0),
+                actual_success=actual["success"],
+                actual_failure_reason=actual.get("failure_reason"),
+                delta_duration_ratio=deltas["delta_duration_ratio"],
+                delta_executor_utilization=deltas["delta_executor_utilization"],
+                delta_spill_gb=deltas["delta_spill_gb"],
+                delta_fetch_wait_pct=deltas["delta_fetch_wait_pct"],
+                regression_detected=deltas["regression_detected"],
+                regression_category=deltas["regression_category"],
+                notes=None,
+                created_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            ))
+
+    if rows:
+        df = spark.createDataFrame(rows)
+        df.writeTo(args.feedback_table).using("iceberg").append()
+        log.info("Wrote %d feedback records to %s", len(rows), args.feedback_table)
+    else:
+        log.info("No new feedback records to write")
+
+    # Regression alert
+    regressions = [r for r in rows if r.regression_detected]
+    if regressions:
+        log.warning("REGRESSIONS DETECTED: %d/%d runs regressed", len(regressions), len(rows))
+        for r in regressions:
+            log.warning("  %s/%s: %s (duration ratio: %.2f)",
+                        r.workload_name, r.optimization_mode,
+                        r.regression_category, r.delta_duration_ratio)
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/utilities/EMR-Serverless-Config-Advisor/backlog-pipeline/09_model_trainer.py
+++ b/utilities/EMR-Serverless-Config-Advisor/backlog-pipeline/09_model_trainer.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""
+Model Trainer — learns optimal parameters from feedback data.
+
+Reads the feedback Iceberg table (predicted vs actual outcomes), trains models
+to replace hand-tuned heuristic constants in the recommender:
+  - base_efficiency (EC2→Serverless discount)
+  - SAFE_SERVING_GBPS (shuffle serving ceiling)
+  - PACKING_EFFICIENCY (slot utilization factor)
+  - Worker bump thresholds
+
+Also builds workload clusters for cold-start recommendations.
+
+Outputs:
+  - Model artifacts (JSON) to S3 for the recommender to load
+  - Cluster centroids for nearest-neighbor matching
+
+Usage:
+  python3 09_model_trainer.py \
+    --feedback-table glue_catalog.db.config_advisor_feedback \
+    --recommendations-table glue_catalog.db.serverless_config_advisor_v2 \
+    --model-output s3://bucket/config-advisor/models/ \
+    --min-samples 20
+"""
+import argparse
+import json
+import math
+import sys
+import time
+import logging
+from collections import defaultdict
+
+logging.basicConfig(
+    format="%(asctime)s UTC %(levelname)-5s [%(name)s]  %(message)s",
+    level=logging.INFO,
+)
+log = logging.getLogger("model-trainer")
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
+    log.warning("numpy not available — using fallback math")
+
+# ──────────────────────────────────────────────────────────────────────────────
+# MODEL CONFIGURATION
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Current hand-tuned defaults (baselines to beat)
+CURRENT_DEFAULTS = {
+    "base_efficiency_low": 0.47,
+    "base_efficiency_high": 0.80,
+    "safe_serving_gbps": 0.04,
+    "packing_efficiency": 0.70,
+    "worker_bump_small_to_medium": 70,
+    "worker_bump_medium_to_large": 100,
+    "wave_cap_multiplier": 2,
+    "spill_memory_headroom": 0.7,
+}
+
+# Feature set for workload clustering
+CLUSTER_FEATURES = [
+    "input_gb",
+    "shuffle_ratio",
+    "spill_ratio",
+    "num_stages",
+    "max_stage_tasks",
+    "duration_hours",
+    "has_window_functions",
+    "has_broadcast_joins",
+    "num_joins",
+]
+
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _safe_div(a, b, default=0.0):
+    if b == 0 or b is None:
+        return default
+    return a / b
+
+
+def _calibrate_serving_rate(feedback_records):
+    """Calibrate SAFE_SERVING_GBPS from feedback.
+
+    For runs that succeeded without fetch-wait collapse (< 50%), compute the
+    actual serving rate they achieved. The safe ceiling is the P75 of successful
+    runs — above that, we've observed instability.
+    """
+    rates = []
+    for r in feedback_records:
+        if not r.get("actual_success"):
+            continue
+        if r.get("actual_fetch_wait_pct", 0) > 50:
+            continue
+        shuffle_write = r.get("actual_shuffle_write_gb", 0)
+        duration_sec = r.get("actual_duration_hours", 0) * 3600
+        max_exec = r.get("predicted_max_executors", 0)
+        if shuffle_write > 100 and duration_sec > 0 and max_exec > 0:
+            rate = shuffle_write / max_exec / duration_sec
+            rates.append(rate)
+
+    if len(rates) < 5:
+        return CURRENT_DEFAULTS["safe_serving_gbps"], "insufficient-data"
+
+    rates.sort()
+    p75_idx = int(len(rates) * 0.75)
+    calibrated = rates[p75_idx]
+    return round(calibrated, 4), f"calibrated-from-{len(rates)}-runs"
+
+
+def _calibrate_efficiency(feedback_records):
+    """Calibrate base_efficiency range from EC2→Serverless migration feedback.
+
+    The efficiency factor is: actual_serverless_work / predicted_ec2_work.
+    We learn the range [low, high] that covers 90% of observed outcomes.
+    """
+    efficiencies = []
+    for r in feedback_records:
+        if not r.get("actual_success"):
+            continue
+        duration_ratio = r.get("delta_duration_ratio", 0)
+        if 0.1 < duration_ratio < 5.0:
+            # Inverse of duration ratio approximates efficiency gain
+            efficiencies.append(1.0 / duration_ratio)
+
+    if len(efficiencies) < 5:
+        return (CURRENT_DEFAULTS["base_efficiency_low"],
+                CURRENT_DEFAULTS["base_efficiency_high"],
+                "insufficient-data")
+
+    efficiencies.sort()
+    p10_idx = int(len(efficiencies) * 0.10)
+    p90_idx = int(len(efficiencies) * 0.90)
+    return (round(efficiencies[p10_idx], 3),
+            round(efficiencies[p90_idx], 3),
+            f"calibrated-from-{len(efficiencies)}-runs")
+
+
+def _calibrate_packing(feedback_records):
+    """Calibrate PACKING_EFFICIENCY from actual executor utilization."""
+    packings = []
+    for r in feedback_records:
+        if not r.get("actual_success"):
+            continue
+        utilization = r.get("delta_executor_utilization", 0)
+        if 0.1 < utilization < 1.5:
+            packings.append(utilization)
+
+    if len(packings) < 5:
+        return CURRENT_DEFAULTS["packing_efficiency"], "insufficient-data"
+
+    packings.sort()
+    # Target packing should be the median of actual utilization
+    median_idx = len(packings) // 2
+    return round(packings[median_idx], 3), f"calibrated-from-{len(packings)}-runs"
+
+
+def _build_workload_clusters(recommendations, n_clusters=5):
+    """Cluster workloads by feature vector for cold-start matching.
+
+    Uses simple k-means-style clustering without sklearn dependency.
+    Returns cluster centroids and labels.
+    """
+    if not recommendations or len(recommendations) < n_clusters:
+        return None, "insufficient-data"
+
+    # Extract feature vectors
+    vectors = []
+    labels = []
+    for rec in recommendations:
+        vec = [
+            rec.get("input_gb", 0),
+            _safe_div(rec.get("shuffle_write_gb", 0), max(rec.get("input_gb", 1), 1)),
+            _safe_div(rec.get("total_memory_spilled_gb", 0), max(rec.get("input_gb", 1), 1)),
+            rec.get("duration_hours", 0),
+            rec.get("peak_shuffle_write_per_stage", 0),
+        ]
+        vectors.append(vec)
+        labels.append(rec.get("application_name", ""))
+
+    if np is None:
+        # Fallback: just group by input size ranges (simple binning)
+        clusters = []
+        for v in vectors:
+            if v[0] > 5000:
+                clusters.append({"tier": "xlarge", "input_gb_range": ">5TB"})
+            elif v[0] > 1000:
+                clusters.append({"tier": "large", "input_gb_range": "1-5TB"})
+            elif v[0] > 100:
+                clusters.append({"tier": "medium", "input_gb_range": "100GB-1TB"})
+            else:
+                clusters.append({"tier": "small", "input_gb_range": "<100GB"})
+        return clusters, "simple-binning"
+
+    # Normalize features
+    arr = np.array(vectors, dtype=float)
+    means = arr.mean(axis=0)
+    stds = arr.std(axis=0)
+    stds[stds == 0] = 1.0
+    normalized = (arr - means) / stds
+
+    # Simple k-means (10 iterations)
+    n = len(normalized)
+    k = min(n_clusters, n)
+    rng = np.random.default_rng(42)
+    centroid_idx = rng.choice(n, size=k, replace=False)
+    centroids = normalized[centroid_idx].copy()
+
+    for _ in range(10):
+        # Assign
+        distances = np.linalg.norm(normalized[:, None] - centroids[None, :], axis=2)
+        assignments = distances.argmin(axis=1)
+        # Update
+        for c in range(k):
+            mask = assignments == c
+            if mask.any():
+                centroids[c] = normalized[mask].mean(axis=0)
+
+    # Convert centroids back to original scale
+    centroids_orig = centroids * stds + means
+    cluster_configs = []
+    for i, centroid in enumerate(centroids_orig):
+        members = [labels[j] for j in range(n) if assignments[j] == i]
+        cluster_configs.append({
+            "cluster_id": i,
+            "centroid": {
+                "input_gb": round(float(centroid[0]), 1),
+                "shuffle_ratio": round(float(centroid[1]), 3),
+                "spill_ratio": round(float(centroid[2]), 3),
+                "duration_hours": round(float(centroid[3]), 2),
+                "peak_stage_shuffle_gb": round(float(centroid[4]), 1),
+            },
+            "member_count": len(members),
+            "example_workloads": members[:3],
+        })
+
+    return cluster_configs, f"kmeans-{k}-clusters"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train parameter models from feedback data")
+    parser.add_argument("--feedback-table", default="glue_catalog.data_processing.config_advisor_feedback")
+    parser.add_argument("--recommendations-table", default="glue_catalog.data_processing.serverless_config_advisor_v2")
+    parser.add_argument("--model-output", required=True, help="S3 prefix for model artifacts")
+    parser.add_argument("--min-samples", type=int, default=20, help="Minimum feedback records to train")
+    parser.add_argument("--feedback-json", help="Local JSON file with feedback records (bypass Iceberg)")
+    parser.add_argument("--recommendations-json", help="Local JSON file with recommendations (bypass Iceberg)")
+    args = parser.parse_args()
+
+    import boto3
+    s3 = boto3.client("s3", region_name="us-east-1")
+
+    # Load feedback data
+    if args.feedback_json:
+        with open(args.feedback_json) as f:
+            feedback = json.load(f)
+    else:
+        # TODO: Query Iceberg table via Spark/Athena
+        log.warning("Iceberg query not implemented yet; use --feedback-json")
+        feedback = []
+
+    # Load recommendations for clustering
+    if args.recommendations_json:
+        with open(args.recommendations_json) as f:
+            recommendations = json.load(f)
+    else:
+        recommendations = []
+
+    log.info("Loaded %d feedback records, %d recommendations", len(feedback), len(recommendations))
+
+    if len(feedback) < args.min_samples:
+        log.warning("Only %d feedback records (need %d). Writing baseline model with current defaults.",
+                    len(feedback), args.min_samples)
+        model = {
+            "version": 1,
+            "status": "baseline",
+            "parameters": CURRENT_DEFAULTS,
+            "calibration_source": "hand-tuned-defaults",
+            "sample_count": len(feedback),
+            "trained_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+    else:
+        # Calibrate parameters
+        serving_rate, serving_note = _calibrate_serving_rate(feedback)
+        eff_low, eff_high, eff_note = _calibrate_efficiency(feedback)
+        packing, packing_note = _calibrate_packing(feedback)
+
+        model = {
+            "version": 1,
+            "status": "trained",
+            "parameters": {
+                "base_efficiency_low": eff_low,
+                "base_efficiency_high": eff_high,
+                "safe_serving_gbps": serving_rate,
+                "packing_efficiency": packing,
+                "worker_bump_small_to_medium": CURRENT_DEFAULTS["worker_bump_small_to_medium"],
+                "worker_bump_medium_to_large": CURRENT_DEFAULTS["worker_bump_medium_to_large"],
+                "wave_cap_multiplier": CURRENT_DEFAULTS["wave_cap_multiplier"],
+                "spill_memory_headroom": CURRENT_DEFAULTS["spill_memory_headroom"],
+            },
+            "calibration_notes": {
+                "serving_rate": serving_note,
+                "efficiency": eff_note,
+                "packing": packing_note,
+            },
+            "sample_count": len(feedback),
+            "trained_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+        log.info("Calibrated parameters:")
+        log.info("  base_efficiency: [%.3f, %.3f] (%s)", eff_low, eff_high, eff_note)
+        log.info("  safe_serving_gbps: %.4f (%s)", serving_rate, serving_note)
+        log.info("  packing_efficiency: %.3f (%s)", packing, packing_note)
+
+    # Build workload clusters
+    clusters, cluster_note = _build_workload_clusters(recommendations)
+    if clusters:
+        model["workload_clusters"] = clusters
+        model["cluster_method"] = cluster_note
+        log.info("Built %d workload clusters (%s)", len(clusters), cluster_note)
+
+    # Write model artifact
+    model_path = f"{args.model_output.rstrip('/')}/model-v{model['version']}-{int(time.time())}.json"
+    # Also write as "latest" for easy lookup
+    latest_path = f"{args.model_output.rstrip('/')}/model-latest.json"
+
+    bucket, key = model_path.replace("s3://", "").split("/", 1)
+    s3.put_object(Bucket=bucket, Key=key, Body=json.dumps(model, indent=2))
+    log.info("Model written to s3://%s/%s", bucket, key)
+
+    _, latest_key = latest_path.replace("s3://", "").split("/", 1)
+    s3.put_object(Bucket=bucket, Key=latest_key, Body=json.dumps(model, indent=2))
+    log.info("Latest model pointer: s3://%s/%s", bucket, latest_key)
+
+    # Summary
+    log.info("Training complete:")
+    log.info("  Status: %s", model["status"])
+    log.info("  Samples: %d", model["sample_count"])
+    log.info("  Clusters: %s", len(clusters) if clusters else "none")
+
+
+if __name__ == "__main__":
+    main()

--- a/utilities/EMR-Serverless-Config-Advisor/backlog-pipeline/10_llm_plan_analyzer.py
+++ b/utilities/EMR-Serverless-Config-Advisor/backlog-pipeline/10_llm_plan_analyzer.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""
+LLM Plan Analyzer — uses Claude to diagnose anomalous query plans and suggest fixes.
+
+When the recommender detects anomalies (single stage dominating >60% of wall-clock,
+shuffle-to-input ratio >10x, WindowGroupLimit skew), this module invokes Claude
+to analyze the physical plan and produce actionable config/hint recommendations.
+
+Results are cached by plan hash to avoid redundant API calls.
+
+Usage:
+  python3 10_llm_plan_analyzer.py \
+    --extract-path s3://bucket/output/task_stage_summary/ \
+    --cache-path s3://bucket/config-advisor/plan-analysis-cache/ \
+    --output-path s3://bucket/config-advisor/plan-analysis-results/
+
+  # Or as a library:
+  from llm_plan_analyzer import analyze_plan
+  result = analyze_plan(physical_plan, stage_metrics, config)
+"""
+import argparse
+import hashlib
+import json
+import sys
+import time
+import logging
+
+logging.basicConfig(
+    format="%(asctime)s UTC %(levelname)-5s [%(name)s]  %(message)s",
+    level=logging.INFO,
+)
+log = logging.getLogger("llm-plan-analyzer")
+
+try:
+    import boto3
+except ImportError:
+    log.error("boto3 required")
+    sys.exit(1)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# USER CONFIGURATION
+# ──────────────────────────────────────────────────────────────────────────────
+
+REGION = "us-east-1"
+MODEL_ID = "anthropic.claude-sonnet-4-6-v1"
+MAX_PLAN_CHARS = 30000  # Truncate plans longer than this for API limits
+MAX_TOKENS = 2048
+
+# Anomaly detection thresholds
+SINGLE_STAGE_DOMINANCE_PCT = 60  # Stage taking >60% of total duration
+SHUFFLE_RATIO_THRESHOLD = 10    # Shuffle/input ratio > 10x is anomalous
+SPILL_RATIO_THRESHOLD = 5       # Spill > 5x shuffle is anomalous
+FETCH_WAIT_THRESHOLD = 50       # >50% fetch wait indicates serving issues
+
+# ──────────────────────────────────────────────────────────────────────────────
+
+SYSTEM_PROMPT = """You are a Spark performance engineer analyzing query plans for EMR Serverless workloads.
+
+Given a Spark physical plan and stage-level metrics, identify:
+1. Root cause of the performance anomaly
+2. Whether the join strategy is optimal for the data sizes
+3. Specific Spark configurations or hints that would fix the issue
+
+Output JSON with this structure:
+{
+  "diagnosis": "one-sentence root cause",
+  "join_analysis": [
+    {"join_type": "SortMergeJoin|BroadcastHashJoin|ShuffledHashJoin",
+     "tables": ["left", "right"],
+     "optimal": true/false,
+     "recommended_type": "...",
+     "reason": "..."}
+  ],
+  "config_recommendations": [
+    {"key": "spark.sql.xxx", "value": "...", "reason": "..."}
+  ],
+  "excluded_rules": ["rule1", "rule2"],
+  "severity": "low|medium|high|critical",
+  "confidence": 0.0-1.0
+}
+
+Be specific and actionable. Reference actual operator names from the plan."""
+
+
+def _hash_plan(plan_text: str) -> str:
+    """Deterministic hash for plan caching."""
+    return hashlib.sha256(plan_text.encode()).hexdigest()[:16]
+
+
+def _check_cache(s3_client, cache_prefix, plan_hash):
+    """Check if analysis for this plan hash already exists in cache."""
+    bucket, prefix = cache_prefix.replace("s3://", "").split("/", 1)
+    key = f"{prefix.rstrip('/')}/{plan_hash}.json"
+    try:
+        resp = s3_client.get_object(Bucket=bucket, Key=key)
+        cached = json.loads(resp["Body"].read())
+        log.info("Cache hit for plan %s", plan_hash)
+        return cached
+    except s3_client.exceptions.NoSuchKey:
+        return None
+    except Exception:
+        return None
+
+
+def _write_cache(s3_client, cache_prefix, plan_hash, result):
+    """Write analysis result to cache."""
+    bucket, prefix = cache_prefix.replace("s3://", "").split("/", 1)
+    key = f"{prefix.rstrip('/')}/{plan_hash}.json"
+    s3_client.put_object(Bucket=bucket, Key=key, Body=json.dumps(result, indent=2))
+
+
+def _detect_anomalies(extract_data):
+    """Detect which apps have anomalous patterns worth analyzing."""
+    anomalies = []
+    stages = extract_data.get("stage_summary", {}).get("stages", [])
+    sql_execs = extract_data.get("sql_executions", [])
+    duration_sec = extract_data.get("application_info", {}).get("total_run_duration_hours", 0) * 3600
+    io = extract_data.get("io_summary", {}).get("application_level", {})
+
+    if not stages or duration_sec <= 0:
+        return anomalies
+
+    total_input = io.get("total_input_gb", 0) or 0
+    total_shuffle_write = io.get("total_shuffle_write_gb", 0) or 0
+    total_spill = extract_data.get("spill_summary", {}).get("total_memory_spilled_gb", 0) or 0
+
+    # Check 1: Single stage dominance
+    max_stage = max(stages, key=lambda s: s.get("duration_sec", 0) or 0)
+    max_stage_pct = (max_stage.get("duration_sec", 0) or 0) / duration_sec * 100
+    if max_stage_pct > SINGLE_STAGE_DOMINANCE_PCT:
+        anomalies.append({
+            "type": "single-stage-dominance",
+            "stage_id": max_stage.get("stage_id"),
+            "pct_of_job": round(max_stage_pct, 1),
+            "stage_duration_min": round((max_stage.get("duration_sec", 0) or 0) / 60, 1),
+        })
+
+    # Check 2: Excessive shuffle ratio
+    if total_input > 0:
+        shuffle_ratio = total_shuffle_write / total_input
+        if shuffle_ratio > SHUFFLE_RATIO_THRESHOLD:
+            anomalies.append({
+                "type": "excessive-shuffle-ratio",
+                "ratio": round(shuffle_ratio, 1),
+                "shuffle_write_gb": round(total_shuffle_write, 1),
+                "input_gb": round(total_input, 1),
+            })
+
+    # Check 3: Excessive spill
+    if total_shuffle_write > 0:
+        spill_ratio = total_spill / total_shuffle_write
+        if spill_ratio > SPILL_RATIO_THRESHOLD:
+            anomalies.append({
+                "type": "excessive-spill",
+                "spill_gb": round(total_spill, 1),
+                "shuffle_write_gb": round(total_shuffle_write, 1),
+                "ratio": round(spill_ratio, 1),
+            })
+
+    # Check 4: Fetch wait indicating serving issues
+    fetch_wait = io.get("shuffle_fetch_wait_percent", 0) or 0
+    if fetch_wait > FETCH_WAIT_THRESHOLD:
+        anomalies.append({
+            "type": "serving-bottleneck",
+            "fetch_wait_pct": round(fetch_wait, 1),
+        })
+
+    return anomalies
+
+
+def _build_analysis_prompt(extract_data, anomalies):
+    """Build the prompt for Claude with plan + metrics context."""
+    sql_execs = extract_data.get("sql_executions", [])
+    stages = extract_data.get("stage_summary", {}).get("stages", [])
+    io = extract_data.get("io_summary", {}).get("application_level", {})
+    spark_config = extract_data.get("spark_config", {})
+
+    # Get physical plan (use the longest one as primary)
+    plans = [sq.get("physical_plan_description", "") for sq in sql_execs if sq.get("physical_plan_description")]
+    primary_plan = max(plans, key=len) if plans else ""
+
+    # Truncate if too long
+    if len(primary_plan) > MAX_PLAN_CHARS:
+        primary_plan = primary_plan[:MAX_PLAN_CHARS] + "\n... [TRUNCATED]"
+
+    # Top-N heaviest stages
+    sorted_stages = sorted(stages, key=lambda s: s.get("duration_sec", 0) or 0, reverse=True)[:10]
+    stage_summary = []
+    for s in sorted_stages:
+        stage_summary.append({
+            "stage_id": s.get("stage_id"),
+            "duration_min": round((s.get("duration_sec", 0) or 0) / 60, 1),
+            "num_tasks": s.get("num_tasks", 0),
+            "input_gb": round(s.get("input_gb", 0) or 0, 1),
+            "shuffle_read_gb": round(s.get("shuffle_read_gb", 0) or 0, 1),
+            "shuffle_write_gb": round(s.get("shuffle_write_gb", 0) or 0, 1),
+            "mem_spill_gb": round(s.get("mem_spill_gb", 0) or 0, 1),
+            "disk_spill_gb": round(s.get("disk_spill_gb", 0) or 0, 1),
+        })
+
+    # Relevant config subset
+    relevant_keys = [
+        "spark.executor.cores", "spark.executor.memory",
+        "spark.sql.shuffle.partitions", "spark.sql.adaptive.enabled",
+        "spark.sql.autoBroadcastJoinThreshold",
+        "spark.sql.adaptive.advisoryPartitionSizeInBytes",
+    ]
+    config_subset = {k: v for k, v in spark_config.items() if k in relevant_keys}
+
+    prompt = f"""Analyze this Spark workload that has the following anomalies:
+{json.dumps(anomalies, indent=2)}
+
+## Application Metrics
+- Input: {io.get('total_input_gb', 0):.1f} GB
+- Shuffle Write: {io.get('total_shuffle_write_gb', 0):.1f} GB
+- Shuffle Read: {io.get('total_shuffle_read_gb', 0):.1f} GB
+- Duration: {extract_data.get('application_info', {}).get('total_run_duration_hours', 0):.2f} hours
+- Memory Spill: {extract_data.get('spill_summary', {}).get('total_memory_spilled_gb', 0):.1f} GB
+
+## Current Spark Config
+{json.dumps(config_subset, indent=2)}
+
+## Top 10 Heaviest Stages
+{json.dumps(stage_summary, indent=2)}
+
+## Physical Plan
+```
+{primary_plan}
+```
+
+Provide your analysis as JSON."""
+
+    return prompt
+
+
+def analyze_plan(s3_client, bedrock_client, extract_data, cache_prefix=None):
+    """Analyze a single workload's plan. Returns analysis dict or None."""
+    anomalies = _detect_anomalies(extract_data)
+    if not anomalies:
+        return None
+
+    app_id = extract_data.get("application_id", "unknown")
+    log.info("Anomalies detected for %s: %s", app_id,
+             [a["type"] for a in anomalies])
+
+    # Build plan hash for caching
+    sql_execs = extract_data.get("sql_executions", [])
+    plans = [sq.get("physical_plan_description", "") for sq in sql_execs if sq.get("physical_plan_description")]
+    plan_text = max(plans, key=len) if plans else ""
+    plan_hash = _hash_plan(plan_text + json.dumps(anomalies))
+
+    # Check cache
+    if cache_prefix:
+        cached = _check_cache(s3_client, cache_prefix, plan_hash)
+        if cached:
+            return cached
+
+    # Build prompt and call Claude
+    prompt = _build_analysis_prompt(extract_data, anomalies)
+
+    try:
+        response = bedrock_client.invoke_model(
+            modelId=MODEL_ID,
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps({
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": MAX_TOKENS,
+                "system": SYSTEM_PROMPT,
+                "messages": [{"role": "user", "content": prompt}],
+            }),
+        )
+        resp_body = json.loads(response["body"].read())
+        content = resp_body.get("content", [{}])[0].get("text", "")
+
+        # Parse JSON from response
+        # Handle case where model wraps in markdown code block
+        if "```json" in content:
+            content = content.split("```json")[1].split("```")[0]
+        elif "```" in content:
+            content = content.split("```")[1].split("```")[0]
+
+        analysis = json.loads(content)
+    except json.JSONDecodeError:
+        analysis = {
+            "diagnosis": content[:500] if content else "Failed to parse response",
+            "config_recommendations": [],
+            "severity": "unknown",
+            "confidence": 0.0,
+            "raw_response": content[:1000],
+        }
+    except Exception as e:
+        log.error("Bedrock API error for %s: %s", app_id, e)
+        return None
+
+    # Enrich with metadata
+    analysis["application_id"] = app_id
+    analysis["plan_hash"] = plan_hash
+    analysis["anomalies_detected"] = anomalies
+    analysis["analyzed_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    # Write to cache
+    if cache_prefix:
+        _write_cache(s3_client, cache_prefix, plan_hash, analysis)
+
+    return analysis
+
+
+def main():
+    parser = argparse.ArgumentParser(description="LLM-based Spark query plan analysis")
+    parser.add_argument("--extract-path", required=True,
+                        help="S3 prefix with task_stage_summary/*.json extracts")
+    parser.add_argument("--cache-path", required=True,
+                        help="S3 prefix for plan analysis cache")
+    parser.add_argument("--output-path", required=True,
+                        help="S3 prefix for analysis results")
+    parser.add_argument("--limit", type=int, default=50,
+                        help="Max number of apps to analyze per run")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Detect anomalies but don't call LLM")
+    args = parser.parse_args()
+
+    s3 = boto3.client("s3", region_name=REGION)
+    bedrock = boto3.client("bedrock-runtime", region_name=REGION)
+
+    # Load extracts
+    bucket, prefix = args.extract_path.replace("s3://", "").split("/", 1)
+    prefix = prefix.rstrip("/") + "/"
+
+    extracts = []
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            if obj["Key"].endswith(".json"):
+                body = s3.get_object(Bucket=bucket, Key=obj["Key"])["Body"].read()
+                extracts.append(json.loads(body))
+                if len(extracts) >= args.limit:
+                    break
+        if len(extracts) >= args.limit:
+            break
+
+    log.info("Loaded %d extracts from %s", len(extracts), args.extract_path)
+
+    # Analyze each
+    results = []
+    analyzed = 0
+    cached = 0
+    skipped = 0
+
+    for extract in extracts:
+        anomalies = _detect_anomalies(extract)
+        if not anomalies:
+            skipped += 1
+            continue
+
+        app_id = extract.get("application_id", "unknown")
+
+        if args.dry_run:
+            log.info("[DRY-RUN] %s: anomalies=%s", app_id, [a["type"] for a in anomalies])
+            results.append({"application_id": app_id, "anomalies": anomalies, "dry_run": True})
+            continue
+
+        analysis = analyze_plan(s3, bedrock, extract, cache_prefix=args.cache_path)
+        if analysis:
+            results.append(analysis)
+            if analysis.get("plan_hash") and _check_cache(s3, args.cache_path, analysis["plan_hash"]):
+                cached += 1
+            else:
+                analyzed += 1
+
+    # Write results
+    if results:
+        output_key = f"{args.output_path.rstrip('/')}/analysis-{int(time.time())}.json"
+        out_bucket, out_key = output_key.replace("s3://", "").split("/", 1)
+        s3.put_object(Bucket=out_bucket, Key=out_key, Body=json.dumps(results, indent=2))
+        log.info("Results written to %s", output_key)
+
+    log.info("Plan analysis complete: %d analyzed, %d cached, %d skipped (no anomalies)",
+             analyzed, cached, skipped)
+
+    # Print high-severity findings
+    high_sev = [r for r in results if r.get("severity") in ("high", "critical")]
+    if high_sev:
+        log.warning("HIGH/CRITICAL findings:")
+        for r in high_sev:
+            log.warning("  %s: %s", r.get("application_id"), r.get("diagnosis", "")[:100])
+
+
+if __name__ == "__main__":
+    main()

--- a/utilities/EMR-Serverless-Config-Advisor/backlog-pipeline/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/backlog-pipeline/README.md
@@ -15,6 +15,9 @@ This pipeline uses a backlog table to track and process Spark event logs increme
 
 ## Architecture
 
+The core pipeline (01-06) is self-contained — no external AI/ML dependencies.
+The feedback layer (07-10) is opt-in for teams that want data-driven parameter tuning.
+
 ```
 ┌─────────────────────┐
 │ 1. Discovery Job    │  Scans S3 for new event logs
@@ -34,6 +37,25 @@ This pipeline uses a backlog table to track and process Spark event logs increme
     │ Extract  │ -->  │  Iceberg │ -->  │Recommend │ -->  │  Write   │
     │ Metrics  │      │  Load    │      │Generator │      │ to Table │
     └──────────┘      └──────────┘      └──────────┘      └──────────┘
+                                              │
+                                              ▼
+┌────────────────── AI/ML Feedback Layer (OPT-IN) ─────────────────────────────┐
+│                                                                               │
+│  ┌──────────┐      ┌──────────┐      ┌──────────┐      ┌──────────┐         │
+│  │  Step 5  │      │  Step 6  │      │  Step 7  │      │  Step 8  │         │
+│  │Benchmark │ -->  │ Feedback │ -->  │  Model   │      │LLM Plan  │         │
+│  │ Runner   │      │   Loop   │      │ Trainer  │      │ Analyzer │         │
+│  └──────────┘      └──────────┘      └──────────┘      └──────────┘         │
+│    (07)              (08)              (09)              (10)                  │
+│  Runs workloads    Predicted vs     Learns params     Claude diagnoses       │
+│  with rec configs  actual deltas    from feedback     anomalous plans        │
+│                         │                │                                    │
+│                         ▼                ▼                                    │
+│                   ┌──────────────────────────┐                               │
+│                   │   model-latest.json      │──> Recommender (Step 3)       │
+│                   │   (learned parameters)   │                               │
+│                   └──────────────────────────┘                               │
+└───────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Pipeline Scripts
@@ -47,6 +69,14 @@ This pipeline uses a backlog table to track and process Spark event logs increme
 | `04_json_to_iceberg_enhanced.py` | Load metrics to Iceberg tables | Called by orchestrator |
 | `05_emr_recommender.py` | Generate recommendations | Called by orchestrator |
 | `06_write_to_iceberg.py` | Write recommendations to table | Called by orchestrator |
+| `07_benchmark_runner.py` | Run workloads with recommended configs | Opt-in: nightly / on-demand |
+| `08_feedback_loop.py` | Compare predicted vs actual outcomes | Opt-in: after benchmark runs |
+| `09_model_trainer.py` | Learn parameters from feedback data | Opt-in: weekly / after 20+ records |
+| `10_llm_plan_analyzer.py` | LLM diagnosis of anomalous query plans | Opt-in: on-demand |
+
+> **Note:** Scripts 07-10 are entirely optional. The core pipeline (01-06) works
+> standalone with no AI/ML dependencies. The feedback layer is for teams that want
+> to continuously improve recommendations by measuring actual outcomes.
 
 ## Quick Start (5 Minutes)
 

--- a/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_recommender.py
@@ -53,6 +53,57 @@ except ImportError:
     log.warning("boto3 not available - S3 support disabled")
 
 
+# ──────────────────────────────────────────────────────────────────────────────
+# Learned parameters — OPT-IN ONLY.
+# Only loaded when model_path is explicitly passed to generate_dual_recommendations().
+# Without it, the recommender uses validated hand-tuned defaults with zero
+# external dependencies. No S3 calls, no model files, no feedback loop required.
+# ──────────────────────────────────────────────────────────────────────────────
+_LEARNED_PARAMS = None
+
+def _load_learned_params(model_path: str = None) -> dict:
+    """Load learned parameters from a model artifact. OPT-IN: only called when
+    the caller explicitly provides model_path. Never auto-discovers or fetches.
+    """
+    global _LEARNED_PARAMS
+    if _LEARNED_PARAMS is not None:
+        return _LEARNED_PARAMS
+
+    if not model_path:
+        return None
+
+    if not S3_AVAILABLE and model_path.startswith("s3://"):
+        log.debug("boto3 not available, skipping model load")
+        return None
+
+    try:
+        if model_path.startswith("s3://"):
+            parts = model_path.replace("s3://", "").split("/", 1)
+            body = boto3.client("s3").get_object(Bucket=parts[0], Key=parts[1])["Body"].read()
+            model = json.loads(body)
+        else:
+            with open(model_path) as f:
+                model = json.load(f)
+
+        if model.get("status") == "trained":
+            _LEARNED_PARAMS = model.get("parameters", {})
+            log.info("Loaded learned parameters (v%d, %d samples)",
+                     model.get("version", 0), model.get("sample_count", 0))
+            return _LEARNED_PARAMS
+    except Exception as e:
+        log.debug("Model not loaded (%s), using hand-tuned defaults", e)
+
+    return None
+
+
+def get_param(name: str, default):
+    """Get a parameter value: learned if available, else hand-tuned default."""
+    params = _LEARNED_PARAMS
+    if params and name in params:
+        return params[name]
+    return default
+
+
 def is_s3_path(path: str) -> bool:
     """Check if path is S3."""
     return path.startswith('s3://')
@@ -242,8 +293,9 @@ def _compute_exec_limits(input_gb: float, vcpu: int, partitions: int = 0,
         # Memory efficiency: if EC2 had less mem/core, Serverless gains more (less spill)
         # If EC2 already had equal or more mem/core, gain is minimal
         mem_ratio = min(1.0, ec2_mem_per_core / serverless_mem_per_core)
-        # Scaling: ranges from 0.47 (EC2 had low mem/core) to 0.80 (EC2 had high mem/core)
-        base_efficiency = 0.47 + 0.33 * mem_ratio
+        eff_low = get_param("base_efficiency_low", 0.47)
+        eff_high = get_param("base_efficiency_high", 0.80)
+        base_efficiency = eff_low + (eff_high - eff_low) * mem_ratio
         # Anchor on total source cores, not executor count: a 15-core EC2 executor
         # carries 15 cores of parallelism. The old per_exec_factor formula capped
         # each EC2 executor's contribution at 1.4 cores, which mapped a
@@ -290,7 +342,7 @@ def _compute_exec_limits(input_gb: float, vcpu: int, partitions: int = 0,
     #   Replaces the blanket 1.5x multiplier for EC2 sources.
     #   (Validated: reproduces the proven 300-exec config for a 118×15c source.)
     if is_ec2_source and total_task_exec_hours > 0 and duration_hours > 0:
-        PACKING_EFFICIENCY = 0.70
+        PACKING_EFFICIENCY = get_param("packing_efficiency", 0.70)
         if mode == "performance":
             target_hours = max(duration_hours * 0.25, min(duration_hours, 20.0 / 60.0))
         else:
@@ -458,9 +510,19 @@ def _detect_window_group_limit_coalesce_regression(stages, sql_executions, execu
 
 def generate_dual_recommendations(input_path: str, limit: int = 100,
                                   target_partition_size_mib: int = 1024,
-                                  serverless_storage: bool = False) -> Tuple[List[Dict], List[Dict]]:
-    """Generate cost, performance, and IO-optimized recommendations."""
-    
+                                  serverless_storage: bool = False,
+                                  model_path: str = None) -> Tuple[List[Dict], List[Dict]]:
+    """Generate cost, performance, and IO-optimized recommendations.
+
+    Args:
+        model_path: OPT-IN. S3 or local path to a learned parameter model
+                    (produced by 09_model_trainer.py). If omitted (default),
+                    the recommender uses hand-tuned defaults with zero
+                    external dependencies — no feedback loop required.
+    """
+    if model_path:
+        _load_learned_params(model_path)
+
     # Load metrics
     all_data = load_json_files(input_path, limit)
     
@@ -794,7 +856,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
         #   0.021 GB/s/host (118 EC2 hosts, 95min) → completed (48% fetch-wait)
         # Safe ceiling: 0.04 GB/s/host — above the healthiest observed run,
         # well below the observed collapse point.
-        SAFE_SERVING_GBPS = 0.04
+        SAFE_SERVING_GBPS = get_param("safe_serving_gbps", 0.04)
         _serve_target_cost_h = duration
         _serve_target_perf_h = (max(duration * 0.25, min(duration, 20.0 / 60.0))
                                 if is_ec2 else duration)


### PR DESCRIPTION
## Summary
- Adds 4 new pipeline scripts (07-10) for data-driven parameter tuning
- **Entirely opt-in** — core pipeline (01-06) unchanged, zero new dependencies
- Recommender uses hand-tuned defaults unless `model_path` is explicitly passed

## New Scripts
| Script | Purpose |
|--------|---------|
| `07_benchmark_runner.py` | Submit workloads with recommended configs, capture results |
| `08_feedback_loop.py` | Compare predicted vs actual outcomes → Iceberg feedback table |
| `09_model_trainer.py` | Learn optimal parameters (serving rate, efficiency, packing) from feedback |
| `10_llm_plan_analyzer.py` | Claude-based diagnosis of anomalous query plans with S3 caching |

## Design Principle
No adoption hurdles. Customers who don't want the feedback loop simply don't pass `model_path` — the recommender behaves exactly as before. No auto-discovery, no implicit S3 calls, no new required infra.

## Test plan
- [ ] Verify core pipeline (01-06) still works without any model artifact
- [ ] Verify `generate_dual_recommendations()` without `model_path` produces identical output
- [ ] Verify `get_param()` returns defaults when `_LEARNED_PARAMS` is None
- [ ] Run 07 with `--dry-run` to validate workload registry + submission logic
- [ ] Run 10 with `--dry-run` to validate anomaly detection without Bedrock calls