### PR TITLE
fix: restrict JMX remote to localhost to resolve RCE vulnerability

### DIFF
--- a/utilities/emr-observability/conf_files/configuration.json
+++ b/utilities/emr-observability/conf_files/configuration.json
@@ -5,8 +5,8 @@
       {
         "Classification": "export",
         "Properties": {
-          "YARN_NODEMANAGER_OPTS": "\"${YARN_NODEMANAGER_OPTS} -javaagent:/usr/lib/prometheus/jmx_prometheus_javaagent-0.17.2.jar=7005:/etc/hadoop/conf/yarn_jmx_config_node_manager.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50111\"",
-          "YARN_RESOURCEMANAGER_OPTS": "\"${YARN_RESOURCEMANAGER_OPTS} -javaagent:/usr/lib/prometheus/jmx_prometheus_javaagent-0.17.2.jar=7005:/etc/hadoop/conf/yarn_jmx_config_resource_manager.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50111\""
+          "YARN_NODEMANAGER_OPTS": "\"${YARN_NODEMANAGER_OPTS} -javaagent:/usr/lib/prometheus/jmx_prometheus_javaagent-0.17.2.jar=7005:/etc/hadoop/conf/yarn_jmx_config_node_manager.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.host=localhost -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50111\"",
+          "YARN_RESOURCEMANAGER_OPTS": "\"${YARN_RESOURCEMANAGER_OPTS} -javaagent:/usr/lib/prometheus/jmx_prometheus_javaagent-0.17.2.jar=7005:/etc/hadoop/conf/yarn_jmx_config_resource_manager.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.host=localhost -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50111\""
         }
       }
     ],
@@ -18,8 +18,8 @@
       {
         "Classification": "export",
         "Properties": {
-          "HADOOP_DATANODE_OPTS": "\"${HADOOP_DATANODE_OPTS} -javaagent:/usr/lib/prometheus/jmx_prometheus_javaagent-0.17.2.jar=7001:/etc/hadoop/conf/hdfs_jmx_config_datanode.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50103\"",
-          "HADOOP_NAMENODE_OPTS": "\"${HADOOP_NAMENODE_OPTS} -javaagent:/usr/lib/prometheus/jmx_prometheus_javaagent-0.17.2.jar=7001:/etc/hadoop/conf/hdfs_jmx_config_namenode.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50103\""
+          "HADOOP_DATANODE_OPTS": "\"${HADOOP_DATANODE_OPTS} -javaagent:/usr/lib/prometheus/jmx_prometheus_javaagent-0.17.2.jar=7001:/etc/hadoop/conf/hdfs_jmx_config_datanode.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.host=localhost -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50103\"",
+          "HADOOP_NAMENODE_OPTS": "\"${HADOOP_NAMENODE_OPTS} -javaagent:/usr/lib/prometheus/jmx_prometheus_javaagent-0.17.2.jar=7001:/etc/hadoop/conf/hdfs_jmx_config_namenode.yaml -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.host=localhost -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=50103\""
         }
       }
     ],


### PR DESCRIPTION
## Summary

Adds `-Dcom.sun.management.jmxremote.host=localhost` to all JVM options in the EMR observability configuration to restrict JMX to localhost-only access.

## Problem

ACAT flagged an insecure JMX configuration (`jmxremote.ssl=false` + `jmxremote.authenticate=false`) that exposes JMX on all network interfaces, enabling Remote Code Execution (RCE) by attackers with network access.

## Fix

Binding JMX to localhost mitigates the vulnerability (per AppSec guidance for JDK 8u102+) while preserving Prometheus JMX exporter functionality since the agent runs on the same host.

**Affected components:**
- YARN NodeManager
- YARN ResourceManager
- HDFS DataNode
- HDFS NameNode

## Testing

The Prometheus jmx_prometheus_javaagent connects locally to scrape metrics, so localhost binding does not break observability.