### PR TITLE
EMR Serverless Config Advisor: T-shirt sizing, renamed tools, NYT-style README

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -58,14 +58,20 @@ Default is **General** — safe for any workload. Pick a specialized category on
 | **IO-Optimized** | Tiny input that explodes into massive intermediate data (EXPLODE, CROSS JOIN). |
 | **Iceberg-Maintenance** | File compaction, snapshot expiration, manifest rewrites. No business logic. |
 
-For **Iceberg-Maintenance**, size by file count rather than input volume:
+For **Iceberg-Maintenance**, if you know the number of files to compact, just provide that — sizing is handled automatically:
 
-| Files to Compact | Recommended Size | Example |
-|-----------------|-----------------|---------|
-| Under 500 | S | `--size S --sub-category Iceberg-Maintenance --num-files 200` |
-| 500 to 5,000 | M | `--size M --sub-category Iceberg-Maintenance --num-files 2000` |
-| 5,000 to 20,000 | L | `--size L --sub-category Iceberg-Maintenance --num-files 10000` |
-| Over 20,000 | XL | `--size XL --sub-category Iceberg-Maintenance --num-files 50000` |
+```bash
+python3 emr_s_tshirt_size.py --sub-category Iceberg-Maintenance --num-files 3000
+```
+
+Or pick a size manually based on file count:
+
+| Files to Compact | Recommended Size |
+|-----------------|-----------------|
+| Under 500 | S |
+| 500 to 5,000 | M |
+| 5,000 to 20,000 | L |
+| Over 20,000 | XL |
 
 ---
 

--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -58,6 +58,15 @@ Default is **General** — safe for any workload. Pick a specialized category on
 | **IO-Optimized** | Tiny input that explodes into massive intermediate data (EXPLODE, CROSS JOIN). |
 | **Iceberg-Maintenance** | File compaction, snapshot expiration, manifest rewrites. No business logic. |
 
+For **Iceberg-Maintenance**, size by file count rather than input volume:
+
+| Files to Compact | Recommended Size | Example |
+|-----------------|-----------------|---------|
+| Under 500 | S | `--size S --sub-category Iceberg-Maintenance --num-files 200` |
+| 500 to 5,000 | M | `--size M --sub-category Iceberg-Maintenance --num-files 2000` |
+| 5,000 to 20,000 | L | `--size L --sub-category Iceberg-Maintenance --num-files 10000` |
+| Over 20,000 | XL | `--size XL --sub-category Iceberg-Maintenance --num-files 50000` |
+
 ---
 
 ## Fine Tuner

--- a/utilities/EMR-Serverless-Config-Advisor/emr_s_tshirt_size.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_s_tshirt_size.py
@@ -181,12 +181,26 @@ def _max_partition_bytes(size, input_gb):
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser(description="EMR Serverless Bucket Recommender")
-    p.add_argument("--size", required=True, choices=SIZES, help="T-shirt size (XS/S/M/L/XL)")
+    p.add_argument("--size", choices=SIZES, help="T-shirt size (XS/S/M/L/XL). Optional if --num-files is provided with Iceberg-Maintenance.")
     p.add_argument("--sub-category", default="General", choices=SUB_CATEGORIES, help="Optimization axis (default: General)")
     p.add_argument("--input-size-gb", type=float, help="Input data size in GB (improves maxPartitionBytes selection)")
     p.add_argument("--num-files", type=int, help="Number of files to compact (for Iceberg-Maintenance)")
     p.add_argument("--format", choices=["json", "spark-submit", "table"], default="table")
     args = p.parse_args()
+
+    # Auto-derive size from num-files for Iceberg-Maintenance
+    if not args.size:
+        if args.sub_category == "Iceberg-Maintenance" and args.num_files:
+            if args.num_files <= 500:
+                args.size = "S"
+            elif args.num_files <= 5000:
+                args.size = "M"
+            elif args.num_files <= 20000:
+                args.size = "L"
+            else:
+                args.size = "XL"
+        else:
+            p.error("--size is required (unless using --sub-category Iceberg-Maintenance with --num-files)")
 
     result = recommend(
         size=args.size,


### PR DESCRIPTION
## What's New (since PR #173)

- **Renamed** `bucket_recommender.py` → `emr_s_tshirt_size.py`, `emr_recommender.py` → `emr_s_fine_tuner.py`
- **Iceberg Maintenance**: `--size` is now optional — provide `--num-files` and sizing is automatic
- **README rewritten** — concise, user-focused, removed internal details

```bash
# Iceberg compaction (auto-sizes from file count):
python3 emr_s_tshirt_size.py --sub-category Iceberg-Maintenance --num-files 3000
```