### PR TITLE
feat: EMR Serverless Advisor web UI (Config Advisor + Observability + AI assistant)

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -11,6 +11,32 @@ Right-size your Spark jobs on EMR Serverless. Two tools, one goal: optimal confi
 
 Use the T-shirt sizer when you want configs fast. Use the Fine Tuner when you want configs tuned to your exact workload.
 
+## Web UI
+
+Both tools (and more) are available through a local web UI — see
+[WEBUI_README.md](WEBUI_README.md) for setup. It adds:
+
+- **Config Advisor page**: drag-and-drop raw Spark event logs (EMR Serverless
+  or EMR on EC2; single files or zipped rolling directories) — extraction
+  runs server-side. Results include bottleneck classification, cost/perf
+  recommendations, run cost, Spark-UI-style query plans with per-operator
+  failure attribution, and a recommended-vs-submitted config audit.
+- **EC2 → Serverless migration**: EC2 logs are auto-detected and translated;
+  upload an EC2 baseline plus a Serverless attempt for a migration-mode
+  comparison.
+- **Compare two runs**: metric deltas, config diff, and per-stage CPU-per-GB
+  analysis to localize regressions.
+- **Observability**: live driver/executor dashboards (heap, RSS, CPU, GC,
+  disk, tasks) for metrics-enabled job runs, backed by a self-hosted
+  Prometheus.
+- **Ask AI** (optional): an embedded assistant that grounds its answers in
+  the analyses, the EMR Serverless API, and live metrics.
+
+```bash
+pip install fastapi 'uvicorn[standard]' python-multipart jinja2 boto3
+python3 app.py    # http://localhost:5000
+```
+
 ---
 
 ## T-Shirt Sizing

--- a/utilities/EMR-Serverless-Config-Advisor/WEBUI_README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/WEBUI_README.md
@@ -1,0 +1,38 @@
+# EMR Serverless Advisor — Web UI
+
+FastAPI web UI for the Config Advisor with an EMR-console-style shell.
+
+## Features
+- **Config Advisor**: upload raw Spark event logs (EMR Serverless or EMR on
+  EC2; plain / .gz / .zstd / rolling `events_N` files, or a .zip of the
+  `eventlog_v2_*` directory) or pre-extracted `task_stage_summary` JSONs.
+  Server-side extraction, bottleneck classification, cost/performance worker
+  recommendations, run cost (billed via the EMR API when the run is in the
+  same account, estimated from executor lifetimes otherwise), query plans
+  (Spark-UI-SQL-tab-style operator trees with metrics and per-operator
+  failure attribution), and a deterministic recommended-vs-submitted config
+  audit.
+- **EC2 → Serverless migration**: EC2 event logs are auto-detected and get
+  migration-translated configs; upload the EC2 baseline and a Serverless
+  attempt together for a migration-mode comparison.
+- **Compare two runs**: metric deltas, noise-filtered config diff, per-stage
+  CPU-per-GB analysis with an automatic verdict.
+- **Observability**: live driver/executor dashboards (heap, RSS, CPU, GC,
+  disk, tasks, job status) from a self-hosted Prometheus (see
+  `bucket-agent/docs/METRICS_OBSERVABILITY_STACK.md` for the stack).
+- **Ask AI**: embedded agentic assistant (Bedrock Converse tool-use) with
+  tools over the EMR Serverless API, Prometheus, the analyses, and a
+  t-shirt-sizing tool for brand-new jobs.
+
+## Run
+```bash
+pip install fastapi 'uvicorn[standard]' python-multipart jinja2 boto3
+export PROMETHEUS_URL=http://your-prometheus:9090   # optional, for Observability
+export MODEL_ID=global.anthropic.claude-sonnet-4-6  # optional, for Ask AI
+python3 app.py                                       # http://localhost:5000
+```
+Or `MONITORING_INSTANCE=i-xxxx ./start_advisor.sh` to run with a self-healing
+SSM port-forward tunnel to a Prometheus host that isn't directly reachable.
+
+All components are permissively licensed: FastAPI (MIT), Prometheus +
+graphite_exporter (Apache-2.0), Chart.js (MIT).

--- a/utilities/EMR-Serverless-Config-Advisor/WEBUI_README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/WEBUI_README.md
@@ -34,5 +34,7 @@ python3 app.py                                       # http://localhost:5000
 Or `MONITORING_INSTANCE=i-xxxx ./start_advisor.sh` to run with a self-healing
 SSM port-forward tunnel to a Prometheus host that isn't directly reachable.
 
-All components are permissively licensed: FastAPI (MIT), Prometheus +
-graphite_exporter (Apache-2.0), Chart.js (MIT).
+This tool vendors no third-party code. Dependencies (FastAPI, uvicorn,
+Jinja2, boto3) are installed via pip; Chart.js is loaded from CDN at runtime;
+the optional Observability backend connects to a user-operated Prometheus
+over HTTP. Consult each project's license for your own compliance needs.

--- a/utilities/EMR-Serverless-Config-Advisor/app.py
+++ b/utilities/EMR-Serverless-Config-Advisor/app.py
@@ -1,0 +1,1801 @@
+#!/usr/bin/env python3
+"""
+EMR Serverless Advisor — FastAPI Web UI
+=======================================
+Landing page navigates to:
+  - Config Advisor: upload extracted event log JSON (task_stage_summary output
+    from spark_extractor.py) for bottleneck classification, worker sizing, and
+    Spark config recommendations
+  - Observability: live driver/executor metrics (heap, RSS, CPU, GC) from
+    Prometheus for metrics-enabled job runs
+
+Run:
+    screen -S emr-serverless-advisor python3 app.py
+API docs (auto-generated): http://localhost:5000/docs
+"""
+
+import gzip
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.parse
+import urllib.request
+import zipfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import uvicorn
+from fastapi import FastAPI, File, Request, UploadFile
+from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+# Import the fine tuner for recommendations
+from emr_s_fine_tuner import generate_dual_recommendations
+
+BASE_DIR = Path(__file__).resolve().parent
+
+app = FastAPI(title="EMR Serverless Advisor")
+app.mount("/static", StaticFiles(directory=BASE_DIR / "static"), name="static")
+templates = Jinja2Templates(directory=BASE_DIR / "templates")
+
+
+def _asset_v(name: str) -> int:
+    """Cache-busting version for static assets: the file's mtime, so any
+    edit to a stylesheet invalidates browser caches automatically."""
+    try:
+        return int((BASE_DIR / "static" / name).stat().st_mtime)
+    except OSError:
+        return 0
+
+
+templates.env.globals["asset_v"] = _asset_v
+
+UPLOAD_DIR = Path(tempfile.gettempdir()) / "emr_config_advisor_uploads"
+UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+MAX_UPLOAD_BYTES = 500 * 1024 * 1024  # 500MB max upload
+
+PROMETHEUS_URL = os.environ.get("PROMETHEUS_URL", "http://localhost:9090")
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Newest EMR release — drives the Upgrade action on the home page
+EMR_LATEST_RELEASE = os.environ.get("EMR_LATEST_RELEASE", "emr-8.0.0")
+
+# EMR Serverless billing rates (us-east-1 x86 defaults; override per region)
+EMRS_PRICE = {
+    "vcpu_hour": float(os.environ.get("EMRS_PRICE_VCPU_HOUR", "0.052624")),
+    "gb_hour": float(os.environ.get("EMRS_PRICE_GB_HOUR", "0.0057785")),
+    "storage_gb_hour": float(os.environ.get("EMRS_PRICE_STORAGE_GB_HOUR", "0.000111")),
+}
+
+
+def _emrs_cost_usd(vcpu_hours: float, gb_hours: float,
+                   storage_gb_hours: float = 0.0) -> float:
+    return round(vcpu_hours * EMRS_PRICE["vcpu_hour"]
+                 + gb_hours * EMRS_PRICE["gb_hour"]
+                 + storage_gb_hours * EMRS_PRICE["storage_gb_hour"], 4)
+
+
+def _parse_mem_gb(v: str) -> float:
+    m = re.match(r"([\d.]+)\s*([gmt]?)", str(v).lower())
+    if not m:
+        return 0.0
+    n, unit = float(m.group(1)), m.group(2)
+    return n / 1024 if unit == "m" else n * 1024 if unit == "t" else n
+
+
+def _run_cost(result: dict) -> dict | None:
+    """EMR-S billing units for an analyzed run.
+
+    Prefers billedResourceUtilization from the EMR API (spark.app.id in the
+    event log IS the job run id) — exact, matches the console. Otherwise
+    estimates from the event log: per-executor add→remove lifetimes ×
+    (heap+overhead rounded up to whole GB). Estimates run LOW (~10-25%)
+    because billing includes worker provisioning/teardown time that never
+    appears in the event log; validated -19% vs billed on a known run.
+    """
+    cfg = result.get("spark_config_source") or {}
+    app_id = cfg.get("spark.app.id", "")
+    if _JOB_RUN_ID_RE.match(app_id):
+        try:
+            emr_app = _find_application_for_job(app_id)
+            if emr_app:
+                jr = _emr().get_job_run(applicationId=emr_app,
+                                        jobRunId=app_id)["jobRun"]
+                b = jr.get("billedResourceUtilization")
+                if b:
+                    vcpu, mem = b.get("vCPUHour", 0), b.get("memoryGBHour", 0)
+                    sto = b.get("storageGBHour", 0)
+                    return {"source": "billed", "vcpu_hours": vcpu,
+                            "memory_gb_hours": mem, "storage_gb_hours": sto,
+                            "cost_usd": _emrs_cost_usd(vcpu, mem, sto)}
+        except Exception:
+            pass
+
+    dur = result.get("duration_hours") or 0
+    execs = result.get("metrics_summary", {}).get("total_executors", 0)
+    if not dur or not execs:
+        return None
+    is_ec2_source = bool(cfg.get("spark.emr_cluster_id"))
+    exec_cores = int(cfg.get("spark.executor.cores", 4))
+    drv_cores = int(cfg.get("spark.driver.cores", 4))
+    # EMR Serverless bills the worker memory = executor heap + overhead
+    # (memoryOverheadFactor, default 0.1)
+    overhead = 1 + float(cfg.get("spark.emr-serverless.memoryOverheadFactor",
+                                 cfg.get("spark.kubernetes.memoryOverheadFactor",
+                                         0.1)))
+    # Billed worker memory is heap+overhead rounded UP to the whole GB
+    # (verified against billedResourceUtilization: 27G heap -> 30 GB billed)
+    import math
+    exec_mem = math.ceil(
+        _parse_mem_gb(cfg.get("spark.executor.memory", "14g")) * overhead)
+    drv_mem = math.ceil(
+        _parse_mem_gb(cfg.get("spark.driver.memory", "14g")) * overhead)
+
+    # Prefer lifetime-aware executor hours (extractor sums per-executor
+    # add→remove uptime from the event log) over executors × app duration —
+    # with dynamic allocation those differ a lot
+    es = result.get("_executor_summary") or {}
+    exec_core_hours = es.get("total_available_core_hours")
+    exec_uptime_hours = es.get("total_uptime_hours")
+    if exec_core_hours:
+        vcpu = exec_core_hours + drv_cores * dur
+        mem = (exec_uptime_hours or exec_core_hours / max(exec_cores, 1)) \
+            * exec_mem + drv_mem * dur
+        basis = "estimated (per-executor lifetimes)"
+    else:
+        vcpu = (execs * exec_cores + drv_cores) * dur
+        mem = (execs * exec_mem + drv_mem) * dur
+        basis = "estimated (executors x duration)"
+
+    # Storage bills only beyond the free 20GB per worker
+    disk_gb = _parse_mem_gb(cfg.get("spark.emr-serverless.executor.disk", "20g"))
+    billable_disk = max(0.0, disk_gb - 20.0)
+    sto = billable_disk * (exec_uptime_hours or execs * dur)
+    if is_ec2_source:
+        # EC2 runs bill EC2 instance-hours, not EMR-S units. This figure is
+        # "what these resource-hours WOULD cost on Serverless" — useful for
+        # migration comparisons, labeled so nobody mistakes it for the bill.
+        basis = "hypothetical Serverless cost (EC2 source)"
+    return {"source": basis, "vcpu_hours": round(vcpu, 3),
+            "memory_gb_hours": round(mem, 3),
+            "storage_gb_hours": round(sto, 3),
+            "cost_usd": _emrs_cost_usd(vcpu, mem, sto)}
+
+# AWS managed Spark Troubleshooting Agent (SigV4 MCP endpoint). Set to e.g.
+# https://sagemaker-unified-studio-mcp.us-east-1.api.aws/spark-troubleshooting/mcp
+# after deploying the spark-troubleshooting-mcp-setup CloudFormation stack.
+SPARK_TROUBLESHOOTING_MCP_URL = os.environ.get("SPARK_TROUBLESHOOTING_MCP_URL", "")
+
+
+def _advisor_home() -> Path:
+    """Directory holding python_extractor.py / emr_s_fine_tuner.py."""
+    return Path(os.environ.get("CONFIG_ADVISOR_HOME") or BASE_DIR)
+
+# EMR Serverless client for the Application -> Job run selector (read-only:
+# list_applications / list_job_runs). Lazy so the UI still works without
+# AWS credentials — the dashboard then falls back to raw Prometheus app_ids.
+_emr_client = None
+
+
+def _emr():
+    global _emr_client
+    if _emr_client is None:
+        import boto3
+        from botocore.config import Config
+        _emr_client = boto3.client(
+            "emr-serverless", region_name=AWS_REGION,
+            config=Config(retries={"mode": "adaptive", "max_attempts": 8}),
+        )
+    return _emr_client
+
+
+# EMR Serverless job run ids look like 00abc123def456gh; anything else in the
+# app_id label is a synthetic test series.
+_JOB_RUN_ID_RE = re.compile(r"^[0-9a-z]{16}$")
+
+# ListJobRuns throttles at very low TPS — cache the app->jobs resolution.
+_APPS_CACHE = {}  # hours -> (expires_epoch, payload)
+_APPS_CACHE_TTL = 120
+
+# --- AI chat assistant (Bedrock) ---
+MODEL_ID = os.environ.get("MODEL_ID", "global.anthropic.claude-sonnet-4-6")
+_bedrock_client = None
+
+
+def _bedrock():
+    global _bedrock_client
+    if _bedrock_client is None:
+        import boto3
+        _bedrock_client = boto3.client("bedrock-runtime", region_name=AWS_REGION)
+    return _bedrock_client
+
+
+CHAT_SYSTEM_PROMPT = """You are the EMR Serverless Advisor assistant, an
+agentic helper embedded in a web UI with two tools: Config Advisor (event-log
+analysis producing bottleneck classification and worker sizing
+recommendations) and Observability (live Prometheus metrics for
+driver/executors: heap, RSS, CPU, GC, disk, tasks).
+
+PRODUCT CAPABILITIES — never claim the UI lacks these; direct users to them:
+- Config Advisor page accepts UPLOADS of raw Spark event logs from BOTH
+  EMR Serverless AND EMR on EC2 (YARN application_* logs): single files
+  (plain/.gz/.zstd/rolling events_N), or a .zip of the log directory. It
+  also accepts pre-extracted task_stage_summary JSONs. Extraction happens
+  server-side; no Spark needed.
+- EC2 logs are auto-detected (spark.emr_cluster_id) and routed through the
+  EC2→Serverless migration branch: it translates instance-based sizing to
+  Serverless workers, applies a Serverless efficiency gain to fleet sizing,
+  and always maxes worker memory tier (EC2 peak metrics undercount
+  Serverless needs). The result IS the migration recommendation.
+- 'Compare two runs' on the same page diffs two event logs side by side:
+  metric deltas, config diff, per-stage CPU-per-GB analysis.
+- Home page lists applications/job runs with Optimize / Troubleshoot /
+  Upgrade actions; Observability shows live metrics for metrics-enabled runs.
+
+GROUNDING DISCIPLINE: always state WHICH run/application id an answer is
+based on. If the user references a run or file that is NOT the one in your
+context (e.g. an EC2 application_* id while your context holds a Serverless
+run), say so explicitly and either use get_recent_analyses to find it or
+tell them to upload it on the Config Advisor page — do not answer about one
+run while appearing to describe another.
+
+HARD GUARDRAILS — violating these is worse than a useless answer:
+1. NEVER build a "recommended vs actually-run" config table yourself. Each
+   analysis carries config_audit, computed deterministically in code with
+   statuses match/differs/absent/unknown-not-in-event-log — quote it
+   verbatim. If config_audit is missing, say the comparison isn't available.
+2. EVENT-LOG BLIND SPOTS: submit-only params (spark.emr-serverless.executor.
+   disk / disk.type, memoryOverheadFactor) and dynamicAllocation min/initial
+   values NEVER reliably appear in event-log Spark conf. A value absent from
+   the event log is NOT evidence it was unset — say "not visible in event
+   logs; check the submitted job parameters" and ask the user for their
+   submit config when it matters.
+3. NUMBERS BEFORE NARRATIVE: call the relevant tool (or quote the exact
+   context field) BEFORE stating any metric. Never state a score, count, or
+   config value you have not read in this conversation. If you catch
+   yourself writing a table with values you didn't fetch, stop and fetch.
+4. Predicted improvements ("spill drops 80-90%") are ESTIMATES — label them
+   as such, with the assumption they rest on. Never present a prediction in
+   the same voice as a measured number.
+5. When two analyses disagree (e.g. EC2-migration recommendation vs the
+   Serverless-native one), present both with their sources and dates and say
+   which one you'd act on and why — do not silently merge them.
+
+You have tools. USE THEM before answering — do not guess:
+- get_job_config: the job run's actual submitted Spark confs, worker sizes,
+  and state from the EMR Serverless API
+- get_metrics_snapshot: per-worker heap/RSS/CPU/GC/disk/task summary from
+  Prometheus for a job run
+- query_prometheus: any PromQL range query for drill-down (metric names use
+  labels app_id=<job_run_id>, exec_id=driver|1|2|…)
+- get_recent_analyses: Config Advisor results analyzed this session
+  (bottleneck scores, recommended cost/perf configs)
+- run_config_advisor: full pipeline on a job run's event log — bottleneck
+  classification + cost/perf recommendations (slow, 30-120s; use for
+  "optimize this job")
+- troubleshoot_job: failure evidence — state details, driver stderr errors,
+  and the AWS managed Spark Troubleshooting Agent analysis when configured
+- get_application_details: release label vs latest EMR, capacity, network
+- tshirt_sizing: for BRAND-NEW jobs with no run history — buckets the
+  workload into our t-shirt sizes (XS/S/M/L/XL × General/Optimized/
+  IO-Optimized/Iceberg-Maintenance) and returns worker type + full configs.
+  Ask the user what they know (input GB, joins, shuffle, SLA, file count)
+  and pass everything they give you; defaults cover the rest. For jobs that
+  HAVE run, prefer run_config_advisor on the event log instead.
+
+For "upgrade" requests: compare release_label to latest_release, then walk
+through what changes between those EMR releases (Spark/Java/Scala major
+versions, default conf changes, deprecations) and give a migration checklist
+including validation steps. Note EMR 7.x → 8.x moves to Spark 4.x: check
+ANSI SQL mode becoming default, removed Spark 2-era APIs, and Java 17+.
+For the code-migration step itself, recommend the AWS Apache Spark Upgrade
+Agent (managed SageMaker Unified Studio MCP server, used from an MCP client
+such as Kiro CLI or Claude Code against the job's source repo): it plans the
+upgrade, transforms PySpark/Scala code, fixes builds, and submits validation
+jobs to EMR — see
+https://docs.aws.amazon.com/emr/latest/ReleaseGuide/spark-upgrades.html.
+Your checklist should cover what to verify before and after running it.
+
+Cross-reference config and metrics: e.g. compare submitted
+spark.executor.memory against observed RSS/heap max, or recommended configs
+against what the job actually ran with. Quote actual numbers. Be concise and
+actionable: name the config or worker change, then justify it.
+
+Key domain facts:
+- Container RSS (ProcessTree JVM+Python+Other) near the worker memory limit
+  means the cgroup OOM-killer (exit 137) is close; heap-only pressure shows
+  as GC ms/s climbing and heap plateauing near heap max.
+- spark.driver.maxResultSize aborts large collects; driver heap holds
+  collected results, so parallel collects need driver heap sized for the sum.
+- EMR Serverless workers: 4 vCPU/16-30GB, 8 vCPU/32-60GB, 16 vCPU/64-120GB;
+  dynamic allocation minimum is 3 executors.
+- Memory spill + disk spill together = severe executor memory pressure;
+  fix with fewer cores per executor, more memory per core, or more partitions.
+- EMR Serverless bills per-second on vCPU-hours, memory GB-hours, and storage
+  GB-hours (beyond the free 20GB/worker). us-east-1 x86: ~$0.052624/vCPU-h,
+  ~$0.0057785/GB-h, ~$0.000111/storage-GB-h. get_job_config returns the run's
+  billed totalResourceUtilization — use it to quantify savings in dollars
+  when recommending sizing changes. run_cost marked "estimated" comes from
+  event-log executor lifetimes and runs 10-25% LOW (billing includes worker
+  provisioning time invisible to the event log) — say so when citing it;
+  values marked "billed" are exact and match the AWS console.
+Run-comparison analysis playbook (page_context.stage_comparison carries
+matched per-stage CPU/GB when comparing two runs — use it):
+1. Localize before theorizing: find the stage(s) whose CPU-per-GB inflated
+   on identical data. If one stage owns the delta, the diagnosis is about
+   that stage's operation (write/sort/join), not the whole job.
+2. Same-stage CPU/GB inflation with unchanged data means the same work
+   burned more cycles — the causes are worker-level: concurrent tasks per
+   JVM sharing memory bandwidth/cache (stalled cycles bill as CPU time),
+   GC pressure (large heap at high occupancy runs concurrent marking that
+   task GC-time metrics do NOT capture), or codec/write-path changes.
+   Check config_diff for executor.cores and executor.memory changes.
+3. Distribution check: if p50 task time is flat but p90/p99 doubled, only
+   heavy tasks suffer — classic shared-resource contention. Uniform
+   slowdown suggests codec/serialization/environment change instead.
+4. Heap occupancy is NOT memory demand: JVM heap fills toward whatever
+   ceiling it has (GC defers collection on big heaps). Judge memory need
+   from the smaller-heap run's peak + spill, normalized per core.
+5. Spill is often cheap: sequential spill I/O shows as wait, not CPU.
+   Weigh measured spill cost (fetch-wait %, "other" time) against the
+   price of the memory that would eliminate it before recommending
+   bigger workers. Fix spill with memory-per-core, not worker class.
+6. Sort-heavy write stages (overwritePartitions, sortWithinPartitions)
+   prefer scale-OUT (more small workers, cache-friendly working sets);
+   scale-UP pays only when coordination/fetch-wait dominates.
+Quantify each claim from the context data and name the config change.
+
+MIGRATION mode (page = ec2-serverless-migration; Run A = EC2 baseline,
+Run B = Serverless attempt): the user is troubleshooting an unacceptable
+Serverless result. Method: (1) normalize before comparing — EC2 task-hours
+include YARN scheduling/spot-loss waste that Serverless avoids; compare
+per-stage CPU-per-GB, not wall-clock alone. (2) Check the Serverless config
+against the migration translation (worker memory should be at tier max,
+disk sized for shuffle). (3) Common migration regressions: undersized
+executor disk (EC2 had big instance stores), missing spark.network.timeout
+increases, maxExecutors too low vs the EC2 fleet's peak cores, and
+memory-per-core changes altering sort/shuffle behavior. (4) EC2 cost in
+context is hypothetical-Serverless — for a true dollar comparison ask the
+user for their EC2 instance-hours bill.
+
+QUERY PLANS: each analysis carries query_plans — per-SQL-execution physical
+operator trees (like the Spark UI SQL tab) with metrics resolved from
+accumulators (rows, bytes, spill, peak memory, shuffle write) and, when
+tasks failed, per-operator "failures" entries: which stage failed on that
+operator, task counts, reasons (FetchFailed / ExecutorLostFailure /
+Resubmitted), and a sample error message. For "which operator failed" or
+"where in the query" questions, walk query_plans and cite the operator
+chain (e.g. Exchange <- Sort <- Window), its stage id, the reason, and the
+sample message. Distinguish origin from casualty: ExecutorLostFailure with
+exit 137 marks WHERE the executor died; FetchFailed/Resubmitted on other
+operators are downstream casualties of that death — name the 137 site as
+the root. Operator metrics (peak memory, spill size) tell you WHY it died
+there.
+
+FAILURE questions ("why did tasks fail"): ground in the actual failure
+counts now present in metrics_summary (failed_tasks, killed_tasks,
+failed_stages, dead_executors, dead_executor_reasons) — a handful of failed
+tasks out of thousands with automatic retries is NORMAL Spark operation and
+must not be narrated as a crisis. Only build a failure story from spill/
+memory metrics when failure counts are material (>1% of tasks, failed
+stages, or dead executors with OOM/killed reasons). For EMR Serverless runs
+in this account, troubleshoot_job gives stateDetails + driver stderr; for
+uploaded EC2 logs, say what evidence the event log does and doesn't carry.
+
+If the tools lack what you need, say what is missing and how to get it — do
+not invent numbers."""
+
+
+# job_run_id -> application_id, filled by the selector endpoints and used by
+# the chat agent's get_job_config tool
+_JOB_TO_APP = {}
+
+# Config Advisor results analyzed this session, for the chat agent
+_RECENT_ANALYSES = []
+_RECENT_ANALYSES_MAX = 5
+
+
+def _find_application_for_job(job_run_id: str, days: int = 7):
+    """Resolve a job run id to its application id (cached, bounded search)."""
+    if job_run_id in _JOB_TO_APP:
+        return _JOB_TO_APP[job_run_id]
+    created_after = datetime.now(timezone.utc) - timedelta(days=days)
+    apps = []
+    for page in _emr().get_paginator("list_applications").paginate():
+        apps.extend(page["applications"])
+    apps = [a for a in apps if (a.get("updatedAt") or created_after) >= created_after]
+    apps.sort(key=lambda a: a.get("updatedAt") or created_after, reverse=True)
+    for a in apps[:10]:
+        for page in _emr().get_paginator("list_job_runs").paginate(
+            applicationId=a["id"], createdAtAfter=created_after,
+        ):
+            for jr in page["jobRuns"]:
+                _JOB_TO_APP[jr["id"]] = a["id"]
+        if job_run_id in _JOB_TO_APP:
+            return _JOB_TO_APP[job_run_id]
+    return None
+
+
+def _metrics_snapshot(job_id: str, hours: int = 6) -> dict:
+    """Compact per-worker metrics summary for one job run, for AI grounding."""
+    end = int(time.time())
+    start = end - hours * 3600
+    GB = 1024 ** 3
+
+    def qr(query):
+        params = urllib.parse.urlencode(
+            {"query": query, "start": start, "end": end, "step": "60s"})
+        url = f"{PROMETHEUS_URL}/api/v1/query_range?{params}"
+        with urllib.request.urlopen(url, timeout=15) as resp:
+            return json.load(resp)["data"]["result"]
+
+    sel = f'app_id="{job_id}"'
+    snapshot = {"job_run_id": job_id, "window_hours": hours}
+
+    def series_stats(query, scale=1.0):
+        out = {}
+        for s in qr(query):
+            vals = [float(v) * scale for _, v in s["values"]]
+            exec_id = s["metric"].get("exec_id", "?")
+            out[exec_id] = {"last": round(vals[-1], 2), "max": round(max(vals), 2)}
+        return out
+
+    snapshot["heap_used_gb"] = series_stats(f'spark_jvm_heap_used{{{sel}}}', 1 / GB)
+    snapshot["heap_max_gb"] = series_stats(f'spark_jvm_heap_max{{{sel}}}', 1 / GB)
+    snapshot["rss_gb"] = series_stats(
+        f'sum by (exec_id) ({{__name__=~"spark_executor_metrics_ProcessTree(JVM|Python|Other)RSSMemory", {sel}}})',
+        1 / GB)
+    snapshot["cpu_cores"] = series_stats(f'rate(spark_jvm_cpu_time_ns{{{sel}}}[2m]) / 1e9')
+    snapshot["gc_ms_per_s"] = series_stats(
+        f'sum by (exec_id) (rate(spark_executor_metrics_TotalGCTime{{{sel}}}[2m]))')
+    snapshot["disk_used_gb"] = series_stats(
+        f'spark_blockmanager_disk_diskSpaceUsed_MB{{{sel}}} / 1024')
+    snapshot["active_tasks"] = series_stats(
+        f'spark_executor_threadpool_activeTasks{{{sel}}}')
+    for name, q in [
+        ("jobs_succeeded", f'spark_app_jobs_succeededJobs{{{sel}}}'),
+        ("jobs_failed", f'spark_app_jobs_failedJobs{{{sel}}}'),
+        ("stages_completed", f'spark_app_stages_completedStages{{{sel}}}'),
+        ("stages_failed", f'spark_app_stages_failedStages{{{sel}}}'),
+        ("tasks_completed", f'spark_app_tasks_completedTasks{{{sel}}}'),
+        ("tasks_failed", f'spark_app_tasks_failedTasks{{{sel}}}'),
+    ]:
+        st = series_stats(q)
+        snapshot[name] = st.get("driver", {}).get("max", 0) if st else 0
+    return snapshot
+
+
+# ---- chat agent tools ----
+
+def _tool_tshirt_sizing(**kwargs) -> dict:
+    """Bucket a BRAND-NEW job (no event log yet) into our t-shirt sizes.
+
+    Wraps emr_s_tshirt_size.select_bucket: Size (XS|S|M|L|XL) × sub-category
+    (General | Optimized | IO-Optimized | Iceberg-Maintenance).
+    """
+    if str(_advisor_home()) not in sys.path:
+        sys.path.insert(0, str(_advisor_home()))
+    from emr_s_tshirt_size import WorkloadIntent, select_bucket
+
+    valid = {f.name for f in WorkloadIntent.__dataclass_fields__.values()}
+    params = {k: v for k, v in kwargs.items() if k in valid and v is not None}
+    # select_bucket detects heavy shuffle via shuffle_ratio_pct — derive it
+    # when the caller gave absolute volumes
+    if ("shuffle_ratio_pct" not in params and params.get("shuffle_write_gb")
+            and params.get("input_size_gb")):
+        params["shuffle_ratio_pct"] = round(
+            100.0 * params["shuffle_write_gb"] / params["input_size_gb"], 1)
+    intent = WorkloadIntent(**params)
+    b = select_bucket(intent)
+    return {
+        "bucket": b.label,
+        "size": b.size,
+        "sub_category": b.sub_bucket,
+        "worker_type": b.worker_type,
+        "rationale": b.rationale,
+        "spark_configs": b.configs,
+        "spark_submit_params": " ".join(
+            f"--conf {k}={v}" for k, v in sorted(b.configs.items())),
+    }
+
+
+def _tool_get_application_details(application_id: str) -> dict:
+    """Application config incl. release label, compared to the latest EMR."""
+    a = _emr().get_application(applicationId=application_id)["application"]
+    release = a.get("releaseLabel", "")
+    return {
+        "application_id": application_id,
+        "name": a.get("name", ""),
+        "state": a.get("state", ""),
+        "release_label": release,
+        "latest_release": EMR_LATEST_RELEASE,
+        "upgrade_available": release != EMR_LATEST_RELEASE,
+        "architecture": a.get("architecture", ""),
+        "maximum_capacity": {k: str(v) for k, v in
+                             (a.get("maximumCapacity") or {}).items()},
+        "auto_stop": a.get("autoStopConfiguration", {}).get("enabled"),
+        "network_configuration": bool(a.get("networkConfiguration")),
+        "created_at": a["createdAt"].isoformat(),
+    }
+
+
+def _tool_run_config_advisor(job_run_id: str) -> dict:
+    """Full Config Advisor pipeline on a finished job run: locate the event
+    log from the job's S3 monitoring config, extract, and recommend."""
+    cfg = _tool_get_job_config(job_run_id)
+    if "error" in cfg:
+        return cfg
+    app_id = cfg["application_id"]
+    jr = _emr().get_job_run(applicationId=app_id, jobRunId=job_run_id)["jobRun"]
+    log_uri = (jr.get("configurationOverrides", {})
+                 .get("monitoringConfiguration", {})
+                 .get("s3MonitoringConfiguration", {})
+                 .get("logUri", ""))
+    if not log_uri:
+        return {"error": "job has no S3 monitoring logUri — cannot locate the "
+                         "Spark event log. Enable S3 monitoring on the job."}
+    sparklogs = (f"{log_uri.rstrip('/')}/applications/{app_id}/jobs/"
+                 f"{job_run_id}/sparklogs/")
+
+    work = Path(tempfile.mkdtemp(prefix=f"advisor_{job_run_id}_"))
+    local_logs = work / "eventlog"
+    local_logs.mkdir()
+    r = subprocess.run(
+        ["aws", "s3", "sync", sparklogs, str(local_logs), "--region", AWS_REGION],
+        capture_output=True, text=True, timeout=300)
+    if r.returncode != 0 or not any(local_logs.iterdir()):
+        return {"error": f"event log download failed from {sparklogs}: "
+                         f"{r.stderr.strip()[:400]}"}
+
+    # Rolling event logs land as eventlog_v2_<appId>/ — --single-app wants
+    # that inner directory, not its parent
+    inner = [d for d in local_logs.iterdir() if d.is_dir()
+             and d.name.startswith("eventlog_v2")]
+    extract_input = inner[0] if inner else local_logs
+
+    extracted = work / "extracted"
+    r = subprocess.run(
+        [sys.executable, str(_advisor_home() / "python_extractor.py"),
+         "--input", str(extract_input), "--output", str(extracted),
+         "--single-app"],
+        capture_output=True, text=True, timeout=600, cwd=str(_advisor_home()))
+    if r.returncode != 0:
+        return {"error": f"extractor failed: {r.stderr.strip()[:400]}"}
+
+    tss = extracted / "task_stage_summary"
+    files = list(tss.glob("*.json")) if tss.is_dir() else []
+    if not files:
+        return {"error": "extractor produced no task_stage_summary JSON"}
+    result = analyze_uploaded_file(str(files[0]))
+    # Trim for the model: drop the verbose source config
+    result.pop("spark_config_source", None)
+    return result
+
+
+def _tool_troubleshoot_job(job_run_id: str) -> dict:
+    """Failure evidence for a job run: state details + driver stderr tail.
+
+    If SPARK_TROUBLESHOOTING_MCP_URL is configured, also calls the AWS
+    managed Spark Troubleshooting Agent (analyze_spark_workload) and
+    includes its analysis verbatim.
+    """
+    cfg = _tool_get_job_config(job_run_id)
+    if "error" in cfg:
+        return cfg
+    app_id = cfg["application_id"]
+    jr = _emr().get_job_run(applicationId=app_id, jobRunId=job_run_id)["jobRun"]
+    out = {
+        "job_run_id": job_run_id,
+        "application_id": app_id,
+        "state": jr.get("state", ""),
+        "state_details": jr.get("stateDetails", ""),
+        "spark_confs": cfg.get("spark_confs", {}),
+    }
+
+    # Driver stderr tail from the S3 monitoring location
+    log_uri = (jr.get("configurationOverrides", {})
+                 .get("monitoringConfiguration", {})
+                 .get("s3MonitoringConfiguration", {})
+                 .get("logUri", ""))
+    if log_uri:
+        stderr_key = (f"{log_uri.rstrip('/')}/applications/{app_id}/jobs/"
+                      f"{job_run_id}/SPARK_DRIVER/stderr.gz")
+        try:
+            import boto3
+            s3 = boto3.client("s3", region_name=AWS_REGION)
+            m = re.match(r"s3://([^/]+)/(.+)", stderr_key)
+            obj = s3.get_object(Bucket=m.group(1), Key=m.group(2))
+            text = gzip.decompress(obj["Body"].read()).decode("utf-8", "replace")
+            # Errors cluster at the end; keep exception lines + the tail
+            lines = text.splitlines()
+            err_lines = [ln for ln in lines
+                         if re.search(r"ERROR|Exception|OutOfMemory|Killed|137",
+                                      ln)][-40:]
+            out["driver_stderr_errors"] = err_lines
+            out["driver_stderr_tail"] = lines[-60:]
+        except Exception as e:
+            out["driver_stderr_error"] = f"could not fetch driver stderr: {e}"
+    else:
+        out["driver_stderr_error"] = "job has no S3 monitoring logUri"
+
+    # Optional: AWS managed Spark Troubleshooting Agent (SigV4 MCP endpoint)
+    if SPARK_TROUBLESHOOTING_MCP_URL:
+        try:
+            out["aws_troubleshooting_agent"] = _call_aws_troubleshooting_mcp(
+                app_id, job_run_id)
+        except Exception as e:
+            out["aws_troubleshooting_agent_error"] = str(e)
+    else:
+        out["aws_troubleshooting_agent"] = (
+            "not configured — set SPARK_TROUBLESHOOTING_MCP_URL (deploy the "
+            "spark-troubleshooting-mcp-setup CloudFormation stack) to include "
+            "the AWS managed agent's analysis")
+    return out
+
+
+def _call_aws_troubleshooting_mcp(application_id: str, job_run_id: str) -> dict:
+    """Call analyze_spark_workload on the AWS managed MCP server (SigV4)."""
+    import boto3
+    from botocore.auth import SigV4Auth
+    from botocore.awsrequest import AWSRequest
+
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "analyze_spark_workload",
+                   "arguments": {"platform": "EMR_SERVERLESS",
+                                 "applicationId": application_id,
+                                 "jobRunId": job_run_id}},
+    }).encode()
+    req = AWSRequest(method="POST", url=SPARK_TROUBLESHOOTING_MCP_URL,
+                     data=payload,
+                     headers={"Content-Type": "application/json",
+                              "Accept": "application/json, text/event-stream"})
+    creds = boto3.Session().get_credentials().get_frozen_credentials()
+    SigV4Auth(creds, "sagemaker-unified-studio-mcp", AWS_REGION).add_auth(req)
+    http_req = urllib.request.Request(
+        SPARK_TROUBLESHOOTING_MCP_URL, data=payload,
+        headers=dict(req.headers), method="POST")
+    with urllib.request.urlopen(http_req, timeout=180) as resp:
+        return json.load(resp)
+
+
+def _tool_get_job_config(job_run_id: str) -> dict:
+    """Submitted Spark confs + state for a job run (EMR Serverless API)."""
+    app_id = _find_application_for_job(job_run_id)
+    if not app_id:
+        return {"error": f"could not locate application for job run {job_run_id}"}
+    jr = _emr().get_job_run(applicationId=app_id, jobRunId=job_run_id)["jobRun"]
+    spark_submit = jr.get("jobDriver", {}).get("sparkSubmit", {})
+    confs = {}
+    for part in spark_submit.get("sparkSubmitParameters", "").split("--conf"):
+        part = part.strip()
+        if "=" in part:
+            k, _, v = part.partition("=")
+            confs[k.strip()] = v.strip()
+    return {
+        "job_run_id": job_run_id,
+        "application_id": app_id,
+        "name": jr.get("name", ""),
+        "state": jr.get("state", ""),
+        "state_details": jr.get("stateDetails", ""),
+        "created_at": jr["createdAt"].isoformat(),
+        "entry_point": spark_submit.get("entryPoint", ""),
+        "entry_point_arguments": spark_submit.get("entryPointArguments", []),
+        "spark_confs": confs,
+        "total_resource_utilization": {
+            k: str(v) for k, v in (jr.get("totalResourceUtilization") or {}).items()
+        },
+    }
+
+
+def _tool_query_prometheus(query: str, hours: int = 6) -> dict:
+    """Arbitrary PromQL range query, compacted for the model."""
+    end = int(time.time())
+    start = end - min(hours, 168) * 3600
+    params = urllib.parse.urlencode(
+        {"query": query, "start": start, "end": end, "step": "60s"})
+    url = f"{PROMETHEUS_URL}/api/v1/query_range?{params}"
+    with urllib.request.urlopen(url, timeout=15) as resp:
+        results = json.load(resp)["data"]["result"]
+    out = []
+    for s in results[:20]:
+        vals = [float(v) for _, v in s["values"]]
+        out.append({
+            "labels": {k: v for k, v in s["metric"].items()
+                       if k not in ("instance", "job")},
+            "min": min(vals), "max": max(vals), "last": vals[-1],
+            "points": len(vals),
+        })
+    return {"series_count": len(results), "series": out}
+
+
+CHAT_TOOLS = [
+    {"toolSpec": {
+        "name": "get_job_config",
+        "description": "Fetch the actual submitted Spark confs, entry point, worker sizing, state, and billed resource usage for an EMR Serverless job run.",
+        "inputSchema": {"json": {
+            "type": "object",
+            "properties": {"job_run_id": {"type": "string", "description": "EMR Serverless job run id, e.g. 00abc123def456gh"}},
+            "required": ["job_run_id"],
+        }},
+    }},
+    {"toolSpec": {
+        "name": "get_metrics_snapshot",
+        "description": "Per-worker summary (heap used/max GB, container RSS GB, CPU cores, GC ms/s, disk GB, active tasks, job/stage/task counts) from Prometheus for one job run.",
+        "inputSchema": {"json": {
+            "type": "object",
+            "properties": {
+                "job_run_id": {"type": "string"},
+                "hours": {"type": "integer", "description": "lookback window, default 6"},
+            },
+            "required": ["job_run_id"],
+        }},
+    }},
+    {"toolSpec": {
+        "name": "query_prometheus",
+        "description": "Run any PromQL range query for drill-down (60s step). Metrics: spark_jvm_heap_used/max, spark_executor_metrics_ProcessTree{JVM,Python,Other}RSSMemory, spark_jvm_cpu_time_ns, spark_executor_metrics_TotalGCTime, spark_blockmanager_disk_diskSpaceUsed_MB, spark_executor_threadpool_activeTasks, spark_app_*, spark_dagscheduler_*. Labels: app_id=<job_run_id>, exec_id=driver|1|2|…",
+        "inputSchema": {"json": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "hours": {"type": "integer", "description": "lookback window, default 6"},
+            },
+            "required": ["query"],
+        }},
+    }},
+    {"toolSpec": {
+        "name": "get_recent_analyses",
+        "description": "Config Advisor analyses run in this UI session: bottleneck classification/scores, metrics summary, source Spark config, and recommended cost/performance configs.",
+        "inputSchema": {"json": {"type": "object", "properties": {}}},
+    }},
+    {"toolSpec": {
+        "name": "run_config_advisor",
+        "description": "Run the FULL Config Advisor pipeline on a finished job run: downloads its Spark event log from S3, extracts metrics, and returns bottleneck classification plus cost- and performance-optimized worker/config recommendations. Takes 30-120s. Use for 'optimize this job' requests.",
+        "inputSchema": {"json": {
+            "type": "object",
+            "properties": {"job_run_id": {"type": "string"}},
+            "required": ["job_run_id"],
+        }},
+    }},
+    {"toolSpec": {
+        "name": "troubleshoot_job",
+        "description": "Gather failure evidence for a job run: state details, submitted confs, driver stderr error lines and tail from S3, and (when configured) the AWS managed Spark Troubleshooting Agent's analysis. Use for failed or cancelled runs.",
+        "inputSchema": {"json": {
+            "type": "object",
+            "properties": {"job_run_id": {"type": "string"}},
+            "required": ["job_run_id"],
+        }},
+    }},
+    {"toolSpec": {
+        "name": "get_application_details",
+        "description": "EMR Serverless application details: release label (vs latest EMR release), capacity limits, architecture, network config. Use for upgrade questions.",
+        "inputSchema": {"json": {
+            "type": "object",
+            "properties": {"application_id": {"type": "string"}},
+            "required": ["application_id"],
+        }},
+    }},
+    {"toolSpec": {
+        "name": "tshirt_sizing",
+        "description": "Size a BRAND-NEW job with no run history into our t-shirt buckets (XS/S/M/L/XL x General/Optimized/IO-Optimized/Iceberg-Maintenance). Returns worker type, full Spark configs, spark-submit params, and rationale. Gather what the user knows about the workload first; every parameter is optional with sensible defaults.",
+        "inputSchema": {"json": {
+            "type": "object",
+            "properties": {
+                "input_size_gb": {"type": "number", "description": "total input data size in GB (default 100)"},
+                "workload_type": {"type": "string", "description": "etl | sql_analytics | ml | streaming | iceberg_maintenance (default etl)"},
+                "num_joins": {"type": "integer", "description": "approximate number of joins (default 5)"},
+                "largest_table_gb": {"type": "number", "description": "largest joined table in GB (default 50)"},
+                "is_compaction": {"type": "boolean", "description": "true for Iceberg compaction/maintenance jobs"},
+                "target_duration_minutes": {"type": "integer", "description": "desired runtime SLA, if any"},
+                "shuffle_write_gb": {"type": "number", "description": "expected shuffle volume in GB, if known"},
+                "num_files": {"type": "integer", "description": "input file count, if known (small-files detection)"},
+            },
+        }},
+    }},
+]
+
+
+def _run_chat_tool(name: str, tool_input: dict):
+    if name == "get_job_config":
+        return _tool_get_job_config(tool_input["job_run_id"])
+    if name == "get_metrics_snapshot":
+        return _metrics_snapshot(tool_input["job_run_id"],
+                                 int(tool_input.get("hours", 6)))
+    if name == "query_prometheus":
+        return _tool_query_prometheus(tool_input["query"],
+                                      int(tool_input.get("hours", 6)))
+    if name == "get_recent_analyses":
+        return {"analyses": _RECENT_ANALYSES or
+                "none this session — ask the user to run one in Config Advisor"}
+    if name == "run_config_advisor":
+        return _tool_run_config_advisor(tool_input["job_run_id"])
+    if name == "troubleshoot_job":
+        return _tool_troubleshoot_job(tool_input["job_run_id"])
+    if name == "get_application_details":
+        return _tool_get_application_details(tool_input["application_id"])
+    if name == "tshirt_sizing":
+        return _tool_tshirt_sizing(**tool_input)
+    return {"error": f"unknown tool {name}"}
+
+
+def _prometheus_job_ids(hours: int) -> set:
+    """Job run IDs that actually have metrics in Prometheus.
+
+    Spark's GraphiteSink prefix (the Spark app id) is the EMR Serverless
+    JOB RUN id, which the exporter maps to the app_id label.
+    """
+    params = {
+        "query": f'count by (app_id) (last_over_time(spark_jvm_heap_used[{hours}h]))',
+    }
+    url = f"{PROMETHEUS_URL}/api/v1/query?{urllib.parse.urlencode(params)}"
+    with urllib.request.urlopen(url, timeout=15) as resp:
+        data = json.load(resp)
+    return {r["metric"].get("app_id", "")
+            for r in data.get("data", {}).get("result", [])}
+
+
+def classify_bottleneck(metrics: dict) -> dict:
+    """Classify the primary bottleneck from extracted metrics.
+
+    Returns a dict with:
+      - primary: the dominant bottleneck type
+      - scores: dict of all bottleneck scores (0-100)
+      - explanation: human-readable explanation
+    """
+    io_summary = metrics.get("io_summary", {}).get("application_level", {})
+    executor_summary = metrics.get("executor_summary", {})
+    spill_summary = metrics.get("spill_summary", {})
+    stage_summary = metrics.get("stage_summary", {})
+    stages = stage_summary.get("stages", [])
+
+    total_input_gb = io_summary.get("total_input_gb", 0) or 0
+    total_output_gb = io_summary.get("total_output_gb", 0) or 0
+    total_shuffle_read_gb = io_summary.get("total_shuffle_read_gb", 0) or 0
+    total_shuffle_write_gb = io_summary.get("total_shuffle_write_gb", 0) or 0
+    total_shuffle_gb = total_shuffle_read_gb + total_shuffle_write_gb
+
+    avg_cpu_pct = executor_summary.get("avg_cpu_utilization_percent", 0) or 0
+    avg_mem_pct = executor_summary.get("avg_memory_utilization_percent", 0) or 0
+    idle_pct = executor_summary.get("idle_core_percentage", 0) or 0
+
+    total_mem_spill_gb = spill_summary.get("total_memory_spilled_gb", 0) or 0
+    total_disk_spill_gb = spill_summary.get("total_disk_spilled_gb", 0) or 0
+
+    total_tasks = metrics.get("task_summary", {}).get("total_tasks", 0) or 0
+    duration_hours = metrics.get("total_run_duration_hours") or metrics.get("application_info", {}).get("total_run_duration_hours", 0) or 0
+
+    # Shuffle fetch wait percent (from io_summary if available)
+    shuffle_fetch_wait_pct = io_summary.get("shuffle_fetch_wait_percent", 0) or 0
+
+    # Compute per-task averages
+    total_task_exec_hours = executor_summary.get("total_task_execution_hours", 0) or 0
+    avg_task_time_sec = (total_task_exec_hours * 3600 / total_tasks) if total_tasks > 0 else 0
+
+    # --- Scoring ---
+    scores = {}
+
+    # IOPS bound: many small shuffle reads/writes, high task count relative to data
+    # Indicator: lots of shuffle operations with small per-task data
+    shuffle_per_task_mb = (total_shuffle_gb * 1024 / total_tasks) if total_tasks > 0 else 0
+    tasks_per_gb = total_tasks / max(total_input_gb + total_shuffle_read_gb, 1)
+    iops_score = 0
+    if shuffle_per_task_mb > 0 and shuffle_per_task_mb < 50:
+        iops_score += 40  # Small per-task shuffle = IOPS pressure
+    if tasks_per_gb > 100:
+        iops_score += 30  # Many tasks per GB = small random I/O
+    if total_shuffle_gb > 1000 and shuffle_per_task_mb < 100:
+        iops_score += 30  # Large total shuffle with small per-task = IOPS storm
+    scores["IOPS Bound"] = min(100, iops_score)
+
+    # Disk Throughput bound: large sequential shuffle writes, spill to disk
+    disk_score = 0
+    if total_disk_spill_gb > 100:
+        disk_score += 40
+    if total_shuffle_write_gb > 500:
+        disk_score += 30
+    if total_disk_spill_gb > total_mem_spill_gb and total_disk_spill_gb > 50:
+        disk_score += 30  # Disk spill dominates memory spill
+    scores["Disk Throughput Bound"] = min(100, disk_score)
+
+    # Memory Constrained: high memory utilization, spill, GC pressure
+    mem_score = 0
+    if avg_mem_pct > 85:
+        mem_score += 40
+    elif avg_mem_pct > 70:
+        mem_score += 20
+    if total_mem_spill_gb > 50:
+        mem_score += 30
+    if total_mem_spill_gb > 0 and total_disk_spill_gb > 0:
+        mem_score += 30  # Both spill types = severe memory pressure
+    scores["Memory Constrained"] = min(100, mem_score)
+
+    # CPU Constrained: high CPU utilization, low I/O wait, minimal spill
+    cpu_score = 0
+    if avg_cpu_pct > 80:
+        cpu_score += 50
+    elif avg_cpu_pct > 60:
+        cpu_score += 30
+    if total_mem_spill_gb < 10 and total_disk_spill_gb < 10:
+        cpu_score += 25  # Low spill = not memory-bound
+    if idle_pct < 20:
+        cpu_score += 25  # Cores fully utilized
+    scores["CPU Constrained"] = min(100, cpu_score)
+
+    # Network Bound: high shuffle, fetch wait dominates, high shuffle ratio
+    net_score = 0
+    if shuffle_fetch_wait_pct > 30:
+        net_score += 50
+    elif shuffle_fetch_wait_pct > 15:
+        net_score += 25
+    shuffle_ratio = total_shuffle_gb / max(total_input_gb, 1)
+    if shuffle_ratio > 5:
+        net_score += 30
+    elif shuffle_ratio > 2:
+        net_score += 15
+    if total_shuffle_gb > 2000:
+        net_score += 20
+    scores["Network Bound"] = min(100, net_score)
+
+    # Determine primary bottleneck
+    primary = max(scores, key=scores.get) if any(v > 0 for v in scores.values()) else "Balanced"
+    primary_score = scores.get(primary, 0)
+
+    # Generate explanation
+    explanations = {
+        "IOPS Bound": f"High task count ({total_tasks:,}) with small per-task shuffle ({shuffle_per_task_mb:.0f} MB/task) creates IOPS pressure on shuffle disks.",
+        "Disk Throughput Bound": f"Large disk spill ({total_disk_spill_gb:.0f} GB) and shuffle writes ({total_shuffle_write_gb:.0f} GB) saturate disk throughput.",
+        "Memory Constrained": f"High memory utilization ({avg_mem_pct:.0f}%) with {total_mem_spill_gb:.0f} GB memory spill indicates insufficient executor memory.",
+        "CPU Constrained": f"High CPU utilization ({avg_cpu_pct:.0f}%) with low idle ({idle_pct:.0f}%) and minimal spill — compute-bound workload.",
+        "Network Bound": f"Shuffle fetch wait at {shuffle_fetch_wait_pct:.0f}% with {total_shuffle_gb:.0f} GB total shuffle — network/shuffle serving is the bottleneck.",
+        "Balanced": "No single dominant bottleneck detected — workload is relatively balanced.",
+    }
+
+    return {
+        "primary": primary,
+        "primary_score": primary_score,
+        "scores": scores,
+        "explanation": explanations.get(primary, ""),
+        "avg_task_time_sec": round(avg_task_time_sec, 2),
+        "total_tasks": total_tasks,
+        "duration_hours": round(duration_hours, 2),
+        "total_task_exec_hours": round(total_task_exec_hours, 2),
+    }
+
+
+def analyze_uploaded_file(json_path: str) -> dict:
+    """Run the full analysis on an uploaded extracted JSON file.
+
+    Expects a task_stage_summary JSON (output of spark_extractor.py).
+    Returns recommendation + bottleneck analysis.
+    """
+    # Write the file into a temp directory structure the fine tuner expects
+    with open(json_path) as f:
+        data = json.load(f)
+
+    app_id = data.get("application_id", "unknown")
+
+    # Create temp dir with task_stage_summary/ subdirectory
+    staging_dir = UPLOAD_DIR / f"staging_{app_id}"
+    tss_dir = staging_dir / "task_stage_summary"
+    tss_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write the JSON file
+    output_file = tss_dir / f"{app_id}.json"
+    with open(output_file, "w") as f:
+        json.dump(data, f)
+
+    # Run the fine tuner
+    try:
+        cost_recs, perf_recs = generate_dual_recommendations(
+            str(staging_dir), limit=1, target_partition_size_mib=1024
+        )
+    except Exception as e:
+        return {"error": f"Fine tuner failed: {str(e)}"}
+
+    cost_rec = cost_recs[0] if cost_recs else {}
+    perf_rec = perf_recs[0] if perf_recs else {}
+
+    # Classify bottleneck from the raw metrics
+    bottleneck = classify_bottleneck(data)
+
+    # Build result
+    result = {
+        "application_id": app_id,
+        "application_name": data.get("application_info", {}).get("application_name", "N/A"),
+        "duration_hours": data.get("total_run_duration_hours") or data.get("application_info", {}).get("total_run_duration_hours", 0),
+        "bottleneck": bottleneck,
+        "cost_recommendation": cost_rec,
+        "perf_recommendation": perf_rec,
+        "metrics_summary": {
+            "total_input_gb": data.get("io_summary", {}).get("application_level", {}).get("total_input_gb", 0),
+            "total_shuffle_read_gb": data.get("io_summary", {}).get("application_level", {}).get("total_shuffle_read_gb", 0),
+            "total_shuffle_write_gb": data.get("io_summary", {}).get("application_level", {}).get("total_shuffle_write_gb", 0),
+            "total_memory_spill_gb": data.get("spill_summary", {}).get("total_memory_spilled_gb", 0),
+            "total_disk_spill_gb": data.get("spill_summary", {}).get("total_disk_spilled_gb", 0),
+            "avg_memory_util_pct": data.get("executor_summary", {}).get("avg_memory_utilization_percent", 0),
+            "avg_cpu_util_pct": data.get("executor_summary", {}).get("avg_cpu_utilization_percent", 0),
+            "idle_core_pct": data.get("executor_summary", {}).get("idle_core_percentage", 0),
+            "total_executors": data.get("executor_summary", {}).get("total_executors", 0),
+            "total_tasks": data.get("task_summary", {}).get("total_tasks", 0),
+            "total_stages": data.get("stage_summary", {}).get("total_stages", 0),
+            "failed_tasks": data.get("task_summary", {}).get("failed_tasks", 0),
+            "killed_tasks": data.get("task_summary", {}).get("killed_tasks", 0),
+            "failed_stages": data.get("stage_summary", {}).get("failed_stages", 0),
+            "dead_executors": data.get("executor_summary", {}).get("dead_executors", 0),
+            "dead_executor_reasons": data.get("executor_summary", {}).get("dead_executor_reasons", {}),
+        },
+        "source_platform": ("emr-ec2" if data.get("spark_config", {}).get("spark.emr_cluster_id")
+                            else "emr-serverless"),
+        "spark_config_source": data.get("spark_config", {}),
+    }
+    try:
+        result["_executor_summary"] = {
+            k: data.get("executor_summary", {}).get(k)
+            for k in ("total_available_core_hours", "total_uptime_hours")
+        }
+        result["run_cost"] = _run_cost(result)
+    except Exception:
+        result["run_cost"] = None
+    finally:
+        result.pop("_executor_summary", None)
+
+    # Per-stage records for the compare view's stage-level diff (stripped
+    # before rendering single-run pages — see /analyze)
+    result["_stages"] = data.get("stage_summary", {}).get("stages", [])
+
+    # Deterministic recommended-vs-submitted comparison — the chat agent
+    # must cite this instead of reconstructing config diffs itself
+    try:
+        result["config_audit"] = _config_audit(result)
+    except Exception:
+        result["config_audit"] = []
+
+    # Query profiles (Spark-UI-style operator trees with metrics)
+    result["query_plans"] = data.get("query_plans", [])
+
+    # Cleanup staging
+    import shutil
+    shutil.rmtree(staging_dir, ignore_errors=True)
+
+    # Keep for the chat agent's get_recent_analyses tool (dedupe by app)
+    _RECENT_ANALYSES[:] = [a for a in _RECENT_ANALYSES
+                           if a.get("application_id") != app_id]
+    _RECENT_ANALYSES.append(result)
+    del _RECENT_ANALYSES[:-_RECENT_ANALYSES_MAX]
+
+    return result
+
+
+# Submit-level params that NEVER appear in event-log Spark conf — claiming
+# these were "not set" based on an event log is fabrication
+_CONFS_INVISIBLE_IN_EVENT_LOGS = (
+    "spark.emr-serverless.executor.disk",
+    "spark.emr-serverless.executor.disk.type",
+    "spark.emr-serverless.driver.disk",
+    "spark.emr-serverless.memoryOverheadFactor",
+)
+
+
+def _config_audit(result: dict) -> list:
+    """Deterministic recommended-vs-submitted config comparison.
+
+    Computed in code so the chat agent cannot fabricate it. status values:
+    match | differs | absent | unknown-not-in-event-log.
+    """
+    submitted = result.get("spark_config_source") or {}
+    rec = (result.get("cost_recommendation") or {}).get("spark_configs") or {}
+    rows = []
+    for k in sorted(rec):
+        sub = submitted.get(k)
+        if sub in (None, "None", ""):
+            # Submit-only params aren't reliably logged: absence is NOT
+            # evidence of being unset
+            if k in _CONFS_INVISIBLE_IN_EVENT_LOGS:
+                rows.append({"key": k, "recommended": rec[k],
+                             "submitted": "(not captured in this event log)",
+                             "status": "unknown-not-in-event-log"})
+                continue
+            status = "absent"
+        elif str(sub).strip().lower() == str(rec[k]).strip().lower():
+            status = "match"
+        else:
+            status = "differs"
+        rows.append({"key": k, "recommended": rec[k],
+                     "submitted": sub, "status": status})
+    return rows
+
+
+def _looks_like_extracted_json(path: Path) -> bool:
+    """True if the upload is already a task_stage_summary JSON (vs a raw
+    Spark event log, which is JSON-lines of SparkListener events)."""
+    if path.suffix != ".json":
+        return False
+    try:
+        with open(path) as f:
+            head = f.read(4096).lstrip()
+        if not head.startswith("{"):
+            return False
+        # Event logs start with {"Event":"SparkListenerLogStart",...}
+        first_line = head.splitlines()[0]
+        return '"Event"' not in first_line
+    except Exception:
+        return False
+
+
+def _extract_raw_event_log(upload_path: Path) -> Path:
+    """Run python_extractor on a raw event log upload; returns the
+    task_stage_summary JSON path. Raises ValueError with a user-facing
+    message on failure.
+
+    Accepts: a single event log file (plain / .gz / .lz4 / .zstd, including
+    a rolling events_N_appId file) or a .zip of an eventlog_v2_<appId>/
+    rolling directory.
+    """
+    work = Path(tempfile.mkdtemp(prefix="advisor_rawlog_"))
+    # The extractor derives the application name from this directory name —
+    # use the upload's stem so results show a meaningful id
+    stem = re.sub(r"[^A-Za-z0-9_.-]", "_",
+                  upload_path.stem.replace(".zip", "")) or "eventlog"
+    logs_dir = work / stem
+    logs_dir.mkdir()
+
+    if upload_path.suffix == ".zip":
+        with zipfile.ZipFile(upload_path) as z:
+            total = sum(i.file_size for i in z.infolist())
+            if total > MAX_UPLOAD_BYTES * 4:
+                raise ValueError("Zip expands beyond the size limit")
+            z.extractall(logs_dir)
+    else:
+        shutil.copy(upload_path, logs_dir / upload_path.name)
+
+    # Rolling logs may arrive as eventlog_v2_<appId>/ inside the zip —
+    # the extractor's --single-app wants that inner directory
+    inner = [d for d in logs_dir.rglob("eventlog_v2*") if d.is_dir()]
+    extract_input = inner[0] if inner else logs_dir
+
+    extracted = work / "extracted"
+    r = subprocess.run(
+        [sys.executable, str(_advisor_home() / "python_extractor.py"),
+         "--input", str(extract_input), "--output", str(extracted),
+         "--single-app"],
+        capture_output=True, text=True, timeout=900, cwd=str(_advisor_home()))
+    if r.returncode != 0:
+        tail = (r.stderr or r.stdout).strip()[-600:]
+        raise ValueError(f"Event log extraction failed: {tail}")
+
+    tss = extracted / "task_stage_summary"
+    files = list(tss.glob("*.json")) if tss.is_dir() else []
+    if not files:
+        raise ValueError("Extractor produced no task_stage_summary output — "
+                         "is this a Spark event log?")
+    return files[0]
+
+
+async def _save_upload(file: UploadFile) -> Path:
+    """Stream an upload to disk, enforcing the size cap."""
+    upload_path = UPLOAD_DIR / Path(file.filename).name
+    written = 0
+    with open(upload_path, "wb") as out:
+        while chunk := await file.read(1024 * 1024):
+            written += len(chunk)
+            if written > MAX_UPLOAD_BYTES:
+                out.close()
+                upload_path.unlink(missing_ok=True)
+                raise ValueError("File exceeds 500MB upload limit")
+            out.write(chunk)
+    return upload_path
+
+
+def _redirect_with_error(message: str) -> RedirectResponse:
+    q = urllib.parse.urlencode({"error": message})
+    return RedirectResponse(url=f"/config-advisor?{q}", status_code=303)
+
+
+# ---------------------------------------------------------------------------
+# Pages
+# ---------------------------------------------------------------------------
+
+@app.get("/")
+def home(request: Request):
+    """Landing page — navigate to Config Advisor or Observability."""
+    return templates.TemplateResponse(request, "landing.html", {"active": "home"})
+
+
+@app.get("/config-advisor")
+def config_advisor(request: Request, error: str = ""):
+    """Upload form for extracted event log JSON."""
+    return templates.TemplateResponse(
+        request, "config_advisor.html",
+        {"active": "config-advisor", "error": error},
+    )
+
+
+ANALYZE_EXTS = (".json", ".zip", ".gz", ".lz4", ".zstd", ".inprogress", "")
+
+
+def _prepare_analysis_input(upload_path: Path) -> Path:
+    """Return a task_stage_summary JSON for the upload — extracting first
+    when it's a raw Spark event log."""
+    if _looks_like_extracted_json(upload_path):
+        return upload_path
+    return _extract_raw_event_log(upload_path)
+
+
+@app.post("/analyze")
+async def analyze(request: Request, file: UploadFile = File(...)):
+    if not file.filename:
+        return _redirect_with_error("No file selected")
+    if not Path(file.filename).suffix.lower() in ANALYZE_EXTS:
+        return _redirect_with_error(
+            "Upload a task_stage_summary JSON, or a raw Spark event log "
+            "(plain / .gz / rolling events_* file, or .zip of an "
+            "eventlog_v2 directory)")
+
+    try:
+        upload_path = await _save_upload(file)
+    except ValueError as e:
+        return _redirect_with_error(str(e))
+
+    try:
+        result = analyze_uploaded_file(str(_prepare_analysis_input(upload_path)))
+    except ValueError as e:
+        return _redirect_with_error(str(e))
+    except Exception as e:
+        return _redirect_with_error(f"Analysis failed: {str(e)}")
+    finally:
+        upload_path.unlink(missing_ok=True)
+
+    if "error" in result:
+        return _redirect_with_error(result["error"])
+
+    result.pop("_stages", None)
+    return templates.TemplateResponse(
+        request, "results.html",
+        {"active": "config-advisor", "result": result},
+    )
+
+
+def _compare_metric_rows(a: dict, b: dict) -> list:
+    """Build [(label, val_a, val_b, delta_pct, better)] rows for the compare
+    view. 'better' marks which side wins when the metric has a direction."""
+    ms_a, ms_b = a["metrics_summary"], b["metrics_summary"]
+    bn_a, bn_b = a["bottleneck"], b["bottleneck"]
+
+    def row(label, va, vb, unit="", lower_is_better=None, fmt="{:,.1f}"):
+        delta = None
+        if va and vb:
+            delta = round((vb - va) / va * 100, 1)
+        better = None
+        if lower_is_better is not None and va != vb and va is not None and vb is not None:
+            better = ("a" if (va < vb) == lower_is_better else "b")
+        return {"label": label, "a": fmt.format(va or 0), "b": fmt.format(vb or 0),
+                "unit": unit, "delta_pct": delta, "better": better}
+
+    rows = []
+    ca, cb = a.get("run_cost"), b.get("run_cost")
+    if ca and cb:
+        all_billed = ca["source"] == "billed" and cb["source"] == "billed"
+        cost_label = "Cost (USD, billed)" if all_billed else "Cost (USD, ESTIMATED)"
+        rows += [
+            row(cost_label, ca["cost_usd"], cb["cost_usd"], "$",
+                lower_is_better=True, fmt="{:,.4f}"),
+            row("vCPU-hours", ca["vcpu_hours"], cb["vcpu_hours"], "",
+                lower_is_better=True, fmt="{:,.2f}"),
+            row("Memory GB-hours", ca["memory_gb_hours"], cb["memory_gb_hours"],
+                "", lower_is_better=True, fmt="{:,.2f}"),
+        ]
+    return rows + [
+        row("Duration", a.get("duration_hours") or 0, b.get("duration_hours") or 0,
+            "h", lower_is_better=True, fmt="{:,.2f}"),
+        row("Total tasks", ms_a["total_tasks"], ms_b["total_tasks"], fmt="{:,.0f}"),
+        row("Total stages", ms_a["total_stages"], ms_b["total_stages"], fmt="{:,.0f}"),
+        row("Executors", ms_a["total_executors"], ms_b["total_executors"], fmt="{:,.0f}"),
+        row("Avg task time", bn_a["avg_task_time_sec"], bn_b["avg_task_time_sec"],
+            "s", lower_is_better=True, fmt="{:,.2f}"),
+        row("Task execution", bn_a["total_task_exec_hours"], bn_b["total_task_exec_hours"],
+            "h", lower_is_better=True, fmt="{:,.2f}"),
+        row("Input", ms_a["total_input_gb"], ms_b["total_input_gb"], "GB"),
+        row("Shuffle read", ms_a["total_shuffle_read_gb"], ms_b["total_shuffle_read_gb"], "GB"),
+        row("Shuffle write", ms_a["total_shuffle_write_gb"], ms_b["total_shuffle_write_gb"], "GB"),
+        row("Memory spill", ms_a["total_memory_spill_gb"], ms_b["total_memory_spill_gb"],
+            "GB", lower_is_better=True),
+        row("Disk spill", ms_a["total_disk_spill_gb"], ms_b["total_disk_spill_gb"],
+            "GB", lower_is_better=True),
+        row("Avg CPU util", ms_a["avg_cpu_util_pct"], ms_b["avg_cpu_util_pct"], "%"),
+        row("Avg memory util", ms_a["avg_memory_util_pct"], ms_b["avg_memory_util_pct"], "%"),
+        row("Idle cores", ms_a["idle_core_pct"], ms_b["idle_core_pct"], "%",
+            lower_is_better=True),
+    ]
+
+
+def _compare_stages(a: dict, b: dict, top_n: int = 8) -> dict:
+    """Stage-level A/B comparison keyed on (stage name, data volume) — stage
+    IDs shift between runs, but the same query plan produces the same named
+    stages over the same data. Computes CPU-per-GB inflation to localize
+    where extra compute burn lives (contention, GC, codec changes)."""
+    def index(res):
+        out = {}
+        for s in (res.get("_stages") or []):
+            data_gb = (s.get("input_gb", 0) + s.get("shuffle_read_gb", 0))
+            # bucket data volume to 2 significant figures for matching
+            key = (s.get("name", "")[:60], f"{data_gb:.2g}")
+            if key not in out or s.get("total_cpu_time_sec", 0) > out[key].get("total_cpu_time_sec", 0):
+                out[key] = s
+        return out
+
+    ia, ib = index(a), index(b)
+    matched = []
+    for key in ia.keys() & ib.keys():
+        sa, sb = ia[key], ib[key]
+        cpu_a = sa.get("total_cpu_time_sec", 0)
+        cpu_b = sb.get("total_cpu_time_sec", 0)
+        data_gb = max(sa.get("input_gb", 0) + sa.get("shuffle_read_gb", 0), 0.01)
+        if cpu_a < 60 and cpu_b < 60:  # skip trivial stages
+            continue
+        rate_a = cpu_a / data_gb
+        rate_b = cpu_b / max(sb.get("input_gb", 0) + sb.get("shuffle_read_gb", 0), 0.01)
+        matched.append({
+            "name": key[0],
+            "stage_a": sa.get("stage_id"), "stage_b": sb.get("stage_id"),
+            "tasks_a": sa.get("tasks_completed"), "tasks_b": sb.get("tasks_completed"),
+            "data_gb": round(data_gb, 1),
+            "cpu_hours_a": round(cpu_a / 3600, 2),
+            "cpu_hours_b": round(cpu_b / 3600, 2),
+            "cpu_per_gb_a": round(rate_a, 1),
+            "cpu_per_gb_b": round(rate_b, 1),
+            "inflation_pct": round((rate_b / rate_a - 1) * 100, 1) if rate_a else None,
+            "spill_gb_a": round(sa.get("mem_spill_gb", 0) + sa.get("disk_spill_gb", 0), 1),
+            "spill_gb_b": round(sb.get("mem_spill_gb", 0) + sb.get("disk_spill_gb", 0), 1),
+        })
+    matched.sort(key=lambda m: -(m["cpu_hours_a"] + m["cpu_hours_b"]))
+    matched = matched[:top_n]
+
+    total_a = sum(m["cpu_hours_a"] for m in matched)
+    total_b = sum(m["cpu_hours_b"] for m in matched)
+    culprit = max(matched, key=lambda m: abs(m["cpu_hours_b"] - m["cpu_hours_a"]),
+                  default=None)
+    verdict = ""
+    if culprit and abs(culprit["cpu_hours_b"] - culprit["cpu_hours_a"]) > 0.5:
+        delta = culprit["cpu_hours_b"] - culprit["cpu_hours_a"]
+        total_delta = total_b - total_a
+        share = abs(delta) / max(abs(total_delta), 0.01) * 100
+        verdict = (f"Stage '{culprit['name']}' accounts for ~{min(share, 100):.0f}% of the "
+                   f"CPU-hour difference ({culprit['cpu_hours_a']} → {culprit['cpu_hours_b']} h, "
+                   f"CPU/GB {'+' if culprit['inflation_pct'] >= 0 else ''}{culprit['inflation_pct']}%). "
+                   "Same-stage CPU-per-GB inflation on identical data usually means "
+                   "worker-level contention (concurrent tasks sharing memory bandwidth), "
+                   "GC pressure from a larger heap, or a codec/write-path change — "
+                   "not more work.")
+    return {"stages": matched, "verdict": verdict}
+
+
+def _compare_config_diff(a: dict, b: dict) -> list:
+    """Spark confs that differ between the two runs (noise filtered)."""
+    ca = a.get("spark_config_source") or {}
+    cb = b.get("spark_config_source") or {}
+    noise = re.compile(
+        r"(app\.id|app\.name|driver\.host|jars|eventLog\.dir|submitTime|"
+        r"driver\.appUIAddress|fileserver|\.port$|app\.startTime|"
+        r"emr\.job\.id|\.uuid|attemptId|proxyBase)", re.I)
+    diff = []
+    for k in sorted(set(ca) | set(cb)):
+        va, vb = ca.get(k), cb.get(k)
+        if va != vb and not noise.search(k):
+            diff.append({"key": k, "a": va or "—", "b": vb or "—"})
+    return diff
+
+
+@app.post("/analyze-compare")
+async def analyze_compare(request: Request,
+                          file_a: UploadFile = File(...),
+                          file_b: UploadFile = File(...)):
+    """Side-by-side comparison of two event logs of the same job."""
+    for f in (file_a, file_b):
+        if not f.filename or Path(f.filename).suffix.lower() not in ANALYZE_EXTS:
+            return _redirect_with_error(
+                "Both files must be task_stage_summary JSONs or raw Spark event logs")
+
+    results = []
+    try:
+        for f in (file_a, file_b):
+            upload_path = await _save_upload(f)
+            try:
+                r = analyze_uploaded_file(str(_prepare_analysis_input(upload_path)))
+                if "error" in r:
+                    return _redirect_with_error(f"{f.filename}: {r['error']}")
+                r["source_filename"] = f.filename
+                results.append(r)
+            finally:
+                upload_path.unlink(missing_ok=True)
+    except ValueError as e:
+        return _redirect_with_error(str(e))
+    except Exception as e:
+        return _redirect_with_error(f"Comparison failed: {e}")
+
+    a, b = results
+    stage_cmp = _compare_stages(a, b)
+    a.pop("_stages", None)
+    b.pop("_stages", None)
+    return templates.TemplateResponse(
+        request, "compare_results.html",
+        {"active": "config-advisor", "a": a, "b": b,
+         "rows": _compare_metric_rows(a, b),
+         "config_diff": _compare_config_diff(a, b),
+         "stage_cmp": stage_cmp},
+    )
+
+
+@app.post("/analyze-migration")
+async def analyze_migration(request: Request,
+                            file_ec2: UploadFile = File(None),
+                            file_sls: UploadFile = File(None)):
+    """EC2 -> Serverless migration workbench.
+
+    One file: full analysis (EC2 logs get the migration-translated configs).
+    Both files: the compare view, EC2 as Run A / Serverless as Run B, with a
+    migration verdict so a disappointing Serverless run can be troubleshot
+    against its EC2 baseline.
+    """
+    uploads = [(f, tag) for f, tag in ((file_ec2, "EC2"), (file_sls, "Serverless"))
+               if f is not None and f.filename]
+    if not uploads:
+        return _redirect_with_error("Upload at least one event log (EC2 or Serverless)")
+    for f, _ in uploads:
+        if Path(f.filename).suffix.lower() not in ANALYZE_EXTS:
+            return _redirect_with_error(f"{f.filename}: unsupported file type")
+
+    results = []
+    try:
+        for f, tag in uploads:
+            upload_path = await _save_upload(f)
+            try:
+                r = analyze_uploaded_file(str(_prepare_analysis_input(upload_path)))
+                if "error" in r:
+                    return _redirect_with_error(f"{f.filename}: {r['error']}")
+                r["source_filename"] = f"[{tag}] {f.filename}"
+                # sanity: warn-but-proceed when the platform doesn't match the slot
+                expected = "emr-ec2" if tag == "EC2" else "emr-serverless"
+                r["slot_mismatch"] = (r.get("source_platform") != expected)
+                results.append(r)
+            finally:
+                upload_path.unlink(missing_ok=True)
+    except ValueError as e:
+        return _redirect_with_error(str(e))
+    except Exception as e:
+        return _redirect_with_error(f"Migration analysis failed: {e}")
+
+    if len(results) == 1:
+        r = results[0]
+        r.pop("_stages", None)
+        return templates.TemplateResponse(
+            request, "results.html",
+            {"active": "config-advisor", "result": r})
+
+    a, b = results  # EC2 = A, Serverless = B
+    stage_cmp = _compare_stages(a, b)
+    a.pop("_stages", None)
+    b.pop("_stages", None)
+    return templates.TemplateResponse(
+        request, "compare_results.html",
+        {"active": "config-advisor", "a": a, "b": b,
+         "rows": _compare_metric_rows(a, b),
+         "config_diff": _compare_config_diff(a, b),
+         "stage_cmp": stage_cmp,
+         "migration_mode": True},
+    )
+
+
+@app.get("/metrics-dashboard")
+def metrics_dashboard(request: Request, app_id: str = ""):
+    """Live/replay Spark worker metrics (heap, RSS, CPU, GC) from Prometheus."""
+    return templates.TemplateResponse(
+        request, "metrics_dashboard.html",
+        {"active": "observability", "app_id": app_id},
+    )
+
+
+# ---------------------------------------------------------------------------
+# APIs
+# ---------------------------------------------------------------------------
+
+@app.get("/api/metrics/query_range")
+def metrics_query_range(query: str = "", start: str = "", end: str = "", step: str = "15s"):
+    """Proxy to the Prometheus query_range API.
+
+    Keeps Prometheus unexposed to the browser and gives one place to swap
+    the datasource (OSS Prometheus vs AMP+SigV4) later.
+    """
+    if not query:
+        return JSONResponse({"error": "query parameter required"}, status_code=400)
+    params = {"query": query, "start": start, "end": end, "step": step}
+    url = f"{PROMETHEUS_URL}/api/v1/query_range?{urllib.parse.urlencode(params)}"
+    try:
+        with urllib.request.urlopen(url, timeout=15) as resp:
+            return JSONResponse(json.load(resp))
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=502)
+
+
+@app.get("/api/metrics/apps")
+def metrics_apps(hours: int = 24):
+    """List Spark app_ids (= EMR Serverless job run ids) present in Prometheus."""
+    try:
+        return JSONResponse({"apps": sorted(_prometheus_job_ids(hours))})
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=502)
+
+
+@app.get("/api/emr/applications")
+def emr_applications(hours: int = 48):
+    """EMR Serverless applications that have metrics-bearing job runs.
+
+    Cross-references list_applications/list_job_runs (read-only) with the
+    job run ids present in Prometheus, so the selector only offers
+    applications with something to show.
+    """
+    cached = _APPS_CACHE.get(hours)
+    if cached and cached[0] > time.time():
+        return JSONResponse(cached[1])
+
+    try:
+        metric_jobs = {j for j in _prometheus_job_ids(hours)
+                       if _JOB_RUN_ID_RE.match(j)}
+    except Exception as e:
+        return JSONResponse({"error": f"prometheus: {e}"}, status_code=502)
+
+    created_after = datetime.now(timezone.utc) - timedelta(hours=hours)
+    apps = []
+    unmatched = set(metric_jobs)
+    try:
+        all_apps = []
+        for page in _emr().get_paginator("list_applications").paginate():
+            all_apps.extend(page["applications"])
+        # Most-recently-updated apps first, and stop as soon as every
+        # metrics-bearing job run is accounted for — avoids paging
+        # list_job_runs across dozens of idle apps (the API throttles at
+        # very low TPS). Apps not touched within the window can't own a
+        # job run created in it.
+        all_apps = [a for a in all_apps
+                    if (a.get("updatedAt") or created_after) >= created_after]
+        all_apps.sort(key=lambda a: a.get("updatedAt") or created_after,
+                      reverse=True)
+        for a in all_apps:
+            if not unmatched:
+                break
+            app_id = a["id"]
+            matched = []
+            for jr_page in _emr().get_paginator("list_job_runs").paginate(
+                applicationId=app_id, createdAtAfter=created_after,
+            ):
+                matched.extend(
+                    jr["id"] for jr in jr_page["jobRuns"]
+                    if jr["id"] in metric_jobs
+                )
+            if matched:
+                unmatched.difference_update(matched)
+                apps.append({
+                    "id": app_id,
+                    "name": a.get("name", app_id),
+                    "state": a.get("state", ""),
+                    "metricJobCount": len(matched),
+                })
+        payload = {"applications": apps}
+        _APPS_CACHE[hours] = (time.time() + _APPS_CACHE_TTL, payload)
+        return JSONResponse(payload)
+    except Exception as e:
+        # No AWS creds / API failure: dashboard falls back to raw job ids
+        return JSONResponse({"error": f"emr-serverless: {e}", "applications": []},
+                            status_code=200)
+
+
+@app.get("/api/home/overview")
+def home_overview(hours: int = 72, max_apps: int = 8, max_jobs: int = 10):
+    """Applications + recent job runs for the home page action table.
+
+    Each app carries releaseLabel vs EMR_LATEST_RELEASE (drives Upgrade);
+    each job run carries state (drives Troubleshoot) and whether metrics
+    exist in Prometheus (annotates Observability links).
+    """
+    cache_key = ("overview", hours, max_apps, max_jobs)
+    cached = _APPS_CACHE.get(cache_key)
+    if cached and cached[0] > time.time():
+        return JSONResponse(cached[1])
+
+    try:
+        metric_jobs = _prometheus_job_ids(hours)
+    except Exception:
+        metric_jobs = set()
+
+    created_after = datetime.now(timezone.utc) - timedelta(hours=hours)
+    out_apps = []
+    try:
+        all_apps = []
+        for page in _emr().get_paginator("list_applications").paginate():
+            all_apps.extend(page["applications"])
+        all_apps = [a for a in all_apps
+                    if (a.get("updatedAt") or created_after) >= created_after]
+        all_apps.sort(key=lambda a: a.get("updatedAt") or created_after,
+                      reverse=True)
+        for a in all_apps[:max_apps]:
+            app_id = a["id"]
+            release = a.get("releaseLabel", "")
+            jobs = []
+            for page in _emr().get_paginator("list_job_runs").paginate(
+                applicationId=app_id, createdAtAfter=created_after,
+            ):
+                for jr in page["jobRuns"]:
+                    _JOB_TO_APP[jr["id"]] = app_id
+                    jobs.append({
+                        "id": jr["id"],
+                        "name": jr.get("name", jr["id"]),
+                        "state": jr.get("state", ""),
+                        "createdAt": jr["createdAt"].isoformat(),
+                        "hasMetrics": jr["id"] in metric_jobs,
+                    })
+            jobs.sort(key=lambda j: j["createdAt"], reverse=True)
+            out_apps.append({
+                "id": app_id,
+                "name": a.get("name", app_id),
+                "state": a.get("state", ""),
+                "releaseLabel": release,
+                "upgradeAvailable": release != EMR_LATEST_RELEASE,
+                "jobs": jobs[:max_jobs],
+            })
+        payload = {"applications": out_apps,
+                   "latestRelease": EMR_LATEST_RELEASE}
+        _APPS_CACHE[cache_key] = (time.time() + _APPS_CACHE_TTL, payload)
+        return JSONResponse(payload)
+    except Exception as e:
+        return JSONResponse({"error": f"emr-serverless: {e}",
+                             "applications": [],
+                             "latestRelease": EMR_LATEST_RELEASE})
+
+
+@app.get("/api/emr/jobs")
+def emr_jobs(application_id: str, hours: int = 48):
+    """Job runs of one EMR Serverless application that have metrics."""
+    try:
+        metric_jobs = _prometheus_job_ids(hours)
+    except Exception as e:
+        return JSONResponse({"error": f"prometheus: {e}"}, status_code=502)
+
+    created_after = datetime.now(timezone.utc) - timedelta(hours=hours)
+    jobs = []
+    try:
+        paginator = _emr().get_paginator("list_job_runs")
+        for page in paginator.paginate(
+            applicationId=application_id, createdAtAfter=created_after,
+        ):
+            for jr in page["jobRuns"]:
+                _JOB_TO_APP[jr["id"]] = application_id
+                if jr["id"] not in metric_jobs:
+                    continue
+                jobs.append({
+                    "id": jr["id"],
+                    "name": jr.get("name", jr["id"]),
+                    "state": jr.get("state", ""),
+                    "createdAt": jr["createdAt"].isoformat(),
+                })
+        jobs.sort(key=lambda j: j["createdAt"], reverse=True)
+        return JSONResponse({"jobs": jobs})
+    except Exception as e:
+        return JSONResponse({"error": f"emr-serverless: {e}", "jobs": []},
+                            status_code=200)
+
+
+@app.post("/api/chat")
+async def api_chat(request: Request):
+    """Agentic chat: Bedrock Converse loop with tools over the EMR Serverless
+    API, Prometheus, and this session's Config Advisor results.
+
+    Body: {"messages": [{"role": "user"|"assistant", "content": "..."}],
+           "page_context": {...}}   (page_context optional)
+    Streams NDJSON events: {"type": "tool", "name", "input"} while the agent
+    works, then {"type": "text", "text"} chunks, then {"type": "done"}.
+    """
+    body = await request.json()
+    messages = [
+        {"role": m["role"], "content": [{"text": m["content"]}]}
+        for m in body.get("messages", [])
+        if m.get("role") in ("user", "assistant") and m.get("content")
+    ]
+    if not messages:
+        return JSONResponse({"error": "messages required"}, status_code=400)
+
+    page_context = body.get("page_context") or {}
+    system = [{"text": CHAT_SYSTEM_PROMPT
+               + "\n\nCurrent page context:\n" + json.dumps(page_context, default=str)}]
+
+    def agent_loop():
+        convo = list(messages)
+        for _turn in range(8):  # tool-use iteration cap
+            resp = _bedrock().converse(
+                modelId=MODEL_ID,
+                system=system,
+                messages=convo,
+                toolConfig={"tools": CHAT_TOOLS},
+                inferenceConfig={"maxTokens": 4000},
+            )
+            out_msg = resp["output"]["message"]
+            convo.append(out_msg)
+
+            if resp["stopReason"] != "tool_use":
+                for block in out_msg["content"]:
+                    if "text" in block:
+                        yield json.dumps({"type": "text", "text": block["text"]}) + "\n"
+                yield json.dumps({"type": "done"}) + "\n"
+                return
+
+            tool_results = []
+            for block in out_msg["content"]:
+                if "toolUse" not in block:
+                    continue
+                tu = block["toolUse"]
+                yield json.dumps({"type": "tool", "name": tu["name"],
+                                  "input": tu["input"]}) + "\n"
+                try:
+                    result = _run_chat_tool(tu["name"], tu["input"])
+                    content = [{"json": result}]
+                    status = "success"
+                except Exception as e:
+                    content = [{"text": f"tool error: {e}"}]
+                    status = "error"
+                tool_results.append({"toolResult": {
+                    "toolUseId": tu["toolUseId"],
+                    "content": content, "status": status,
+                }})
+            convo.append({"role": "user", "content": tool_results})
+
+        yield json.dumps({"type": "text",
+                          "text": "(stopped: tool iteration limit reached)"}) + "\n"
+        yield json.dumps({"type": "done"}) + "\n"
+
+    return StreamingResponse(agent_loop(), media_type="application/x-ndjson")
+
+
+@app.post("/api/analyze")
+async def api_analyze(file: UploadFile = File(...)):
+    """JSON API endpoint for programmatic access.
+
+    Accepts a task_stage_summary JSON or a raw Spark event log
+    (plain / .gz / rolling / .zip) — raw logs are extracted server-side.
+    """
+    if not file.filename or Path(file.filename).suffix.lower() not in ANALYZE_EXTS:
+        return JSONResponse(
+            {"error": "Upload a task_stage_summary JSON or a raw Spark event log"},
+            status_code=400)
+
+    try:
+        upload_path = await _save_upload(file)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=413)
+
+    try:
+        result = analyze_uploaded_file(str(_prepare_analysis_input(upload_path)))
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=422)
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+    finally:
+        upload_path.unlink(missing_ok=True)
+
+    return JSONResponse(result)
+
+
+if __name__ == "__main__":
+    print("EMR Serverless Advisor — FastAPI UI")
+    print("=" * 50)
+    print("  /                   landing page")
+    print("  /config-advisor     event log analysis + recommendations")
+    print("  /metrics-dashboard  live worker metrics (Prometheus)")
+    print("  /docs               auto-generated API docs")
+    print("=" * 50)
+    print("\nStarting on http://0.0.0.0:5000")
+    uvicorn.run(app, host="0.0.0.0", port=5000)

--- a/utilities/EMR-Serverless-Config-Advisor/emr_s_tshirt_size.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_s_tshirt_size.py
@@ -198,9 +198,13 @@ def _shuffle_partitions(n: int, cores: int, waves: int = 1,
         # (shuffle wire bytes include serialization overhead, hash headers,
         #  and are typically 3-5× the deserialized in-memory size)
         by_size = max(200, int(math.ceil(shuffle_write_gb / 5.0)))
-        # Use the larger of parallelism floor and size-based
+        # Parallelism floor: 1 wave (not 2) when shuffle is known — AQE coalesces
+        # down anyway, and extra partitions create more blocks (worse IOPS).
+        # Validated: Veeva 294×16c at 5280 parts (1.1 waves) = 3.7 min;
+        #            at 9408 parts (2 waves) = 6.5 min (regression).
+        parallelism_floor = n * cores
         # Minimum 1000 — EMR Serverless default + AQE coalesces down from here
-        return max(1000, max(parallelism, by_size))
+        return max(1000, max(parallelism_floor, by_size))
     else:
         # Fallback: parallelism-based, capped at 10K
         return max(1000, min(parallelism, 10000))

--- a/utilities/EMR-Serverless-Config-Advisor/python_extractor.py
+++ b/utilities/EMR-Serverless-Config-Advisor/python_extractor.py
@@ -1538,6 +1538,124 @@ def extract_sql_metrics(events):
 
 
 
+def extract_query_plans(events, max_executions=30, max_nodes=400):
+    """Query profiles (Spark-UI SQL-tab style): per-execution operator trees from
+    sparkPlanInfo with metric accumulators resolved to values.
+
+    Values come from two sources, max-merged: SparkListenerDriverAccumUpdates
+    (driver-side metrics like file counts) and TaskEnd accumulables
+    (executor-side: rows, spill, shuffle bytes). AQE re-emits plans via
+    SQLAdaptiveExecutionUpdate — the LAST plan per execution wins (final
+    adaptive plan)."""
+    plans = {}        # execution_id -> {meta, plan_info}
+    acc_values = {}   # accumulator id -> max observed value
+    stage_accs = {}   # stage_id -> set of accumulator ids its tasks updated
+    stage_failures = {}  # stage_id -> {failed, reasons: {reason: count}, sample}
+
+    for event in events:
+        et = event.get("Event", "")
+        if et.endswith("SparkListenerSQLExecutionStart"):
+            eid = event.get("executionId")
+            plans[eid] = {
+                "execution_id": eid,
+                "description": (event.get("description") or "")[:200],
+                "submission_time": datetime.fromtimestamp(
+                    event["time"] / 1000).isoformat() if event.get("time") else None,
+                "duration_ms": None,
+                "_start_ms": event.get("time", 0),
+                "plan_info": event.get("sparkPlanInfo"),
+            }
+        elif et.endswith("SparkListenerSQLAdaptiveExecutionUpdate"):
+            eid = event.get("executionId")
+            if eid in plans and event.get("sparkPlanInfo"):
+                plans[eid]["plan_info"] = event["sparkPlanInfo"]
+        elif et.endswith("SparkListenerSQLExecutionEnd"):
+            eid = event.get("executionId")
+            if eid in plans and event.get("time") and plans[eid]["_start_ms"]:
+                plans[eid]["duration_ms"] = event["time"] - plans[eid]["_start_ms"]
+        elif et.endswith("SparkListenerDriverAccumUpdates"):
+            for aid, v in event.get("accumUpdates", []):
+                if isinstance(v, (int, float)):
+                    acc_values[aid] = max(acc_values.get(aid, 0), int(v))
+        elif et == "SparkListenerTaskEnd":
+            sid = event.get("Stage ID")
+            saccs = stage_accs.setdefault(sid, set())
+            for acc in (event.get("Task Info") or {}).get("Accumulables", []):
+                aid, v = acc.get("ID"), acc.get("Value")
+                saccs.add(aid)
+                if isinstance(v, (int, float)):
+                    acc_values[aid] = max(acc_values.get(aid, 0), int(v))
+                elif isinstance(v, str) and v.replace("-", "").isdigit():
+                    acc_values[aid] = max(acc_values.get(aid, 0), int(v))
+            # failure attribution: record non-Success task end reasons
+            ter = event.get("Task End Reason") or {}
+            reason = ter.get("Reason", "Success")
+            if reason != "Success":
+                sf = stage_failures.setdefault(
+                    sid, {"failed": 0, "reasons": {}, "sample": ""})
+                sf["failed"] += 1
+                sf["reasons"][reason] = sf["reasons"].get(reason, 0) + 1
+                if not sf["sample"]:
+                    sf["sample"] = str(
+                        ter.get("Error Message") or ter.get("Message")
+                        or ter.get("Loss Reason") or reason)[:300]
+
+    # operator -> stage attribution: a stage's tasks update the accumulators
+    # of exactly the operators pipelined into that stage
+    failed_stage_accs = {sid: stage_accs.get(sid, set())
+                         for sid in stage_failures}
+
+    def build(node, depth=0, counter=None):
+        if counter is None:
+            counter = [0]
+        if counter[0] >= max_nodes or node is None:
+            return None
+        counter[0] += 1
+        metrics = {}
+        node_acc_ids = set()
+        for m in node.get("metrics", []):
+            aid = m.get("accumulatorId")
+            node_acc_ids.add(aid)
+            val = acc_values.get(aid)
+            if val:
+                metrics[m.get("name", "?")] = val
+        # failure attribution: which failed stages ran this operator
+        failures = []
+        for sid, saccs in failed_stage_accs.items():
+            if node_acc_ids & saccs:
+                sf = stage_failures[sid]
+                failures.append({"stage_id": sid, "failed_tasks": sf["failed"],
+                                 "reasons": sf["reasons"], "sample": sf["sample"]})
+        children = [c for c in (build(ch, depth + 1, counter)
+                                for ch in node.get("children", [])) if c]
+        out = {
+            "name": node.get("nodeName", "?"),
+            "detail": (node.get("simpleString") or "")[:250],
+            "metrics": metrics,
+            "children": children,
+        }
+        if failures:
+            out["failures"] = failures
+        return out
+
+    out = []
+    # keep the longest executions (they carry the cost)
+    ranked = sorted(plans.values(),
+                    key=lambda p: -(p["duration_ms"] or 0))[:max_executions]
+    for p in sorted(ranked, key=lambda p: p["execution_id"]):
+        tree = build(p.get("plan_info"))
+        if not tree:
+            continue
+        out.append({
+            "execution_id": p["execution_id"],
+            "description": p["description"],
+            "submission_time": p["submission_time"],
+            "duration_ms": p["duration_ms"],
+            "plan": tree,
+        })
+    return out
+
+
 def extract_sql_execution_plans(events):
     """Extract SQL execution plans from Spark SQL events"""
     execution_plans = {}
@@ -1890,13 +2008,20 @@ def extract_driver_metrics(events):
             # Driver has executor ID "driver"
             if executor_id == "driver":
                 executor_metrics = event.get("Executor Metrics Updated", [])
-                
-                for stage_id, metrics_list in executor_metrics:
+
+                # Entries are (stage_id, metrics_list) pairs on older Spark,
+                # (stage_id, attempt_id, metrics) triples on newer Spark
+                for entry in executor_metrics:
+                    if not isinstance(entry, (list, tuple)) or len(entry) < 2:
+                        continue
+                    metrics_list = entry[-1]
+                    if isinstance(metrics_list, dict):
+                        metrics_list = [metrics_list]
                     for metrics in metrics_list:
                         if isinstance(metrics, dict):
                             jvm_heap = metrics.get("JVMHeapMemory", 0)
                             jvm_off_heap = metrics.get("JVMOffHeapMemory", 0)
-                            
+
                             if jvm_heap > 0:
                                 driver_heap_memory_samples.append(jvm_heap)
                             if jvm_off_heap > 0:
@@ -4046,6 +4171,21 @@ def extract_spark_config(events: List[Dict]) -> Dict[str, Any]:
                         config[key] = value
                 else:
                     config[key] = value
+
+            # Also capture every other spark.* property present at submit —
+            # the fixed allowlist silently dropped confs like
+            # spark.network.timeout and dynamicAllocation.minExecutors,
+            # making them look "unset" downstream. Skip only bulky/noisy keys.
+            _skip = ("extraClassPath", "extraLibraryPath", "extraJavaOptions",
+                     "defaultJavaOptions", "spark.yarn.dist", "spark.jars",
+                     "spark.files", "spark.repl", "spark.driver.host",
+                     "spark.driver.port", "spark.ui.proxy")
+            for key, value in spark_props.items():
+                if key in config or not key.startswith("spark."):
+                    continue
+                if any(s in key for s in _skip):
+                    continue
+                config[key] = value
             break
     return config
 
@@ -4115,6 +4255,7 @@ def process_application(args_tuple: Tuple[str, List[str], str]) -> Tuple[str, Di
         a["mem_spill"] += s.get("memory_bytes_spilled", 0)
         a["disk_spill"] += s.get("disk_bytes_spilled", 0)
         a["run_time"] += s.get("executor_run_time_ms", 0)
+        a["cpu_time"] = a.get("cpu_time", 0) + s.get("executor_cpu_time_ms", 0)
         a["tasks"] += s.get("actual_task_count", 0)
     GB = 1024 ** 3
     stage_summary["stages"] = [{
@@ -4130,6 +4271,8 @@ def process_application(args_tuple: Tuple[str, List[str], str]) -> Tuple[str, Di
         "mem_spill_gb": round(stage_io_agg[s["stage_id"]]["mem_spill"] / GB, 2),
         "disk_spill_gb": round(stage_io_agg[s["stage_id"]]["disk_spill"] / GB, 2),
         "total_task_time_sec": round(stage_io_agg[s["stage_id"]]["run_time"] / 1000, 1),
+        # "Executor CPU Time" in event logs is NANOSECONDS despite the _ms field name
+        "total_cpu_time_sec": round(stage_io_agg[s["stage_id"]].get("cpu_time", 0) / 1e9, 1),
         "failure_reason": s.get("failure_reason"),
     } for s in stages_list]
 
@@ -4191,6 +4334,7 @@ def process_application(args_tuple: Tuple[str, List[str], str]) -> Tuple[str, Di
         "sql_metrics": sql_metrics,
         "executor_timeline": executor_timeline,
         "sql_executions": sql_metrics.get("sql_executions", []),
+        "query_plans": extract_query_plans(all_events),
         "spark_config": spark_config,
     }
     

--- a/utilities/EMR-Serverless-Config-Advisor/start_advisor.sh
+++ b/utilities/EMR-Serverless-Config-Advisor/start_advisor.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Starts the EMR Serverless Advisor UI with a self-healing SSM tunnel to
+# Prometheus on the monitoring host. Use this instead of `python3 app.py`
+# when the monitoring host's 9090 isn't directly reachable (corp egress
+# filtering) — the tunnel is watched and restarted if the SSM session expires.
+#
+#   ./start_advisor.sh            # foreground app, background tunnel-keeper
+#
+MONITORING_INSTANCE="${MONITORING_INSTANCE:?set MONITORING_INSTANCE to your monitoring EC2 instance id}"
+LOCAL_PORT="${LOCAL_PORT:-19090}"
+REGION="${AWS_REGION:-us-east-1}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+tunnel_alive() {
+    curl -s -m 3 -o /dev/null "http://localhost:${LOCAL_PORT}/api/v1/query?query=up"
+}
+
+keep_tunnel() {
+    while true; do
+        if ! tunnel_alive; then
+            echo "[tunnel-keeper] (re)starting SSM port-forward to ${MONITORING_INSTANCE}:9090"
+            pkill -f "session-manager-plugin.*${LOCAL_PORT}" 2>/dev/null
+            nohup aws ssm start-session \
+                --target "$MONITORING_INSTANCE" \
+                --document-name AWS-StartPortForwardingSession \
+                --parameters "{\"portNumber\":[\"9090\"],\"localPortNumber\":[\"${LOCAL_PORT}\"]}" \
+                --region "$REGION" >> /tmp/advisor-ssm-tunnel.log 2>&1 &
+            sleep 8
+        fi
+        sleep 30
+    done
+}
+
+keep_tunnel &
+KEEPER_PID=$!
+trap 'kill $KEEPER_PID 2>/dev/null' EXIT
+
+export PROMETHEUS_URL="http://localhost:${LOCAL_PORT}"
+export MODEL_ID="${MODEL_ID:-global.anthropic.claude-fable-5}"
+cd "$DIR"
+exec python3 app.py

--- a/utilities/EMR-Serverless-Config-Advisor/static/advisor.css
+++ b/utilities/EMR-Serverless-Config-Advisor/static/advisor.css
@@ -1,0 +1,155 @@
+/* Config Advisor components — light theme for the console shell.
+   Same class names as the original dark style.css so results.html markup
+   carries over unchanged. */
+
+:root {
+    --card-bg: #ffffff;
+    --card-border: #EAEEF2;
+    --ink: #3B4B5E;
+    --ink-muted: #7A8B9A;
+    --blue: #4DA3D4;
+    --green: #5CB85C;
+    --orange: #FFAD4A;
+    --red: #E87461;
+    --purple: #9B8FD4;
+    --radius: 10px;
+}
+
+.app-id { font-family: monospace; font-size: 0.85rem; color: var(--ink-muted); }
+
+.back-link { color: var(--blue); text-decoration: none; font-size: 0.9rem; display: inline-block; margin-bottom: 0.5rem; }
+.back-link:hover { text-decoration: underline; }
+
+/* Flash / error banner */
+.flash { padding: 0.75rem 1rem; border-radius: var(--radius); margin-bottom: 1rem; }
+.flash.error { background: #FDF1EF; border: 1px solid var(--red); color: var(--red); }
+
+/* Upload */
+.upload-section { margin-bottom: 2rem; max-width: 760px; }
+
+.drop-zone {
+    border: 2px dashed #C4CFD9;
+    border-radius: var(--radius);
+    padding: 3rem 2rem;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.2s;
+    background: var(--card-bg);
+    position: relative;
+}
+.drop-zone:hover, .drop-zone.drag-over { border-color: var(--blue); background: #EDF6FC; }
+.drop-zone.has-file { border-color: var(--green); background: #EFF8EF; }
+.drop-zone input[type="file"] { position: absolute; inset: 0; opacity: 0; cursor: pointer; }
+.drop-zone-content svg { color: #7A8B9A; margin-bottom: 1rem; }
+
+.drop-text { font-size: 1.05rem; color: var(--ink); margin-bottom: 0.25rem; }
+.drop-text code { background: #FAFBFC; border: 1px solid var(--card-border); padding: 0.1rem 0.45rem; border-radius: 4px; font-size: 0.9rem; }
+.drop-hint { color: var(--ink-muted); font-size: 0.85rem; }
+.file-name { color: var(--green); font-family: monospace; font-size: 0.9rem; margin-top: 0.75rem; }
+
+.btn-analyze {
+    display: block; width: 100%; margin-top: 1rem; padding: 0.8rem;
+    font-size: 1rem; font-weight: 600; color: #fff;
+    background: var(--blue); border: none; border-radius: 6px; cursor: pointer;
+}
+.btn-analyze:hover:not(:disabled) { background: #3D8CBD; }
+.btn-analyze:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Info cards */
+.info-section { margin-top: 1.5rem; }
+.info-section h3 { font-size: 1.05rem; color: var(--ink); margin: 1.5rem 0 1rem; }
+.info-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; }
+.info-card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: var(--radius); padding: 1.1rem 1.25rem; }
+.info-card h4 { font-size: 0.9rem; color: var(--blue); margin: 0 0 0.4rem; }
+.info-card p { font-size: 0.85rem; color: var(--ink-muted); margin: 0; }
+.info-section pre { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: var(--radius); padding: 1rem; overflow-x: auto; font-size: 0.82rem; color: var(--ink-muted); }
+
+/* Summary cards */
+.summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+.summary-card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: var(--radius); padding: 1.1rem; text-align: center; }
+.summary-value { font-size: 1.5rem; font-weight: 700; color: var(--blue); font-family: monospace; }
+.summary-label { font-size: 0.78rem; color: var(--ink-muted); margin-top: 0.25rem; text-transform: uppercase; letter-spacing: 0.05em; }
+
+/* Sections */
+.section { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: var(--radius); padding: 1.5rem; margin-bottom: 1.25rem; }
+.section h2 { font-size: 1.1rem; margin: 0 0 1rem; color: var(--ink); }
+
+/* Bottleneck */
+.bottleneck-primary { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.75rem; }
+.bottleneck-badge { display: inline-block; padding: 0.35rem 1rem; border-radius: 20px; font-weight: 600; font-size: 0.9rem; }
+.bottleneck-badge.iops-bound { background: #F4F2FB; color: var(--purple); }
+.bottleneck-badge.disk-throughput-bound { background: #FFF6EA; color: var(--orange); }
+.bottleneck-badge.memory-constrained { background: #FDF1EF; color: var(--red); }
+.bottleneck-badge.cpu-constrained { background: #EFF8EF; color: var(--green); }
+.bottleneck-badge.network-bound { background: #EDF6FC; color: var(--blue); }
+.bottleneck-badge.balanced { background: #FAFBFC; color: var(--ink-muted); }
+.bottleneck-score { font-size: 0.85rem; color: var(--ink-muted); font-family: monospace; }
+.bottleneck-explanation { color: var(--ink-muted); font-size: 0.9rem; margin-bottom: 1.25rem; }
+
+.bottleneck-bars { display: flex; flex-direction: column; gap: 0.6rem; }
+.bar-row { display: grid; grid-template-columns: 180px 1fr 40px; align-items: center; gap: 0.75rem; }
+.bar-label { font-size: 0.82rem; color: var(--ink-muted); }
+.bar-track { height: 8px; background: #EAEEF2; border-radius: 4px; overflow: hidden; }
+.bar-fill { height: 100%; border-radius: 4px; transition: width 0.5s ease; }
+.bar-fill.bar-high { background: var(--red); }
+.bar-fill.bar-med { background: var(--orange); }
+.bar-fill.bar-low { background: var(--blue); }
+.bar-value { font-size: 0.8rem; font-family: monospace; color: var(--ink-muted); text-align: right; }
+
+/* Metrics grid */
+.metrics-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 1rem; }
+.metric { text-align: center; }
+.metric-value { display: block; font-size: 1.1rem; font-weight: 600; font-family: monospace; color: var(--ink); }
+.metric-label { display: block; font-size: 0.75rem; color: var(--ink-muted); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 0.2rem; }
+
+/* Recommendations */
+.rec-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; }
+.rec-card { background: #FAFBFC; border: 1px solid var(--card-border); border-radius: var(--radius); padding: 1.25rem; }
+.rec-title { font-size: 0.9rem; text-transform: uppercase; letter-spacing: 0.05em; margin: 0 0 1rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--card-border); }
+.rec-title.cost { color: var(--green); }
+.rec-title.perf { color: var(--orange); }
+.worker-spec { text-align: center; margin-bottom: 1rem; }
+.worker-type { font-size: 1.3rem; font-weight: 700; color: var(--ink); }
+.worker-details { font-size: 1rem; color: var(--blue); font-family: monospace; }
+.rec-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.rec-table td { padding: 0.4rem 0; border-bottom: 1px solid #EAEEF2; }
+.rec-table td:first-child { color: var(--ink-muted); }
+.rec-table td:last-child { text-align: right; font-family: monospace; color: var(--ink); }
+
+/* Warnings */
+.warning-card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: var(--radius); padding: 1rem; margin-bottom: 0.75rem; border-left: 3px solid; }
+.warning-card.high { border-left-color: var(--red); }
+.warning-card.medium { border-left-color: var(--orange); }
+.warning-card.low { border-left-color: var(--blue); }
+.warning-header { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
+.warning-severity { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; padding: 0.15rem 0.5rem; border-radius: 3px; background: #FDF1EF; color: var(--red); }
+.warning-card.medium .warning-severity { background: #FFF6EA; color: var(--orange); }
+.warning-type { font-size: 0.8rem; color: var(--ink-muted); font-family: monospace; }
+.warning-message { font-size: 0.88rem; color: var(--ink-muted); margin-bottom: 0.5rem; }
+.warning-rec { display: block; font-size: 0.8rem; background: #FAFBFC; padding: 0.4rem 0.6rem; border-radius: 4px; color: var(--blue); word-break: break-all; }
+
+/* Config blocks */
+.config-block { position: relative; background: #FAFBFC; border: 1px solid var(--card-border); border-radius: var(--radius); overflow: hidden; }
+.config-block pre { padding: 1rem; overflow-x: auto; font-size: 0.8rem; line-height: 1.7; color: #333; margin: 0; }
+.config-block code { font-family: 'SF Mono', Menlo, Monaco, monospace; }
+.source-config pre { max-height: 300px; overflow-y: auto; }
+.copy-btn { position: absolute; top: 0.5rem; right: 0.5rem; padding: 0.3rem 0.7rem; font-size: 0.75rem; background: #fff; border: 1px solid var(--card-border); border-radius: 4px; color: var(--ink-muted); cursor: pointer; z-index: 1; }
+.copy-btn:hover { background: var(--blue); color: #fff; }
+
+/* Compare form */
+.compare-section { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: var(--radius); padding: 1.25rem 1.5rem; }
+.compare-section h3 { font-size: 1.05rem; color: var(--ink); margin: 0; }
+.compare-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 0.5rem; }
+.cmp-slot { display: flex; align-items: center; gap: 10px; border: 1.5px dashed #C4CFD9; border-radius: 8px; padding: 0.8rem 1rem; cursor: pointer; }
+.cmp-slot:hover { border-color: var(--blue); }
+.cmp-slot input[type="file"] { font-size: 0.8rem; color: var(--ink-muted); min-width: 0; }
+.cmp-tag { font-size: 11px; font-weight: 700; padding: 2px 10px; border-radius: 10px; flex-shrink: 0; }
+.cmp-tag.a { background: #EDF6FC; color: var(--blue); }
+.cmp-tag.b { background: #F4F2FB; color: #9B8FD4; }
+
+@media (max-width: 768px) {
+    .rec-grid { grid-template-columns: 1fr; }
+    .bar-row { grid-template-columns: 120px 1fr 30px; }
+    .metrics-grid { grid-template-columns: repeat(2, 1fr); }
+    .compare-grid { grid-template-columns: 1fr; }
+}

--- a/utilities/EMR-Serverless-Config-Advisor/static/console.css
+++ b/utilities/EMR-Serverless-Config-Advisor/static/console.css
@@ -1,0 +1,421 @@
+/* EMR Serverless Advisor — console shell (top bar + sidebar + light content) */
+
+:root {
+    --topbar-bg: #3B4B5E;
+    --sidebar-bg: #31404F;
+    --sidebar-text: #EAEEF2;
+    --sidebar-hover: #3B4B5E;
+    --sidebar-active: #4DA3D4;
+    --console-blue: #4DA3D4;
+    --content-bg: #FAFBFC;
+}
+
+html, body {
+    height: 100%;
+    font-family: "Amazon Ember", Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body.console {
+    display: flex;
+    flex-direction: column;
+    background: var(--content-bg);
+}
+
+/* ===== Top bar ===== */
+.topbar {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    height: 44px;
+    padding: 0 16px;
+    background: var(--topbar-bg);
+    color: #fff;
+    flex-shrink: 0;
+}
+
+.topbar .hamburger {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 4px;
+    cursor: pointer;
+}
+.topbar .hamburger span {
+    width: 18px;
+    height: 2px;
+    background: #EAEEF2;
+    border-radius: 1px;
+}
+
+.topbar .emr-badge {
+    background: #FFAD4A;
+    color: #fff;
+    font-size: 12px;
+    font-weight: 700;
+    padding: 3px 8px;
+    border-radius: 4px;
+    letter-spacing: 0.02em;
+}
+
+.topbar .crumb {
+    font-size: 14px;
+    color: #fff;
+    text-decoration: none;
+}
+.topbar .crumb.muted { color: #9FAEBD; }
+.topbar .crumb-sep { color: #9FAEBD; font-size: 13px; }
+
+.topbar .topbar-right {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    font-size: 13px;
+    color: #EAEEF2;
+}
+.topbar .top-icon {
+    width: 18px;
+    height: 18px;
+    border: 1.5px solid #9FAEBD;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    color: #9FAEBD;
+}
+
+/* ===== Shell layout ===== */
+.shell {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+}
+
+/* ===== Sidebar ===== */
+.sidebar {
+    width: 230px;
+    flex-shrink: 0;
+    background: var(--sidebar-bg);
+    color: var(--sidebar-text);
+    padding: 18px 0;
+    overflow-y: auto;
+}
+
+.sidebar .sidebar-title {
+    font-size: 15px;
+    font-weight: 700;
+    color: #fff;
+    padding: 0 20px 12px;
+    border-bottom: 1px solid #4A5B6D;
+    margin-bottom: 10px;
+}
+
+.sidebar .nav-group-label {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #9FAEBD;
+    padding: 12px 20px 6px;
+}
+
+.sidebar a.nav-item {
+    display: block;
+    padding: 8px 20px;
+    color: var(--sidebar-text);
+    text-decoration: none;
+    font-size: 14px;
+    border-left: 3px solid transparent;
+}
+.sidebar a.nav-item:hover { background: var(--sidebar-hover); color: #fff; }
+.sidebar a.nav-item.active {
+    background: var(--sidebar-hover);
+    border-left-color: var(--sidebar-active);
+    color: #fff;
+    font-weight: 600;
+}
+
+.sidebar .sidebar-foot {
+    margin-top: 24px;
+    padding: 12px 20px 0;
+    border-top: 1px solid #4A5B6D;
+    font-size: 12px;
+    color: #9FAEBD;
+}
+
+/* ===== Main content ===== */
+.main {
+    flex: 1;
+    min-width: 0;
+    overflow-y: auto;
+    padding: 22px 32px 48px;
+}
+
+.breadcrumbs {
+    font-size: 13px;
+    margin-bottom: 14px;
+}
+.breadcrumbs a { color: var(--console-blue); text-decoration: none; }
+.breadcrumbs a:hover { text-decoration: underline; }
+.breadcrumbs .sep { color: #7A8B9A; margin: 0 6px; }
+.breadcrumbs .current { color: #7A8B9A; }
+
+.page-title {
+    font-size: 26px;
+    font-weight: 700;
+    color: #3B4B5E;
+    margin-bottom: 4px;
+}
+.page-subtitle {
+    color: #7A8B9A;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+/* Console-style pill buttons */
+.btn-pill {
+    display: inline-block;
+    padding: 7px 20px;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    border: 1.5px solid var(--console-blue);
+    transition: background 0.15s;
+}
+.btn-pill.primary { background: var(--console-blue); color: #fff; }
+.btn-pill.primary:hover { background: #3D8CBD; }
+.btn-pill.secondary { background: #fff; color: var(--console-blue); }
+.btn-pill.secondary:hover { background: #EDF6FC; }
+
+/* Landing cards */
+.landing-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+    gap: 20px;
+    margin-top: 8px;
+}
+
+.landing-card {
+    background: #fff;
+    border: 1px solid #EAEEF2;
+    border-radius: 10px;
+    padding: 26px 26px 22px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+    display: flex;
+    flex-direction: column;
+}
+.landing-card h2 {
+    font-size: 18px;
+    color: #3B4B5E;
+    margin-bottom: 8px;
+}
+.landing-card p.desc {
+    color: #7A8B9A;
+    font-size: 14px;
+    margin-bottom: 14px;
+}
+.landing-card ul {
+    margin: 0 0 18px 18px;
+    color: #7A8B9A;
+    font-size: 13px;
+    line-height: 1.9;
+}
+.landing-card .card-actions { margin-top: auto; }
+.landing-card .status-line {
+    font-size: 12px;
+    color: #7A8B9A;
+    margin-top: 12px;
+}
+.status-dot {
+    display: inline-block;
+    width: 9px; height: 9px;
+    border-radius: 50%;
+    background: #C4CFD9;
+    margin-right: 5px;
+}
+.status-dot.ok { background: #5CB85C; }
+.status-dot.bad { background: #E87461; }
+
+.landing-info {
+    background: #fff;
+    border: 1px solid #EAEEF2;
+    border-radius: 10px;
+    padding: 18px 26px;
+    margin-bottom: 20px;
+    display: flex;
+    gap: 48px;
+    flex-wrap: wrap;
+}
+.landing-info .info-item .k {
+    font-size: 12px;
+    color: #7A8B9A;
+    margin-bottom: 2px;
+}
+.landing-info .info-item .v {
+    font-size: 14px;
+    color: #3B4B5E;
+    font-family: 'SF Mono', Menlo, monospace;
+}
+
+@media (max-width: 820px) {
+    .sidebar { display: none; }
+    .main { padding: 18px; }
+}
+
+/* ===== Home: applications & job runs table ===== */
+.jobs-panel {
+    background: #fff;
+    border: 1px solid #EAEEF2;
+    border-radius: 10px;
+    padding: 18px 22px;
+    margin-bottom: 20px;
+}
+.jobs-panel-head { display: flex; align-items: baseline; gap: 14px; margin-bottom: 6px; }
+.jobs-panel-head h2 { font-size: 17px; color: #3B4B5E; margin: 0; }
+.jobs-panel-head .hint { font-size: 12px; color: #7A8B9A; margin-left: auto; }
+.jobs-loading { color: #7A8B9A; font-size: 13px; padding: 8px 0; }
+
+.app-section { border-top: 1px solid #EAEEF2; padding: 12px 0 4px; }
+.app-section:first-child { border-top: none; }
+.app-row { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
+.app-name { font-weight: 700; font-size: 14px; color: #3B4B5E; }
+.app-meta { font-size: 12px; color: #7A8B9A; font-family: 'SF Mono', Menlo, monospace; }
+.app-row .act-btn { margin-left: auto; }
+
+.jobs-table { width: 100%; border-collapse: collapse; font-size: 13px; margin-bottom: 10px; }
+.jobs-table th {
+    text-align: left; font-size: 11px; text-transform: uppercase;
+    letter-spacing: 0.04em; color: #7A8B9A; font-weight: 600;
+    padding: 6px 10px; border-bottom: 2px solid #EAEEF2;
+}
+.jobs-table td { padding: 7px 10px; border-bottom: 1px solid #FAFBFC; color: #3B4B5E; }
+.jobs-table .mono { font-family: 'SF Mono', Menlo, monospace; font-size: 12px; color: #7A8B9A; }
+.jobs-table .job-name { font-weight: 500; }
+.jobs-table .mlink { text-decoration: none; font-size: 12px; }
+.th-actions, .td-actions { text-align: right; white-space: nowrap; }
+
+.job-state {
+    display: inline-block; padding: 2px 10px; border-radius: 12px;
+    font-size: 11px; font-weight: 700;
+}
+.job-state.ok { background: #EFF8EF; color: #5CB85C; }
+.job-state.bad { background: #FDF1EF; color: #E87461; }
+.job-state.run { background: #EDF6FC; color: #4DA3D4; }
+.job-state.other { background: #FAFBFC; color: #7A8B9A; }
+
+.act-btn {
+    border: 1.5px solid var(--console-blue);
+    background: #fff; color: var(--console-blue);
+    border-radius: 6px; padding: 4px 14px;
+    font-size: 12px; font-weight: 600; cursor: pointer;
+}
+.act-btn:hover:not(:disabled) { background: #EDF6FC; }
+.act-btn:disabled { border-color: #C4CFD9; color: #C4CFD9; cursor: not-allowed; }
+.act-btn.troubleshoot:not(:disabled) { border-color: #E87461; color: #E87461; }
+.act-btn.troubleshoot:not(:disabled):hover { background: #FDF1EF; }
+.act-btn.upgrade:not(:disabled) { border-color: #FFAD4A; color: #FFAD4A; }
+.act-btn.upgrade:not(:disabled):hover { background: #FFF6EA; }
+
+/* ===== Ask AI chat widget ===== */
+#aiFab {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    z-index: 60;
+    background: var(--console-blue);
+    color: #fff;
+    border: none;
+    border-radius: 24px;
+    padding: 11px 20px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.25);
+}
+#aiFab:hover { background: #3D8CBD; }
+
+#aiPanel {
+    position: fixed;
+    right: 24px;
+    bottom: 78px;
+    z-index: 60;
+    width: 400px;
+    max-width: calc(100vw - 48px);
+    height: 520px;
+    max-height: calc(100vh - 120px);
+    background: #fff;
+    border: 1px solid #EAEEF2;
+    border-radius: 12px;
+    box-shadow: 0 8px 28px rgba(0,0,0,0.28);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+#aiPanel[hidden] { display: none; }
+
+.ai-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: var(--topbar-bg);
+    color: #fff;
+    padding: 10px 14px;
+    font-size: 14px;
+    font-weight: 600;
+}
+.ai-head .ai-hint { font-weight: 400; font-size: 11px; color: #9FAEBD; margin-left: auto; }
+.ai-head #aiClose {
+    background: none; border: none; color: #EAEEF2;
+    font-size: 20px; cursor: pointer; line-height: 1; padding: 0 2px;
+}
+
+.ai-msgs {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    background: #FAFBFC;
+}
+.ai-msg {
+    max-width: 88%;
+    padding: 8px 12px;
+    border-radius: 10px;
+    font-size: 13px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.ai-msg.user { align-self: flex-end; background: var(--console-blue); color: #fff; }
+.ai-msg.assistant { align-self: flex-start; background: #fff; border: 1px solid #EAEEF2; color: #3B4B5E; }
+.ai-msg.status { align-self: flex-start; color: #7A8B9A; font-size: 12px; font-family: 'SF Mono', Menlo, monospace; }
+
+#aiForm {
+    display: flex;
+    gap: 8px;
+    padding: 10px;
+    border-top: 1px solid #EAEEF2;
+    background: #fff;
+}
+#aiInput {
+    flex: 1;
+    border: 1px solid #C4CFD9;
+    border-radius: 18px;
+    padding: 8px 14px;
+    font-size: 13px;
+    outline: none;
+}
+#aiInput:focus { border-color: var(--console-blue); }
+#aiSend {
+    background: var(--console-blue);
+    color: #fff;
+    border: none;
+    border-radius: 18px;
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+}
+#aiSend:disabled { opacity: 0.5; cursor: default; }

--- a/utilities/EMR-Serverless-Config-Advisor/static/style.css
+++ b/utilities/EMR-Serverless-Config-Advisor/static/style.css
@@ -1,0 +1,514 @@
+/* EMR Serverless Config Advisor — UI Styles */
+
+:root {
+    --bg: #0f1419;
+    --surface: #1a2029;
+    --surface-2: #232d3a;
+    --border: #2d3a4a;
+    --text: #e4e8ec;
+    --text-muted: #8b99ab;
+    --accent: #4dabf7;
+    --accent-dim: #2e7bc8;
+    --green: #51cf66;
+    --orange: #ffa94d;
+    --red: #ff6b6b;
+    --purple: #cc5de8;
+    --radius: 8px;
+    --shadow: 0 2px 8px rgba(0,0,0,0.3);
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+}
+
+header {
+    margin-bottom: 2rem;
+}
+
+header h1 {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--text);
+}
+
+.subtitle {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    margin-top: 0.3rem;
+}
+
+.app-id {
+    font-family: monospace;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.back-link {
+    color: var(--accent);
+    text-decoration: none;
+    font-size: 0.9rem;
+    display: inline-block;
+    margin-bottom: 0.5rem;
+}
+.back-link:hover { text-decoration: underline; }
+
+/* Flash messages */
+.flash-messages { margin-bottom: 1.5rem; }
+.flash {
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius);
+    margin-bottom: 0.5rem;
+}
+.flash.error {
+    background: rgba(255, 107, 107, 0.15);
+    border: 1px solid var(--red);
+    color: var(--red);
+}
+
+/* Upload Section */
+.upload-section {
+    margin-bottom: 2.5rem;
+}
+
+.drop-zone {
+    border: 2px dashed var(--border);
+    border-radius: var(--radius);
+    padding: 3rem 2rem;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.2s;
+    background: var(--surface);
+    position: relative;
+}
+
+.drop-zone:hover, .drop-zone.drag-over {
+    border-color: var(--accent);
+    background: rgba(77, 171, 247, 0.05);
+}
+
+.drop-zone.has-file {
+    border-color: var(--green);
+    background: rgba(81, 207, 102, 0.05);
+}
+
+.drop-zone input[type="file"] {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+}
+
+.drop-zone-content svg {
+    color: var(--text-muted);
+    margin-bottom: 1rem;
+}
+
+.drop-text {
+    font-size: 1.1rem;
+    color: var(--text);
+    margin-bottom: 0.25rem;
+}
+
+.drop-text code {
+    background: var(--surface-2);
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.9rem;
+}
+
+.drop-hint {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+}
+
+.file-name {
+    color: var(--green);
+    font-family: monospace;
+    font-size: 0.9rem;
+    margin-top: 0.75rem;
+}
+
+.btn-analyze {
+    display: block;
+    width: 100%;
+    margin-top: 1rem;
+    padding: 0.85rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #fff;
+    background: var(--accent-dim);
+    border: none;
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: background 0.2s;
+}
+.btn-analyze:hover:not(:disabled) { background: var(--accent); }
+.btn-analyze:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Info Section */
+.info-section {
+    margin-top: 2rem;
+}
+.info-section h3 {
+    font-size: 1.1rem;
+    color: var(--text);
+    margin-bottom: 1rem;
+    margin-top: 1.5rem;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.info-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.25rem;
+}
+.info-card h4 {
+    font-size: 0.9rem;
+    color: var(--accent);
+    margin-bottom: 0.5rem;
+}
+.info-card p {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.info-section pre {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem;
+    overflow-x: auto;
+    font-size: 0.82rem;
+    color: var(--text-muted);
+}
+
+/* Summary Grid */
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.summary-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.25rem;
+    text-align: center;
+}
+
+.summary-value {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--accent);
+    font-family: monospace;
+}
+
+.summary-label {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin-top: 0.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+/* Sections */
+.section {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+.section h2 {
+    font-size: 1.15rem;
+    margin-bottom: 1rem;
+    color: var(--text);
+}
+
+/* Bottleneck */
+.bottleneck-primary {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+}
+
+.bottleneck-badge {
+    display: inline-block;
+    padding: 0.4rem 1rem;
+    border-radius: 20px;
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+.bottleneck-badge.iops-bound { background: rgba(204, 93, 232, 0.2); color: var(--purple); }
+.bottleneck-badge.disk-throughput-bound { background: rgba(255, 169, 77, 0.2); color: var(--orange); }
+.bottleneck-badge.memory-constrained { background: rgba(255, 107, 107, 0.2); color: var(--red); }
+.bottleneck-badge.cpu-constrained { background: rgba(81, 207, 102, 0.2); color: var(--green); }
+.bottleneck-badge.network-bound { background: rgba(77, 171, 247, 0.2); color: var(--accent); }
+.bottleneck-badge.balanced { background: rgba(139, 153, 171, 0.2); color: var(--text-muted); }
+
+.bottleneck-score {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    font-family: monospace;
+}
+
+.bottleneck-explanation {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    margin-bottom: 1.5rem;
+}
+
+/* Score Bars */
+.bottleneck-bars {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.bar-row {
+    display: grid;
+    grid-template-columns: 180px 1fr 40px;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.bar-label {
+    font-size: 0.82rem;
+    color: var(--text-muted);
+}
+
+.bar-track {
+    height: 8px;
+    background: var(--surface-2);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.bar-fill {
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.5s ease;
+}
+.bar-fill.bar-high { background: var(--red); }
+.bar-fill.bar-med { background: var(--orange); }
+.bar-fill.bar-low { background: var(--accent); }
+
+.bar-value {
+    font-size: 0.8rem;
+    font-family: monospace;
+    color: var(--text-muted);
+    text-align: right;
+}
+
+/* Metrics Grid */
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1rem;
+}
+
+.metric {
+    text-align: center;
+}
+
+.metric-value {
+    display: block;
+    font-size: 1.1rem;
+    font-weight: 600;
+    font-family: monospace;
+    color: var(--text);
+}
+
+.metric-label {
+    display: block;
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-top: 0.2rem;
+}
+
+/* Recommendation Cards */
+.rec-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+}
+
+.rec-card {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.25rem;
+}
+
+.rec-title {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+}
+.rec-title.cost { color: var(--green); }
+.rec-title.perf { color: var(--orange); }
+
+.worker-spec {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.worker-type {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: var(--text);
+}
+
+.worker-details {
+    font-size: 1rem;
+    color: var(--accent);
+    font-family: monospace;
+}
+
+.rec-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+}
+.rec-table td {
+    padding: 0.4rem 0;
+    border-bottom: 1px solid var(--border);
+}
+.rec-table td:first-child { color: var(--text-muted); }
+.rec-table td:last-child {
+    text-align: right;
+    font-family: monospace;
+    color: var(--text);
+}
+
+/* Warning Cards */
+.warning-card {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem;
+    margin-bottom: 0.75rem;
+    border-left: 3px solid;
+}
+.warning-card.high { border-left-color: var(--red); }
+.warning-card.medium { border-left-color: var(--orange); }
+.warning-card.low { border-left-color: var(--accent); }
+
+.warning-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.warning-severity {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    padding: 0.15rem 0.5rem;
+    border-radius: 3px;
+    background: rgba(255,107,107,0.15);
+    color: var(--red);
+}
+.warning-card.medium .warning-severity {
+    background: rgba(255,169,77,0.15);
+    color: var(--orange);
+}
+
+.warning-type {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    font-family: monospace;
+}
+
+.warning-message {
+    font-size: 0.88rem;
+    color: var(--text-muted);
+    margin-bottom: 0.5rem;
+}
+
+.warning-rec {
+    display: block;
+    font-size: 0.8rem;
+    background: var(--surface-2);
+    padding: 0.4rem 0.6rem;
+    border-radius: 4px;
+    color: var(--accent);
+    word-break: break-all;
+}
+
+/* Config Block */
+.config-block {
+    position: relative;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.config-block pre {
+    padding: 1rem;
+    overflow-x: auto;
+    font-size: 0.8rem;
+    line-height: 1.7;
+    color: var(--text-muted);
+}
+
+.config-block code {
+    font-family: 'SF Mono', Menlo, Monaco, monospace;
+}
+
+.source-config pre {
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.copy-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    padding: 0.3rem 0.7rem;
+    font-size: 0.75rem;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-muted);
+    cursor: pointer;
+    z-index: 1;
+}
+.copy-btn:hover {
+    background: var(--accent-dim);
+    color: #fff;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .rec-grid { grid-template-columns: 1fr; }
+    .bar-row { grid-template-columns: 120px 1fr 30px; }
+    .metrics-grid { grid-template-columns: repeat(2, 1fr); }
+}

--- a/utilities/EMR-Serverless-Config-Advisor/templates/base.html
+++ b/utilities/EMR-Serverless-Config-Advisor/templates/base.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}EMR Serverless Advisor{% endblock %}</title>
+    <link rel="stylesheet" href="/static/console.css?v={{ asset_v('console.css') }}">
+    {% block extra_head %}{% endblock %}
+</head>
+<body class="console">
+    <div class="topbar">
+        <span class="hamburger"><span></span><span></span><span></span></span>
+        <span class="emr-badge">EMR</span>
+        <a class="crumb" href="/">EMR Serverless Advisor</a>
+        <span class="crumb-sep">&rsaquo;</span>
+        <span class="crumb muted">{% block topbar_crumb %}Home{% endblock %}</span>
+        <div class="topbar-right">
+            <span>us-east-1</span>
+            <span class="top-icon">?</span>
+        </div>
+    </div>
+
+    <div class="shell">
+        <nav class="sidebar">
+            <div class="sidebar-title">EMR Serverless Advisor</div>
+            <a class="nav-item {{ 'active' if active == 'home' }}" href="/">Home</a>
+            <div class="nav-group-label">Tools</div>
+            <a class="nav-item {{ 'active' if active == 'config-advisor' }}" href="/config-advisor">Config Advisor</a>
+            <a class="nav-item {{ 'active' if active == 'observability' }}" href="/metrics-dashboard">Observability</a>
+            <div class="nav-group-label">Developers</div>
+            <a class="nav-item" href="/docs">API reference</a>
+            <div class="sidebar-foot">OSS stack: FastAPI &middot; Prometheus &middot; Chart.js</div>
+        </nav>
+
+        <main class="main {% block main_class %}{% endblock %}">
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+
+    <!-- ===== Ask AI chat widget ===== -->
+    <button id="aiFab" title="Ask AI">✦ Ask AI</button>
+    <div id="aiPanel" hidden>
+        <div class="ai-head">
+            <span>✦ Advisor AI</span>
+            <span class="ai-hint" id="aiCtxHint"></span>
+            <button id="aiClose" aria-label="close">×</button>
+        </div>
+        <div class="ai-msgs" id="aiMsgs">
+            <div class="ai-msg assistant">Ask me about this job's metrics or configs —
+            I can pull the submitted Spark confs, live Prometheus metrics, and
+            Config Advisor recommendations to give a grounded opinion.</div>
+        </div>
+        <form id="aiForm">
+            <input id="aiInput" placeholder="e.g. is the driver memory sized right for this run?" autocomplete="off">
+            <button type="submit" id="aiSend">Send</button>
+        </form>
+    </div>
+
+    <script>
+    (function () {
+        const fab = document.getElementById("aiFab");
+        const panel = document.getElementById("aiPanel");
+        const msgs = document.getElementById("aiMsgs");
+        const form = document.getElementById("aiForm");
+        const input = document.getElementById("aiInput");
+        const send = document.getElementById("aiSend");
+        const history = [];
+
+        fab.addEventListener("click", () => {
+            panel.hidden = !panel.hidden;
+            if (!panel.hidden) {
+                const ctx = window.aiPageContext ? window.aiPageContext() : {};
+                document.getElementById("aiCtxHint").textContent =
+                    ctx.job_run_id ? `context: ${ctx.job_run_id}` :
+                    ctx.application_id ? `context: ${ctx.application_id}` : "";
+                input.focus();
+            }
+        });
+        document.getElementById("aiClose").addEventListener("click", () => panel.hidden = true);
+
+        function addMsg(cls, text) {
+            const d = document.createElement("div");
+            d.className = "ai-msg " + cls;
+            d.textContent = text;
+            msgs.appendChild(d);
+            msgs.scrollTop = msgs.scrollHeight;
+            return d;
+        }
+
+        form.addEventListener("submit", async (e) => {
+            e.preventDefault();
+            const q = input.value.trim();
+            if (!q || send.disabled) return;
+            input.value = "";
+            send.disabled = true;
+            addMsg("user", q);
+            history.push({ role: "user", content: q });
+
+            const thinking = addMsg("status", "thinking…");
+            let answer = null, answerText = "";
+            try {
+                // Pages define window.aiPageContext() to describe what's on screen
+                const ctx = window.aiPageContext ? window.aiPageContext() : {};
+                const r = await fetch("/api/chat", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ messages: history, page_context: ctx }),
+                });
+                if (!r.ok) throw new Error("chat backend " + r.status);
+                const reader = r.body.getReader();
+                const dec = new TextDecoder();
+                let buf = "";
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    buf += dec.decode(value, { stream: true });
+                    const lines = buf.split("\n");
+                    buf = lines.pop();
+                    for (const line of lines) {
+                        if (!line.trim()) continue;
+                        const ev = JSON.parse(line);
+                        if (ev.type === "tool") {
+                            thinking.textContent = `⚙ ${ev.name}(${JSON.stringify(ev.input).slice(0, 80)})`;
+                        } else if (ev.type === "text") {
+                            if (!answer) { thinking.remove(); answer = addMsg("assistant", ""); }
+                            answerText += ev.text;
+                            answer.textContent = answerText;
+                            msgs.scrollTop = msgs.scrollHeight;
+                        }
+                    }
+                }
+                if (!answer) { thinking.textContent = "(no answer)"; }
+                else history.push({ role: "assistant", content: answerText });
+            } catch (err) {
+                thinking.textContent = "error: " + err.message;
+            } finally {
+                send.disabled = false;
+                input.focus();
+            }
+        });
+    })();
+    </script>
+</body>
+</html>

--- a/utilities/EMR-Serverless-Config-Advisor/templates/compare_results.html
+++ b/utilities/EMR-Serverless-Config-Advisor/templates/compare_results.html
@@ -1,0 +1,189 @@
+{% extends "base.html" %}
+{% block title %}Compare Runs — EMR Serverless Advisor{% endblock %}
+{% block topbar_crumb %}Config Advisor{% endblock %}
+{% block extra_head %}
+<link rel="stylesheet" href="/static/advisor.css?v={{ asset_v('advisor.css') }}">
+<style>
+  .cmp-table { width: 100%; border-collapse: collapse; font-size: 13px; background: #fff; }
+  .cmp-table th, .cmp-table td { padding: 8px 12px; border-bottom: 1px solid #EAEEF2; text-align: right; }
+  .cmp-table th { font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: #7A8B9A; border-bottom: 2px solid #EAEEF2; }
+  .cmp-table td:first-child, .cmp-table th:first-child { text-align: left; color: #7A8B9A; }
+  .cmp-table td.num { font-family: 'SF Mono', Menlo, monospace; }
+  .cmp-table td.win { font-weight: 700; color: #5CB85C; }
+  .delta-up { color: #E87461; font-family: 'SF Mono', Menlo, monospace; }
+  .delta-down { color: #5CB85C; font-family: 'SF Mono', Menlo, monospace; }
+  .delta-flat { color: #7A8B9A; font-family: 'SF Mono', Menlo, monospace; }
+  .run-head { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-bottom: 18px; }
+  .run-card { background: #fff; border: 1px solid #EAEEF2; border-radius: 10px; padding: 14px 18px; }
+  .run-card .tag { display: inline-block; font-size: 11px; font-weight: 700; padding: 2px 10px; border-radius: 10px; margin-bottom: 6px; }
+  .run-card.a .tag { background: #EDF6FC; color: #4DA3D4; }
+  .run-card.b .tag { background: #F4F2FB; color: #9B8FD4; }
+  .run-card .fname { font-family: 'SF Mono', Menlo, monospace; font-size: 12px; color: #7A8B9A; word-break: break-all; }
+  .diff-table td { text-align: left !important; font-family: 'SF Mono', Menlo, monospace; font-size: 12px; word-break: break-all; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="breadcrumbs">
+  <a href="/">EMR Serverless Advisor</a><span class="sep">&rsaquo;</span><a href="/config-advisor">Config Advisor</a><span class="sep">&rsaquo;</span><span class="current">Compare</span>
+</div>
+
+<a href="/config-advisor" class="back-link">&larr; New Analysis</a>
+<h1 class="page-title">{{ 'EC2 → Serverless Migration' if migration_mode else 'Run Comparison' }}</h1>
+<p class="page-subtitle">Delta % is B relative to A &middot; green value = better side where the metric has a direction</p>
+
+{% if migration_mode %}
+<div class="flash" style="background:#EDF6FC;border:1px solid #4DA3D4;color:#2F6E96;">
+  <b>Migration mode:</b> Run A = EC2 baseline, Run B = Serverless. The EC2 cost shown is
+  <i>hypothetical Serverless pricing of its resource-hours</i> (EC2 bills instance-hours —
+  compare against your actual EC2 bill separately). Use the stage-level table to find where
+  the Serverless run diverges; the Ask-AI panel has both runs and the migration context.
+</div>
+{% if a.slot_mismatch or b.slot_mismatch %}
+<div class="flash" style="background:#FFF6EA;border:1px solid #FFAD4A;color:#8A5A1F;">
+  <b>Check your uploads:</b>
+  {% if a.slot_mismatch %}the EC2 slot received what looks like a Serverless log.{% endif %}
+  {% if b.slot_mismatch %}the Serverless slot received what looks like an EC2 log.{% endif %}
+</div>
+{% endif %}
+{% endif %}
+
+<div class="run-head">
+  <div class="run-card a">
+    <span class="tag">RUN A</span>
+    <div class="fname">{{ a.source_filename }}</div>
+    <div style="margin-top:8px">
+      <span class="bottleneck-badge {{ a.bottleneck.primary|lower|replace(' ', '-') }}">{{ a.bottleneck.primary }}</span>
+      <span class="bottleneck-score">{{ a.bottleneck.primary_score }}/100</span>
+    </div>
+  </div>
+  <div class="run-card b">
+    <span class="tag">RUN B</span>
+    <div class="fname">{{ b.source_filename }}</div>
+    <div style="margin-top:8px">
+      <span class="bottleneck-badge {{ b.bottleneck.primary|lower|replace(' ', '-') }}">{{ b.bottleneck.primary }}</span>
+      <span class="bottleneck-score">{{ b.bottleneck.primary_score }}/100</span>
+    </div>
+  </div>
+</div>
+
+{% if a.run_cost and b.run_cost and (a.run_cost.source != 'billed' or b.run_cost.source != 'billed') %}
+<div class="flash" style="background:#FFF6EA;border:1px solid #FFAD4A;color:#8A5A1F;">
+  <b>Cost is an estimate.</b>
+  {% if a.run_cost.source != 'billed' %}Run A{% endif %}{% if a.run_cost.source != 'billed' and b.run_cost.source != 'billed' %} and {% endif %}{% if b.run_cost.source != 'billed' %}Run B{% endif %}
+  {{ 'were' if (a.run_cost.source != 'billed' and b.run_cost.source != 'billed') else 'was' }} not run in this AWS account, so billed utilization isn't available.
+  Estimates come from event-log executor lifetimes and typically run <b>2–20% below</b> the actual bill
+  (billing includes worker provisioning time invisible to the event log). Use the AWS console's
+  billed resource utilization for exact figures.
+</div>
+{% endif %}
+
+<section class="section">
+  <h2>Metrics side by side</h2>
+  <table class="cmp-table">
+    <thead><tr><th>Metric</th><th>Run A</th><th>Run B</th><th>Δ B vs A</th></tr></thead>
+    <tbody>
+      {% for r in rows %}
+      <tr>
+        <td>{{ r.label }}</td>
+        <td class="num {{ 'win' if r.better == 'a' }}">{{ r.a }} {{ r.unit }}</td>
+        <td class="num {{ 'win' if r.better == 'b' }}">{{ r.b }} {{ r.unit }}</td>
+        <td>
+          {% if r.delta_pct is not none %}
+            <span class="{{ 'delta-flat' if r.delta_pct == 0 else ('delta-up' if r.delta_pct > 0 else 'delta-down') }}">
+              {{ '%+.1f'|format(r.delta_pct) }}%</span>
+          {% else %}<span class="delta-flat">—</span>{% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+
+{% if stage_cmp.stages %}
+<section class="section">
+  <h2>Stage-level analysis (matched stages, CPU per GB)</h2>
+  <p class="page-subtitle" style="margin-bottom:10px">
+    Stages matched by name + data volume across runs. CPU/GB inflation on identical
+    data localizes contention, GC pressure, or write-path changes — the stage where
+    compute burn actually changed.
+  </p>
+  {% if stage_cmp.verdict %}
+  <div class="flash" style="background:#EDF6FC;border:1px solid #4DA3D4;color:#2F6E96;">
+    {{ stage_cmp.verdict }}
+  </div>
+  {% endif %}
+  <table class="cmp-table">
+    <thead><tr>
+      <th>Stage</th><th>Data</th><th>Tasks A/B</th>
+      <th>CPU-h A</th><th>CPU-h B</th>
+      <th>CPU s/GB A</th><th>CPU s/GB B</th><th>Δ CPU/GB</th>
+      <th>Spill A/B</th>
+    </tr></thead>
+    <tbody>
+      {% for s in stage_cmp.stages %}
+      <tr>
+        <td style="text-align:left">{{ s.name[:48] }}</td>
+        <td class="num">{{ "%.0f"|format(s.data_gb) }}G</td>
+        <td class="num">{{ s.tasks_a }}/{{ s.tasks_b }}</td>
+        <td class="num">{{ s.cpu_hours_a }}</td>
+        <td class="num">{{ s.cpu_hours_b }}</td>
+        <td class="num">{{ s.cpu_per_gb_a }}</td>
+        <td class="num">{{ s.cpu_per_gb_b }}</td>
+        <td>
+          {% if s.inflation_pct is not none %}
+          <span class="{{ 'delta-flat' if -10 <= s.inflation_pct <= 10 else ('delta-up' if s.inflation_pct > 10 else 'delta-down') }}">
+            {{ '%+.0f'|format(s.inflation_pct) }}%</span>
+          {% else %}—{% endif %}
+        </td>
+        <td class="num">{{ s.spill_gb_a }}/{{ s.spill_gb_b }}G</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endif %}
+
+<section class="section">
+  <h2>Config differences ({{ config_diff|length }})</h2>
+  {% if config_diff %}
+  <table class="cmp-table diff-table">
+    <thead><tr><th>Property</th><th>Run A</th><th>Run B</th></tr></thead>
+    <tbody>
+      {% for d in config_diff %}
+      <tr><td>{{ d.key }}</td><td>{{ d.a }}</td><td>{{ d.b }}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="page-subtitle">No meaningful Spark config differences detected.</p>
+  {% endif %}
+</section>
+
+<section class="section">
+  <h2>Bottleneck scores</h2>
+  <table class="cmp-table">
+    <thead><tr><th>Dimension</th><th>Run A</th><th>Run B</th></tr></thead>
+    <tbody>
+      {% for name, score_a in a.bottleneck.scores.items() %}
+      <tr>
+        <td>{{ name }}</td>
+        <td class="num">{{ score_a }}</td>
+        <td class="num">{{ b.bottleneck.scores.get(name, 0) }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+
+<script>
+  // Ask-AI grounding: both analyses + config diff + stage-level comparison
+  window.aiPageContext = () => ({
+    page: {{ '"ec2-serverless-migration"' if migration_mode else '"config-advisor-compare"' }},
+    run_a: {{ a | tojson }},
+    run_b: {{ b | tojson }},
+    config_diff: {{ config_diff | tojson }},
+    stage_comparison: {{ stage_cmp | tojson }},
+  });
+</script>
+{% endblock %}

--- a/utilities/EMR-Serverless-Config-Advisor/templates/config_advisor.html
+++ b/utilities/EMR-Serverless-Config-Advisor/templates/config_advisor.html
@@ -1,0 +1,193 @@
+{% extends "base.html" %}
+{% block title %}Config Advisor — EMR Serverless Advisor{% endblock %}
+{% block topbar_crumb %}Config Advisor{% endblock %}
+{% block extra_head %}<link rel="stylesheet" href="/static/advisor.css?v={{ asset_v('advisor.css') }}">{% endblock %}
+
+{% block content %}
+<div class="breadcrumbs">
+    <a href="/">EMR Serverless Advisor</a><span class="sep">&rsaquo;</span><span class="current">Config Advisor</span>
+</div>
+
+<h1 class="page-title">Config Advisor</h1>
+<p class="page-subtitle">Upload an extracted event log JSON to get bottleneck analysis and worker sizing recommendations</p>
+
+{% if error %}
+<div class="flash error">{{ error }}</div>
+{% endif %}
+
+<div class="upload-section">
+    <form action="/analyze" method="post" enctype="multipart/form-data" id="upload-form">
+        <div class="drop-zone" id="drop-zone">
+            <div class="drop-zone-content">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                    <polyline points="17,8 12,3 7,8"/>
+                    <line x1="12" y1="3" x2="12" y2="15"/>
+                </svg>
+                <p class="drop-text">Drop a raw <code>Spark event log</code> or extracted <code>task_stage_summary</code> JSON here</p>
+                <p class="drop-hint">raw logs (plain, .gz, rolling events_*, or .zip of an eventlog_v2 folder) are extracted on the server — or click to browse</p>
+                <p class="file-name" id="file-name"></p>
+            </div>
+            <input type="file" name="file" id="file-input" accept=".json,.zip,.gz,.lz4,.zstd,.inprogress" required>
+        </div>
+        <button type="submit" class="btn-analyze" id="btn-submit" disabled>
+            <span class="btn-text">Analyze</span>
+            <span class="btn-loading" style="display:none;">Analyzing... (raw event logs can take a minute)</span>
+        </button>
+    </form>
+</div>
+
+<div class="upload-section compare-section">
+    <h3 style="margin-bottom:10px">EC2 &rarr; EMR Serverless migration</h3>
+    <p class="drop-hint" style="margin-bottom:10px">
+        Migrating a job from EMR on EC2? Upload what you have — one or both.
+        EC2 log alone: get the translated Serverless config to start from.
+        Both logs: side-by-side comparison with per-stage analysis to troubleshoot
+        when the Serverless run's performance or cost isn't acceptable, plus a
+        hypothetical-Serverless cost for the EC2 run.
+    </p>
+    <form action="/analyze-migration" method="post" enctype="multipart/form-data" id="migration-form">
+        <div class="compare-grid">
+            <label class="cmp-slot">
+                <span class="cmp-tag a">EC2 RUN</span>
+                <input type="file" name="file_ec2" accept=".json,.zip,.gz,.lz4,.zstd,.inprogress">
+            </label>
+            <label class="cmp-slot">
+                <span class="cmp-tag b">SERVERLESS RUN</span>
+                <input type="file" name="file_sls" accept=".json,.zip,.gz,.lz4,.zstd,.inprogress">
+            </label>
+        </div>
+        <button type="submit" class="btn-analyze" id="btn-migrate">
+            <span class="btn-text">Analyze migration</span>
+            <span class="btn-loading" style="display:none;">Analyzing... (raw event logs can take a minute)</span>
+        </button>
+    </form>
+</div>
+
+<div class="upload-section compare-section">
+    <h3 style="margin-bottom:10px">Compare two runs</h3>
+    <p class="drop-hint" style="margin-bottom:10px">Two event logs of the same job (e.g. before / after a config change) — get metrics deltas, config diff, and both bottleneck profiles side by side.</p>
+    <form action="/analyze-compare" method="post" enctype="multipart/form-data" id="compare-form">
+        <div class="compare-grid">
+            <label class="cmp-slot">
+                <span class="cmp-tag a">RUN A</span>
+                <input type="file" name="file_a" accept=".json,.zip,.gz,.lz4,.zstd,.inprogress" required>
+            </label>
+            <label class="cmp-slot">
+                <span class="cmp-tag b">RUN B</span>
+                <input type="file" name="file_b" accept=".json,.zip,.gz,.lz4,.zstd,.inprogress" required>
+            </label>
+        </div>
+        <button type="submit" class="btn-analyze" id="btn-compare">
+            <span class="btn-text">Compare</span>
+            <span class="btn-loading" style="display:none;">Comparing... (raw event logs can take a minute)</span>
+        </button>
+    </form>
+</div>
+
+<div class="info-section">
+    <h3>What this tool does</h3>
+    <div class="info-grid">
+        <div class="info-card">
+            <h4>Bottleneck Detection</h4>
+            <p>Classifies your workload as IOPS bound, disk throughput bound, memory constrained, CPU constrained, or network bound.</p>
+        </div>
+        <div class="info-card">
+            <h4>Worker Sizing</h4>
+            <p>Recommends optimal worker type (4c, 8c, or 16c) with memory sizing based on workload profile.</p>
+        </div>
+        <div class="info-card">
+            <h4>Spark Configs</h4>
+            <p>Generates tuned Spark configurations including shuffle partitions, dynamic allocation, and disk sizing.</p>
+        </div>
+        <div class="info-card">
+            <h4>Cost vs Performance</h4>
+            <p>Provides both cost-optimized and performance-optimized recommendations with trade-off analysis.</p>
+        </div>
+    </div>
+
+    <h3>How to get the input file</h3>
+    <pre><code># Option A — upload the raw event log directly (extraction happens here):
+aws s3 cp s3://bucket/emr-serverless-logs/applications/app-id/jobs/job-id/sparklogs/eventlog_v2_app-id/events_1_app-id .
+#   single file: upload as-is (plain or .gz)
+#   rolling directory: zip it first ->  zip -r eventlog.zip eventlog_v2_app-id/
+
+# Option B — pre-extract locally, upload the summary JSON:
+python3 python_extractor.py \
+    --input /path/to/eventlog_v2_app-id \
+    --output /tmp/extracted/ --single-app
+# Upload the file from: /tmp/extracted/task_stage_summary/*.json</code></pre>
+</div>
+
+<script>
+    const dropZone = document.getElementById('drop-zone');
+    const fileInput = document.getElementById('file-input');
+    const fileName = document.getElementById('file-name');
+    const btnSubmit = document.getElementById('btn-submit');
+    const form = document.getElementById('upload-form');
+
+    dropZone.addEventListener('click', () => fileInput.click());
+
+    dropZone.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        dropZone.classList.add('drag-over');
+    });
+
+    dropZone.addEventListener('dragleave', () => {
+        dropZone.classList.remove('drag-over');
+    });
+
+    dropZone.addEventListener('drop', (e) => {
+        e.preventDefault();
+        dropZone.classList.remove('drag-over');
+        if (e.dataTransfer.files.length > 0) {
+            fileInput.files = e.dataTransfer.files;
+            updateFileName(e.dataTransfer.files[0]);
+        }
+    });
+
+    fileInput.addEventListener('change', () => {
+        if (fileInput.files.length > 0) {
+            updateFileName(fileInput.files[0]);
+        }
+    });
+
+    function updateFileName(file) {
+        fileName.textContent = file.name + ' (' + formatBytes(file.size) + ')';
+        btnSubmit.disabled = false;
+        dropZone.classList.add('has-file');
+    }
+
+    function formatBytes(bytes) {
+        if (bytes < 1024) return bytes + ' B';
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+        return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+    }
+
+    form.addEventListener('submit', () => {
+        btnSubmit.querySelector('.btn-text').style.display = 'none';
+        btnSubmit.querySelector('.btn-loading').style.display = 'inline';
+        btnSubmit.disabled = true;
+    });
+
+    document.getElementById('compare-form').addEventListener('submit', (e) => {
+        const btn = document.getElementById('btn-compare');
+        btn.querySelector('.btn-text').style.display = 'none';
+        btn.querySelector('.btn-loading').style.display = 'inline';
+        btn.disabled = true;
+    });
+
+    document.getElementById('migration-form').addEventListener('submit', (e) => {
+        const f = e.target;
+        if (!f.file_ec2.files.length && !f.file_sls.files.length) {
+            e.preventDefault();
+            alert('Upload at least one event log (EC2 or Serverless).');
+            return;
+        }
+        const btn = document.getElementById('btn-migrate');
+        btn.querySelector('.btn-text').style.display = 'none';
+        btn.querySelector('.btn-loading').style.display = 'inline';
+        btn.disabled = true;
+    });
+</script>
+{% endblock %}

--- a/utilities/EMR-Serverless-Config-Advisor/templates/index.html
+++ b/utilities/EMR-Serverless-Config-Advisor/templates/index.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EMR Serverless Config Advisor</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>EMR Serverless Config Advisor</h1>
+            <p class="subtitle">Upload an extracted event log JSON to get bottleneck analysis and worker sizing recommendations</p>
+        </header>
+
+        {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+        <div class="flash-messages">
+            {% for category, message in messages %}
+            <div class="flash {{ category }}">{{ message }}</div>
+            {% endfor %}
+        </div>
+        {% endif %}
+        {% endwith %}
+
+        <div class="upload-section">
+            <form action="{{ url_for('analyze') }}" method="post" enctype="multipart/form-data" id="upload-form">
+                <div class="drop-zone" id="drop-zone">
+                    <div class="drop-zone-content">
+                        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                            <polyline points="17,8 12,3 7,8"/>
+                            <line x1="12" y1="3" x2="12" y2="15"/>
+                        </svg>
+                        <p class="drop-text">Drop your <code>task_stage_summary</code> JSON here</p>
+                        <p class="drop-hint">or click to browse</p>
+                        <p class="file-name" id="file-name"></p>
+                    </div>
+                    <input type="file" name="file" id="file-input" accept=".json" required>
+                </div>
+                <button type="submit" class="btn-analyze" id="btn-submit" disabled>
+                    <span class="btn-text">Analyze</span>
+                    <span class="btn-loading" style="display:none;">Analyzing...</span>
+                </button>
+            </form>
+        </div>
+
+        <div class="info-section">
+            <h3>What this tool does</h3>
+            <div class="info-grid">
+                <div class="info-card">
+                    <h4>Bottleneck Detection</h4>
+                    <p>Classifies your workload as IOPS bound, disk throughput bound, memory constrained, CPU constrained, or network bound.</p>
+                </div>
+                <div class="info-card">
+                    <h4>Worker Sizing</h4>
+                    <p>Recommends optimal worker type (4c, 8c, or 16c) with memory sizing based on workload profile.</p>
+                </div>
+                <div class="info-card">
+                    <h4>Spark Configs</h4>
+                    <p>Generates tuned Spark configurations including shuffle partitions, dynamic allocation, and disk sizing.</p>
+                </div>
+                <div class="info-card">
+                    <h4>Cost vs Performance</h4>
+                    <p>Provides both cost-optimized and performance-optimized recommendations with trade-off analysis.</p>
+                </div>
+            </div>
+
+            <h3>How to get the input file</h3>
+            <pre><code># Run the spark extractor on your event logs:
+python3 spark_extractor.py \
+    --input s3://bucket/emr-serverless-logs/applications/app-id/jobs/job-id/sparklogs/ \
+    --output /tmp/extracted/ \
+    --limit 1
+
+# Upload the file from: /tmp/extracted/task_stage_summary/*.json</code></pre>
+        </div>
+    </div>
+
+    <script>
+        const dropZone = document.getElementById('drop-zone');
+        const fileInput = document.getElementById('file-input');
+        const fileName = document.getElementById('file-name');
+        const btnSubmit = document.getElementById('btn-submit');
+        const form = document.getElementById('upload-form');
+
+        dropZone.addEventListener('click', () => fileInput.click());
+
+        dropZone.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            dropZone.classList.add('drag-over');
+        });
+
+        dropZone.addEventListener('dragleave', () => {
+            dropZone.classList.remove('drag-over');
+        });
+
+        dropZone.addEventListener('drop', (e) => {
+            e.preventDefault();
+            dropZone.classList.remove('drag-over');
+            if (e.dataTransfer.files.length > 0) {
+                fileInput.files = e.dataTransfer.files;
+                updateFileName(e.dataTransfer.files[0]);
+            }
+        });
+
+        fileInput.addEventListener('change', () => {
+            if (fileInput.files.length > 0) {
+                updateFileName(fileInput.files[0]);
+            }
+        });
+
+        function updateFileName(file) {
+            fileName.textContent = file.name + ' (' + formatBytes(file.size) + ')';
+            btnSubmit.disabled = false;
+            dropZone.classList.add('has-file');
+        }
+
+        function formatBytes(bytes) {
+            if (bytes < 1024) return bytes + ' B';
+            if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+            return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+        }
+
+        form.addEventListener('submit', () => {
+            btnSubmit.querySelector('.btn-text').style.display = 'none';
+            btnSubmit.querySelector('.btn-loading').style.display = 'inline';
+            btnSubmit.disabled = true;
+        });
+    </script>
+</body>
+</html>

--- a/utilities/EMR-Serverless-Config-Advisor/templates/landing.html
+++ b/utilities/EMR-Serverless-Config-Advisor/templates/landing.html
@@ -1,0 +1,174 @@
+{% extends "base.html" %}
+{% block title %}EMR Serverless Advisor{% endblock %}
+{% block topbar_crumb %}Home{% endblock %}
+
+{% block content %}
+<h1 class="page-title">EMR Serverless Advisor</h1>
+<p class="page-subtitle">Analyze Spark workloads, right-size workers, and watch live worker metrics — all from one place.</p>
+
+<div class="landing-info">
+    <div class="info-item">
+        <div class="k">Region</div>
+        <div class="v">us-east-1</div>
+    </div>
+    <div class="info-item">
+        <div class="k">Prometheus</div>
+        <div class="v" id="promStatus"><span class="status-dot"></span>checking…</div>
+    </div>
+    <div class="info-item">
+        <div class="k">Apps with metrics (48h)</div>
+        <div class="v" id="appCount">–</div>
+    </div>
+</div>
+
+<!-- ===== Applications & recent job runs ===== -->
+<div class="jobs-panel">
+    <div class="jobs-panel-head">
+        <h2>Applications &amp; recent job runs</h2>
+        <button class="act-btn" id="newJobBtn" title="T-shirt size a brand-new job with no run history">＋ Size a new job</button>
+        <span class="hint" id="jobsHint">last 72h · latest release <b id="latestRel">–</b></span>
+    </div>
+    <div id="jobsTables"><p class="jobs-loading">loading applications…</p></div>
+</div>
+
+<div class="landing-grid">
+    <div class="landing-card">
+        <h2>Config Advisor</h2>
+        <p class="desc">Upload an extracted event log to diagnose your workload and get sizing recommendations.</p>
+        <ul>
+            <li>Bottleneck classification — IOPS, disk throughput, memory, CPU, network</li>
+            <li>Worker sizing (4c / 8c / 16c) with memory and disk recommendations</li>
+            <li>Cost-optimized and performance-optimized Spark configs, ready to copy</li>
+        </ul>
+        <div class="card-actions">
+            <a class="btn-pill primary" href="/config-advisor">Open Config Advisor</a>
+        </div>
+        <div class="status-line">Input: task_stage_summary JSON from spark_extractor.py</div>
+    </div>
+
+    <div class="landing-card">
+        <h2>Observability</h2>
+        <p class="desc">Live and replay dashboards for driver and executor resources during a job run.</p>
+        <ul>
+            <li>Separate driver / executor views — heap, RSS, CPU, GC</li>
+            <li>Shuffle disk usage and active tasks per executor</li>
+            <li>Spark job status — jobs, stages, task completions and failures</li>
+        </ul>
+        <div class="card-actions">
+            <a class="btn-pill primary" href="/metrics-dashboard">Open Observability</a>
+        </div>
+        <div class="status-line">Source: GraphiteSink &rarr; Prometheus (metrics-enabled job runs)</div>
+    </div>
+</div>
+
+<script>
+fetch("/api/metrics/apps?hours=48").then(r => r.json()).then(j => {
+    const st = document.getElementById("promStatus");
+    if (j.apps) {
+        st.innerHTML = '<span class="status-dot ok"></span>connected';
+        document.getElementById("appCount").textContent = j.apps.length;
+    } else {
+        st.innerHTML = '<span class="status-dot bad"></span>unreachable';
+    }
+}).catch(() => {
+    document.getElementById("promStatus").innerHTML = '<span class="status-dot bad"></span>unreachable';
+});
+
+// ===== Applications & job runs table with Optimize / Troubleshoot / Upgrade =====
+const FAILED_STATES = ["FAILED", "CANCELLED", "CANCELLING"];
+
+// Home page context for the Ask-AI panel (set when an action button is clicked)
+let aiCtx = { page: "home" };
+window.aiPageContext = () => aiCtx;
+
+function askAgent(prompt, ctx) {
+    aiCtx = Object.assign({ page: "home" }, ctx);
+    const panel = document.getElementById("aiPanel");
+    if (panel.hidden) document.getElementById("aiFab").click();
+    const input = document.getElementById("aiInput");
+    input.value = prompt;
+    document.getElementById("aiForm").requestSubmit();
+}
+
+function stateBadge(state) {
+    const cls = state === "SUCCESS" ? "ok" :
+        FAILED_STATES.includes(state) ? "bad" :
+        state === "RUNNING" ? "run" : "other";
+    return `<span class="job-state ${cls}">${state}</span>`;
+}
+
+function renderOverview(data) {
+    const root = document.getElementById("jobsTables");
+    document.getElementById("latestRel").textContent = data.latestRelease;
+    if (!data.applications.length) {
+        root.innerHTML = `<p class="jobs-loading">${data.error ? "EMR API unavailable: " + data.error : "no applications active in the last 72h"}</p>`;
+        return;
+    }
+    root.innerHTML = "";
+    data.applications.forEach(app => {
+        const upg = app.upgradeAvailable;
+        const section = document.createElement("div");
+        section.className = "app-section";
+        section.innerHTML = `
+            <div class="app-row">
+                <span class="app-name">${app.name}</span>
+                <span class="app-meta">${app.id} · ${app.releaseLabel || "?"} · ${app.state}</span>
+                <button class="act-btn upgrade" ${upg ? "" : "disabled"}
+                    title="${upg ? "Plan upgrade to " + data.latestRelease : "Already on latest (" + data.latestRelease + ")"}"
+                    data-app="${app.id}" data-rel="${app.releaseLabel}">Upgrade</button>
+            </div>`;
+        const upgBtn = section.querySelector(".act-btn.upgrade");
+        if (upg) upgBtn.addEventListener("click", () =>
+            askAgent(`Plan an upgrade of application ${app.id} (${app.name}) from ${app.releaseLabel} to ${data.latestRelease}. Use get_application_details, then give a migration checklist: Spark/Java version changes, config/API breakages to check in our jobs, and a validation plan.`,
+                     { application_id: app.id }));
+
+        if (app.jobs.length) {
+            const tbl = document.createElement("table");
+            tbl.className = "jobs-table";
+            tbl.innerHTML = `<thead><tr>
+                <th>Job run</th><th>ID</th><th>Status</th><th>Started</th><th class="th-actions">Actions</th>
+            </tr></thead>`;
+            const tb = document.createElement("tbody");
+            app.jobs.forEach(job => {
+                const failed = FAILED_STATES.includes(job.state);
+                const tr = document.createElement("tr");
+                tr.innerHTML = `
+                    <td class="job-name">${job.name}${job.hasMetrics ? ` <a class="mlink" href="/metrics-dashboard?app_id=${job.id}" title="open in Observability">📈</a>` : ""}</td>
+                    <td class="mono">${job.id}</td>
+                    <td>${stateBadge(job.state)}</td>
+                    <td class="mono">${job.createdAt.slice(0, 16).replace("T", " ")}</td>
+                    <td class="td-actions">
+                        <button class="act-btn optimize">Optimize</button>
+                        <button class="act-btn troubleshoot" ${failed ? "" : "disabled"}
+                            title="${failed ? "Diagnose this failed run" : "Enabled for failed/cancelled runs"}">Troubleshoot</button>
+                    </td>`;
+                tr.querySelector(".optimize").addEventListener("click", () =>
+                    askAgent(`Optimize job run ${job.id} (${job.name}). Run run_config_advisor on it${job.hasMetrics ? " and cross-check with get_metrics_snapshot" : ""}, then give me the recommended worker sizing and Spark configs with the reasoning, cost vs performance.`,
+                             { application_id: app.id, job_run_id: job.id }));
+                tr.querySelector(".troubleshoot").addEventListener("click", () =>
+                    askAgent(`Troubleshoot job run ${job.id} (${job.name}) which is ${job.state}. Use troubleshoot_job, identify the root cause from the state details and driver stderr, and give the fix.`,
+                             { application_id: app.id, job_run_id: job.id }));
+                tb.appendChild(tr);
+            });
+            tbl.appendChild(tb);
+            section.appendChild(tbl);
+        } else {
+            section.insertAdjacentHTML("beforeend",
+                `<p class="jobs-loading">no job runs in window</p>`);
+        }
+        root.appendChild(section);
+    });
+}
+
+document.getElementById("newJobBtn").addEventListener("click", () =>
+    askAgent("I have a brand-new Spark job with no run history. Interview me briefly (input size GB, workload type, joins and largest table, expected shuffle, SLA, file count — whatever I know), then use tshirt_sizing to bucket it and give me the worker type and full spark-submit configs.",
+             { intent: "new-job-sizing" }));
+
+fetch("/api/home/overview?hours=72")
+    .then(r => r.json()).then(renderOverview)
+    .catch(e => {
+        document.getElementById("jobsTables").innerHTML =
+            `<p class="jobs-loading">failed to load: ${e.message}</p>`;
+    });
+</script>
+{% endblock %}

--- a/utilities/EMR-Serverless-Config-Advisor/templates/metrics_dashboard.html
+++ b/utilities/EMR-Serverless-Config-Advisor/templates/metrics_dashboard.html
@@ -1,0 +1,363 @@
+{% extends "base.html" %}
+{% block title %}Observability — EMR Serverless Advisor{% endblock %}
+{% block topbar_crumb %}Observability{% endblock %}
+
+{% block extra_head %}
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
+  <style>
+    .dash-controls { display: flex; gap: 12px; align-items: center; margin: 16px 0; flex-wrap: wrap; }
+    .section { margin: 22px 0; }
+    .section-header { padding: 8px 14px; border-radius: 8px 8px 0 0; font-weight: 600; color: #fff; font-size: 15px; }
+    .section-header.overview { background: #9B8FD4; }
+    .section-header.driver { background: #FFAD4A; }
+    .section-header.executor { background: #4DA3D4; }
+    .section-header.jobs { background: #5CB85C; }
+    .section-body { border: 1px solid #EAEEF2; border-top: none; border-radius: 0 0 8px 8px; padding: 14px; background: #FAFBFC; }
+    .stat-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+    .stat-card { background: #fff; border: 1px solid #EAEEF2; border-radius: 8px; padding: 14px; text-align: center; }
+    .stat-card .value { font-size: 44px; font-weight: 700; line-height: 1.1; }
+    .stat-card .label { color: #666; font-size: 13px; margin-top: 4px; }
+    .chart-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+    .panel { background: #fff; border: 1px solid #EAEEF2; border-radius: 8px; padding: 12px; }
+    .panel h4 { margin: 0 0 4px; font-size: 14px; }
+    .panel .hint { color: #888; font-size: 11px; margin: 0 0 6px; }
+    .live-dot { display:inline-block; width:10px; height:10px; border-radius:50%; background:#5CB85C; margin-right:6px; }
+    .live-dot.paused { background:#aaa; }
+    canvas { max-height: 210px; }
+    .hint { color: #888; font-size: 12px; }
+  </style>
+{% endblock %}
+
+{% block content %}
+    <div class="breadcrumbs">
+      <a href="/">EMR Serverless Advisor</a><span class="sep">&rsaquo;</span><span class="current">Observability</span>
+    </div>
+    <h1 class="page-title">Observability</h1>
+    <p class="page-subtitle">Live driver and executor resources for metrics-enabled job runs</p>
+
+    <div class="dash-controls">
+      <label>Application:
+        <select id="emrAppSelect"><option value="">loading…</option></select>
+      </label>
+      <label>Job run:
+        <select id="appSelect"><option value="">loading…</option></select>
+      </label>
+      <label>Window:
+        <select id="windowSelect">
+          <option value="900">last 15 min</option>
+          <option value="3600" selected>last 1 h</option>
+          <option value="21600">last 6 h</option>
+          <option value="86400">last 24 h</option>
+        </select>
+      </label>
+      <label><input type="checkbox" id="liveToggle" checked> <span class="live-dot" id="liveDot"></span>live (30s)</label>
+      <span id="status" class="hint"></span>
+    </div>
+
+    <!-- ===== Resource overview (stat cards) ===== -->
+    <div class="section">
+      <div class="section-header overview">Resource overview</div>
+      <div class="section-body">
+        <div class="stat-grid">
+          <div class="stat-card"><div class="value" id="statJobs">–</div><div class="label">Jobs running</div></div>
+          <div class="stat-card"><div class="value" id="statStages">–</div><div class="label">Stages running</div></div>
+          <div class="stat-card"><div class="value" id="statTasks">–</div><div class="label">Tasks running</div></div>
+          <div class="stat-card"><div class="value" id="statExecutors">–</div><div class="label">Executors</div></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== Driver resources ===== -->
+    <div class="section">
+      <div class="section-header driver">Driver resources</div>
+      <div class="section-body">
+        <div class="chart-grid">
+          <div class="panel">
+            <h4>Driver heap used (GB)</h4>
+            <p class="hint">dotted line = heap max — the gap is your OOM headroom</p>
+            <canvas id="drvHeap"></canvas>
+          </div>
+          <div class="panel">
+            <h4>Driver process RSS (GB)</h4>
+            <p class="hint">JVM + Python + other — what the container OOM-killer (137) sees</p>
+            <canvas id="drvRss"></canvas>
+          </div>
+          <div class="panel">
+            <h4>Driver CPU (cores)</h4>
+            <canvas id="drvCpu"></canvas>
+          </div>
+          <div class="panel">
+            <h4>Driver GC (ms/s)</h4>
+            <p class="hint">sustained &gt;100 ms/s = heap pressure (GC thrash)</p>
+            <canvas id="drvGc"></canvas>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== Executor resources ===== -->
+    <div class="section">
+      <div class="section-header executor">Executor resources</div>
+      <div class="section-body">
+        <div class="chart-grid">
+          <div class="panel">
+            <h4>Executor heap used (GB)</h4>
+            <canvas id="exeHeap"></canvas>
+          </div>
+          <div class="panel">
+            <h4>Executor process RSS (GB)</h4>
+            <canvas id="exeRss"></canvas>
+          </div>
+          <div class="panel">
+            <h4>Executor CPU (cores)</h4>
+            <canvas id="exeCpu"></canvas>
+          </div>
+          <div class="panel">
+            <h4>Executor GC (ms/s)</h4>
+            <canvas id="exeGc"></canvas>
+          </div>
+          <div class="panel">
+            <h4>Executor disk used (GB)</h4>
+            <p class="hint">BlockManager disk (shuffle + spill + cached blocks)</p>
+            <canvas id="exeDisk"></canvas>
+          </div>
+          <div class="panel">
+            <h4>Active tasks per executor</h4>
+            <p class="hint">flat at cores = fully utilized; 0 while others work = skew</p>
+            <canvas id="exeTasks"></canvas>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== Spark job status ===== -->
+    <div class="section">
+      <div class="section-header jobs">Spark job status</div>
+      <div class="section-body">
+        <div class="chart-grid">
+          <div class="panel">
+            <h4>Jobs by status</h4>
+            <p class="hint">needs spark.metrics.appStatusSource.enabled=true</p>
+            <canvas id="jobStatus"></canvas>
+          </div>
+          <div class="panel">
+            <h4>Stages by status</h4>
+            <canvas id="stageStatus"></canvas>
+          </div>
+          <div class="panel">
+            <h4>Tasks completed (cumulative)</h4>
+            <canvas id="taskDone"></canvas>
+          </div>
+          <div class="panel">
+            <h4>Task failures</h4>
+            <canvas id="taskFail"></canvas>
+          </div>
+        </div>
+      </div>
+    </div>
+
+<script>
+const GB = 1024 ** 3;
+const DRIVER = 'exec_id="driver"';
+const EXEC = 'exec_id!="driver"';
+
+const PANELS = [
+  // Driver
+  { canvas: "drvHeap", scale: 1/GB, query: `spark_jvm_heap_used{app_id="{app}",${DRIVER}}`,
+    overlay: { query: `spark_jvm_heap_max{app_id="{app}",${DRIVER}}`, label: "heap max", dash: [6,4] } },
+  { canvas: "drvRss", scale: 1/GB,
+    query: `sum by (exec_id) ({__name__=~"spark_executor_metrics_ProcessTree(JVM|Python|Other)RSSMemory", app_id="{app}", ${DRIVER}})` },
+  { canvas: "drvCpu", scale: 1, query: `rate(spark_jvm_cpu_time_ns{app_id="{app}",${DRIVER}}[1m]) / 1e9` },
+  { canvas: "drvGc", scale: 1, query: `sum by (exec_id) (rate(spark_executor_metrics_TotalGCTime{app_id="{app}",${DRIVER}}[1m]))` },
+  // Executors
+  { canvas: "exeHeap", scale: 1/GB, query: `spark_jvm_heap_used{app_id="{app}",${EXEC}}`,
+    overlay: { query: `max(spark_jvm_heap_max{app_id="{app}",${EXEC}})`, label: "heap max", dash: [6,4] } },
+  { canvas: "exeRss", scale: 1/GB,
+    query: `sum by (exec_id) ({__name__=~"spark_executor_metrics_ProcessTree(JVM|Python|Other)RSSMemory", app_id="{app}", ${EXEC}})` },
+  { canvas: "exeCpu", scale: 1, query: `rate(spark_jvm_cpu_time_ns{app_id="{app}",${EXEC}}[1m]) / 1e9` },
+  { canvas: "exeGc", scale: 1, query: `sum by (exec_id) (rate(spark_executor_metrics_TotalGCTime{app_id="{app}",${EXEC}}[1m]))` },
+  { canvas: "exeDisk", scale: 1/GB, query: `spark_blockmanager_disk_diskSpaceUsed_MB{app_id="{app}"} * 1024 * 1024` },
+  { canvas: "exeTasks", scale: 1, query: `spark_executor_threadpool_activeTasks{app_id="{app}",${EXEC}}` },
+  // Job status — running/active gauges come from DAGScheduler; cumulative
+  // counters from appStatus (spark.metrics.appStatusSource.enabled=true)
+  { canvas: "jobStatus", scale: 1, labelBy: "status", query:
+    `label_replace(spark_dagscheduler_job_activeJobs{app_id="{app}",${DRIVER}}, "status","active","","")
+      or label_replace(spark_app_jobs_succeededJobs{app_id="{app}",${DRIVER}}, "status","succeeded","","")
+      or label_replace(spark_app_jobs_failedJobs{app_id="{app}",${DRIVER}}, "status","failed","","")` },
+  { canvas: "stageStatus", scale: 1, labelBy: "status", query:
+    `label_replace(spark_dagscheduler_stage_runningStages{app_id="{app}",${DRIVER}}, "status","running","","")
+      or label_replace(spark_dagscheduler_stage_waitingStages{app_id="{app}",${DRIVER}}, "status","waiting","","")
+      or label_replace(spark_app_stages_completedStages{app_id="{app}",${DRIVER}}, "status","completed","","")
+      or label_replace(spark_app_stages_failedStages{app_id="{app}",${DRIVER}}, "status","failed","","")
+      or label_replace(spark_app_stages_skippedStages{app_id="{app}",${DRIVER}}, "status","skipped","","")` },
+  { canvas: "taskDone", scale: 1, query: `spark_app_tasks_completedTasks{app_id="{app}",${DRIVER}}` },
+  { canvas: "taskFail", scale: 1, query: `spark_app_tasks_failedTasks{app_id="{app}",${DRIVER}}` },
+];
+
+// Stat cards: instant queries evaluated at "now" (or end of window)
+const STATS = [
+  { el: "statJobs", query: `spark_dagscheduler_job_activeJobs{app_id="{app}"}` },
+  { el: "statStages", query: `spark_dagscheduler_stage_runningStages{app_id="{app}"}` },
+  { el: "statTasks", query: `sum(spark_executor_threadpool_activeTasks{app_id="{app}",${EXEC}})` },
+  { el: "statExecutors", query: `count(count by (exec_id) (spark_jvm_heap_used{app_id="{app}",${EXEC}}))` },
+];
+
+const COLORS = ["#E87461","#3498db","#5CB85C","#9B8FD4","#FFAD4A","#1abc9c","#34495e","#FFAD4A","#D65A47","#4DA3D4"];
+const charts = {};
+
+function mkChart(id) {
+  return new Chart(document.getElementById(id), {
+    type: "line",
+    data: { datasets: [] },
+    options: {
+      animation: false, responsive: true,
+      scales: { x: { type: "linear", ticks: { callback: v => new Date(v*1000).toLocaleTimeString() } },
+                y: { beginAtZero: true } },
+      plugins: { legend: { labels: { boxWidth: 12, font: { size: 10 } } } },
+      elements: { point: { radius: 0 } },
+    },
+  });
+}
+
+async function q(query, appId, start, end, step) {
+  const u = `/api/metrics/query_range?query=${encodeURIComponent(query.replaceAll("{app}", appId))}&start=${start}&end=${end}&step=${step}`;
+  const r = await fetch(u);
+  const j = await r.json();
+  if (j.status !== "success") throw new Error(j.error || "query failed");
+  return j.data.result;
+}
+
+function seriesLabel(metric, labelBy) {
+  if (labelBy && metric[labelBy]) return metric[labelBy];
+  const e = metric.exec_id || "?";
+  return e === "driver" ? "driver" : `executor ${e}`;
+}
+
+async function refresh() {
+  const appId = document.getElementById("appSelect").value;
+  if (!appId) return;
+  const winSec = parseInt(document.getElementById("windowSelect").value);
+  const end = Math.floor(Date.now() / 1000);
+  const start = end - winSec;
+  const step = Math.max(15, Math.floor(winSec / 200)) + "s";
+  document.getElementById("status").textContent = "refreshing…";
+
+  await Promise.all(PANELS.map(async p => {
+    try {
+      const results = await q(p.query, appId, start, end, step);
+      const ch = charts[p.canvas];
+      const ds = results.map((r, i) => ({
+        label: seriesLabel(r.metric, p.labelBy),
+        data: r.values.map(([t, v]) => ({ x: +t, y: +v * p.scale })),
+        borderColor: COLORS[i % COLORS.length],
+        borderWidth: 1.5, fill: false,
+      }));
+      if (p.overlay) {
+        try {
+          const ov = await q(p.overlay.query, appId, start, end, step);
+          if (ov.length) ds.push({
+            label: p.overlay.label,
+            data: ov[0].values.map(([t, v]) => ({ x: +t, y: +v * p.scale })),
+            borderColor: "#555", borderDash: p.overlay.dash, borderWidth: 1.5, fill: false,
+          });
+        } catch (e) { /* overlay optional */ }
+      }
+      ch.data.datasets = ds;
+      ch.update();
+    } catch (e) { console.error(p.canvas, e); }
+  }));
+
+  // stat cards — use last value in window so finished jobs still show
+  await Promise.all(STATS.map(async s => {
+    try {
+      const results = await q(s.query, appId, start, end, step);
+      let v = "–";
+      if (results.length) {
+        const vals = results[0].values;
+        v = Math.round(+vals[vals.length - 1][1]);
+      }
+      document.getElementById(s.el).textContent = v;
+    } catch (e) { document.getElementById(s.el).textContent = "–"; }
+  }));
+
+  document.getElementById("status").textContent = "updated " + new Date().toLocaleTimeString();
+}
+
+// Selector model: Application = EMR Serverless application id,
+// Job run = EMR Serverless job run id (which IS the Spark app id that
+// Prometheus stores in the app_id label).
+const LOOKBACK_HOURS = 48;
+const PRESELECT_JOB = "{{ app_id }}";
+
+function fillSelect(sel, items, valueKey, labelFn) {
+  sel.innerHTML = "";
+  items.forEach(it => {
+    const o = document.createElement("option");
+    o.value = valueKey ? it[valueKey] : it;
+    o.textContent = labelFn ? labelFn(it) : it;
+    sel.appendChild(o);
+  });
+}
+
+async function loadJobsForApp(emrAppId) {
+  const jobSel = document.getElementById("appSelect");
+  jobSel.innerHTML = "<option value=''>loading…</option>";
+  const r = await fetch(`/api/emr/jobs?application_id=${encodeURIComponent(emrAppId)}&hours=${LOOKBACK_HOURS}`);
+  const j = await r.json();
+  const jobs = j.jobs || [];
+  fillSelect(jobSel, jobs, "id",
+    jb => `${jb.name || jb.id} (${jb.id}, ${jb.state})`);
+  if (PRESELECT_JOB) jobSel.value = PRESELECT_JOB;
+  if (!jobSel.value && jobSel.options.length) jobSel.selectedIndex = 0;
+  refresh();
+}
+
+async function loadFallbackJobList() {
+  // No EMR API access — flat list of job run ids straight from Prometheus
+  const r = await fetch(`/api/metrics/apps?hours=${LOOKBACK_HOURS}`);
+  const j = await r.json();
+  const jobSel = document.getElementById("appSelect");
+  fillSelect(jobSel, j.apps || []);
+  if (PRESELECT_JOB) jobSel.value = PRESELECT_JOB;
+  if (!jobSel.value && jobSel.options.length) jobSel.selectedIndex = jobSel.options.length - 1;
+  refresh();
+}
+
+async function loadApps() {
+  const appSel = document.getElementById("emrAppSelect");
+  try {
+    const r = await fetch(`/api/emr/applications?hours=${LOOKBACK_HOURS}`);
+    const j = await r.json();
+    const apps = j.applications || [];
+    if (!apps.length) throw new Error(j.error || "no applications");
+    fillSelect(appSel, apps, "id",
+      a => `${a.name} (${a.id}, ${a.metricJobCount} jobs)`);
+    appSel.addEventListener("change", () => loadJobsForApp(appSel.value));
+    await loadJobsForApp(appSel.value);
+  } catch (e) {
+    console.warn("EMR application list unavailable, falling back:", e);
+    fillSelect(appSel, []);
+    appSel.innerHTML = "<option value=''>unavailable</option>";
+    await loadFallbackJobList();
+  }
+}
+
+// Ask-AI grounding: what's currently selected on this page
+window.aiPageContext = () => ({
+  page: "observability",
+  application_id: document.getElementById("emrAppSelect").value || undefined,
+  job_run_id: document.getElementById("appSelect").value || undefined,
+  window_seconds: parseInt(document.getElementById("windowSelect").value),
+});
+
+PANELS.forEach(p => charts[p.canvas] = mkChart(p.canvas));
+document.getElementById("appSelect").addEventListener("change", refresh);
+document.getElementById("windowSelect").addEventListener("change", refresh);
+setInterval(() => {
+  const live = document.getElementById("liveToggle").checked;
+  document.getElementById("liveDot").classList.toggle("paused", !live);
+  if (live) refresh();
+}, 30000);
+loadApps();
+</script>
+{% endblock %}

--- a/utilities/EMR-Serverless-Config-Advisor/templates/results.html
+++ b/utilities/EMR-Serverless-Config-Advisor/templates/results.html
@@ -1,0 +1,383 @@
+{% extends "base.html" %}
+{% block title %}Analysis Results — EMR Serverless Advisor{% endblock %}
+{% block topbar_crumb %}Config Advisor{% endblock %}
+{% block extra_head %}<link rel="stylesheet" href="/static/advisor.css?v={{ asset_v('advisor.css') }}">{% endblock %}
+
+{% block content %}
+<div class="breadcrumbs">
+    <a href="/">EMR Serverless Advisor</a><span class="sep">&rsaquo;</span><a href="/config-advisor">Config Advisor</a><span class="sep">&rsaquo;</span><span class="current">Results</span>
+</div>
+
+<a href="/config-advisor" class="back-link">&larr; New Analysis</a>
+<h1 class="page-title">Analysis Results</h1>
+<p class="page-subtitle">{{ result.application_name }} <span class="app-id">({{ result.application_id }})</span></p>
+
+{% if result.source_platform == 'emr-ec2' %}
+<div class="flash" style="background:#EDF6FC;border:1px solid #4DA3D4;color:#2F6E96;">
+  <b>EMR on EC2 source detected</b> — recommendations below are the
+  <b>EC2 &rarr; Serverless migration</b> translation: instance-based sizing mapped to
+  Serverless workers, fleet sized with the Serverless efficiency gain, worker memory
+  at tier maximum (EC2 peak metrics undercount Serverless needs).
+</div>
+{% endif %}
+{% if result.metrics_summary.failed_tasks or result.metrics_summary.dead_executors %}
+<div class="flash" style="background:#FFF6EA;border:1px solid #FFAD4A;color:#8A5A1F;">
+  <b>Run health:</b> {{ result.metrics_summary.failed_tasks }} failed /
+  {{ result.metrics_summary.killed_tasks }} killed tasks of
+  {{ "{:,}".format(result.metrics_summary.total_tasks) }},
+  {{ result.metrics_summary.dead_executors }} executors lost
+  {%- if result.metrics_summary.dead_executor_reasons %}
+    ({{ result.metrics_summary.dead_executor_reasons.items() | map('join', ': ') | join(', ') }})
+  {%- endif %}.
+</div>
+{% endif %}
+
+        <!-- Summary Cards -->
+        <div class="summary-grid">
+            <div class="summary-card">
+                <div class="summary-value">{{ "%.1f"|format(result.duration_hours or 0) }}h</div>
+                <div class="summary-label">Duration</div>
+            </div>
+            <div class="summary-card">
+                <div class="summary-value">{{ "{:,}".format(result.metrics_summary.total_tasks) }}</div>
+                <div class="summary-label">Total Tasks</div>
+            </div>
+            <div class="summary-card">
+                <div class="summary-value">{{ "%.1f"|format(result.bottleneck.avg_task_time_sec) }}s</div>
+                <div class="summary-label">Avg Task Time</div>
+            </div>
+            <div class="summary-card">
+                <div class="summary-value">{{ result.metrics_summary.total_executors }}</div>
+                <div class="summary-label">Executors</div>
+            </div>
+            {% if result.run_cost %}
+            <div class="summary-card">
+                <div class="summary-value">${{ "%.4f"|format(result.run_cost.cost_usd) }}</div>
+                <div class="summary-label">Run cost ({{ result.run_cost.source }})</div>
+            </div>
+            <div class="summary-card">
+                <div class="summary-value">{{ "%.2f"|format(result.run_cost.vcpu_hours) }} / {{ "%.1f"|format(result.run_cost.memory_gb_hours) }}</div>
+                <div class="summary-label">vCPU-h / GB-h</div>
+            </div>
+            {% endif %}
+        </div>
+
+        <!-- Bottleneck Classification -->
+        <section class="section bottleneck-section">
+            <h2>Bottleneck Classification</h2>
+            <div class="bottleneck-primary">
+                <span class="bottleneck-badge {{ result.bottleneck.primary|lower|replace(' ', '-') }}">
+                    {{ result.bottleneck.primary }}
+                </span>
+                <span class="bottleneck-score">Score: {{ result.bottleneck.primary_score }}/100</span>
+            </div>
+            <p class="bottleneck-explanation">{{ result.bottleneck.explanation }}</p>
+
+            <div class="bottleneck-bars">
+                {% for name, score in result.bottleneck.scores.items() %}
+                <div class="bar-row">
+                    <span class="bar-label">{{ name }}</span>
+                    <div class="bar-track">
+                        <div class="bar-fill {{ 'bar-high' if score >= 60 else ('bar-med' if score >= 30 else 'bar-low') }}"
+                             style="width: {{ score }}%"></div>
+                    </div>
+                    <span class="bar-value">{{ score }}</span>
+                </div>
+                {% endfor %}
+            </div>
+        </section>
+
+        <!-- IO Metrics -->
+        <section class="section">
+            <h2>I/O Profile</h2>
+            <div class="metrics-grid">
+                <div class="metric">
+                    <span class="metric-value">{{ "%.1f"|format(result.metrics_summary.total_input_gb) }} GB</span>
+                    <span class="metric-label">Input</span>
+                </div>
+                <div class="metric">
+                    <span class="metric-value">{{ "%.1f"|format(result.metrics_summary.total_shuffle_read_gb) }} GB</span>
+                    <span class="metric-label">Shuffle Read</span>
+                </div>
+                <div class="metric">
+                    <span class="metric-value">{{ "%.1f"|format(result.metrics_summary.total_shuffle_write_gb) }} GB</span>
+                    <span class="metric-label">Shuffle Write</span>
+                </div>
+                <div class="metric">
+                    <span class="metric-value">{{ "%.1f"|format(result.metrics_summary.total_memory_spill_gb) }} GB</span>
+                    <span class="metric-label">Mem Spill</span>
+                </div>
+                <div class="metric">
+                    <span class="metric-value">{{ "%.1f"|format(result.metrics_summary.total_disk_spill_gb) }} GB</span>
+                    <span class="metric-label">Disk Spill</span>
+                </div>
+                <div class="metric">
+                    <span class="metric-value">{{ "%.0f"|format(result.metrics_summary.avg_cpu_util_pct) }}%</span>
+                    <span class="metric-label">Avg CPU</span>
+                </div>
+                <div class="metric">
+                    <span class="metric-value">{{ "%.0f"|format(result.metrics_summary.avg_memory_util_pct) }}%</span>
+                    <span class="metric-label">Avg Memory</span>
+                </div>
+                <div class="metric">
+                    <span class="metric-value">{{ "%.0f"|format(result.metrics_summary.idle_core_pct) }}%</span>
+                    <span class="metric-label">Idle Cores</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Recommendations Side by Side -->
+        <section class="section">
+            <h2>Worker Recommendations</h2>
+            <div class="rec-grid">
+                <!-- Cost Optimized -->
+                <div class="rec-card">
+                    <h3 class="rec-title cost">Cost Optimized</h3>
+                    {% if result.cost_recommendation.worker %}
+                    <div class="worker-spec">
+                        <div class="worker-type">{{ result.cost_recommendation.worker.type }}</div>
+                        <div class="worker-details">
+                            {{ result.cost_recommendation.worker.vcpu }}c / {{ result.cost_recommendation.worker.memory_gb }}G
+                        </div>
+                    </div>
+                    <table class="rec-table">
+                        <tr><td>Max Executors</td><td>{{ result.cost_recommendation.worker.max_executors }}</td></tr>
+                        <tr><td>Min Executors</td><td>{{ result.cost_recommendation.worker.min_executors }}</td></tr>
+                        <tr><td>Total vCPU</td><td>{{ result.cost_recommendation.worker.total_vcpu_capacity }}</td></tr>
+                        <tr><td>Total Memory</td><td>{{ result.cost_recommendation.worker.total_memory_capacity }} GB</td></tr>
+                        {% if result.cost_recommendation.shuffle_tuned %}
+                        <tr><td>Partitions</td><td>{{ result.cost_recommendation.shuffle_tuned.partitions }}</td></tr>
+                        {% endif %}
+                    </table>
+                    {% endif %}
+                </div>
+
+                <!-- Performance Optimized -->
+                <div class="rec-card">
+                    <h3 class="rec-title perf">Performance Optimized</h3>
+                    {% if result.perf_recommendation.worker %}
+                    <div class="worker-spec">
+                        <div class="worker-type">{{ result.perf_recommendation.worker.type }}</div>
+                        <div class="worker-details">
+                            {{ result.perf_recommendation.worker.vcpu }}c / {{ result.perf_recommendation.worker.memory_gb }}G
+                        </div>
+                    </div>
+                    <table class="rec-table">
+                        <tr><td>Max Executors</td><td>{{ result.perf_recommendation.worker.max_executors }}</td></tr>
+                        <tr><td>Min Executors</td><td>{{ result.perf_recommendation.worker.min_executors }}</td></tr>
+                        <tr><td>Total vCPU</td><td>{{ result.perf_recommendation.worker.total_vcpu_capacity }}</td></tr>
+                        <tr><td>Total Memory</td><td>{{ result.perf_recommendation.worker.total_memory_capacity }} GB</td></tr>
+                        {% if result.perf_recommendation.shuffle_tuned %}
+                        <tr><td>Partitions</td><td>{{ result.perf_recommendation.shuffle_tuned.partitions }}</td></tr>
+                        {% endif %}
+                    </table>
+                    {% endif %}
+                </div>
+            </div>
+        </section>
+
+        <!-- Bottleneck Warnings -->
+        {% if result.cost_recommendation.get('bottleneck_warnings') %}
+        <section class="section">
+            <h2>Bottleneck Warnings</h2>
+            {% for warning in result.cost_recommendation.bottleneck_warnings %}
+            <div class="warning-card {{ warning.severity|lower }}">
+                <div class="warning-header">
+                    <span class="warning-severity">{{ warning.severity }}</span>
+                    <span class="warning-type">{{ warning.type }}</span>
+                </div>
+                <p class="warning-message">{{ warning.message }}</p>
+                {% if warning.recommendation %}
+                <code class="warning-rec">{{ warning.recommendation }}</code>
+                {% endif %}
+            </div>
+            {% endfor %}
+        </section>
+        {% endif %}
+
+        <!-- Spark Configs -->
+        <section class="section">
+            <h2>Recommended Spark Configs (Cost)</h2>
+            {% if result.cost_recommendation.spark_configs %}
+            <div class="config-block">
+                <button class="copy-btn" onclick="copyConfigs('cost-configs')">Copy</button>
+                <pre id="cost-configs"><code>{% for key, value in result.cost_recommendation.spark_configs.items()|sort %}--conf {{ key }}={{ value }}
+{% endfor %}</code></pre>
+            </div>
+            {% endif %}
+        </section>
+
+        <section class="section">
+            <h2>Recommended Spark Configs (Performance)</h2>
+            {% if result.perf_recommendation.spark_configs %}
+            <div class="config-block">
+                <button class="copy-btn" onclick="copyConfigs('perf-configs')">Copy</button>
+                <pre id="perf-configs"><code>{% for key, value in result.perf_recommendation.spark_configs.items()|sort %}--conf {{ key }}={{ value }}
+{% endfor %}</code></pre>
+            </div>
+            {% endif %}
+        </section>
+
+        <!-- Query plans (Spark-UI-style, from event log sparkPlanInfo) -->
+        {% if result.query_plans %}
+        <section class="section">
+            <h2>Query plans</h2>
+            <p class="page-subtitle" style="margin-bottom:10px">
+                Physical operator trees per SQL execution with metrics from the event log —
+                like the Spark UI's SQL tab. Expand an execution; 🔥 marks the operators
+                doing the most work (rows/bytes/spill).
+            </p>
+            <div id="qp-root"></div>
+        </section>
+        <style>
+            .qp-exec { border: 1px solid var(--card-border); border-radius: 8px; margin-bottom: 8px; background: #FAFBFC; }
+            .qp-exec > summary { cursor: pointer; padding: 10px 14px; font-size: 0.88rem; font-weight: 600; color: var(--ink); }
+            .qp-exec > summary .qp-dur { color: var(--ink-muted); font-weight: 400; font-family: monospace; margin-left: 8px; }
+            .qp-tree { padding: 4px 14px 12px; overflow-x: auto; }
+            .qp-node { font-family: 'SF Mono', Menlo, monospace; font-size: 0.76rem; line-height: 1.9; white-space: nowrap; }
+            .qp-node .op { color: var(--ink); font-weight: 600; }
+            .qp-node .op.hot { color: var(--red); }
+            .qp-node .met { color: var(--blue); }
+            .qp-node .det { color: var(--ink-muted); }
+            .qp-toggle { cursor: pointer; user-select: none; color: var(--ink-muted); }
+        </style>
+        <script>
+        (function () {
+            const plans = {{ result.query_plans | tojson }};
+            const fmt = (name, v) => {
+                const n = name.toLowerCase();
+                if (n.includes("size") || n.includes("bytes") || n.includes("memory") || n.includes("spill")) {
+                    if (v >= 1024**4) return (v/1024**4).toFixed(1) + " TiB";
+                    if (v >= 1024**3) return (v/1024**3).toFixed(1) + " GiB";
+                    if (v >= 1024**2) return (v/1024**2).toFixed(1) + " MiB";
+                    if (v >= 1024) return (v/1024).toFixed(1) + " KiB";
+                    return v + " B";
+                }
+                if (n.includes("time") || n.includes("duration")) {
+                    if (v >= 3600000) return (v/3600000).toFixed(1) + " h";
+                    if (v >= 60000) return (v/60000).toFixed(1) + " m";
+                    if (v >= 1000) return (v/1000).toFixed(1) + " s";
+                    return v + " ms";
+                }
+                return v.toLocaleString();
+            };
+            const KEY_METRICS = ["number of output rows", "spill size", "shuffle bytes written",
+                "shuffle records written", "data size", "peak memory", "files read",
+                "bytes read", "records read", "time in aggregation build",
+                "sort time", "number of partitions", "written output"];
+            function maxWork(node) {
+                let w = 0;
+                for (const [k, v] of Object.entries(node.metrics || {}))
+                    if (k.includes("rows") || k.includes("bytes") || k.includes("size")) w = Math.max(w, v);
+                return Math.max(w, ...(node.children || []).map(maxWork), 0);
+            }
+            function render(node, depth, hotThreshold) {
+                const div = document.createElement("div");
+                div.className = "qp-node";
+                div.style.paddingLeft = (depth * 18) + "px";
+                let own = 0;
+                for (const [k, v] of Object.entries(node.metrics || {}))
+                    if (k.includes("rows") || k.includes("bytes") || k.includes("size")) own = Math.max(own, v);
+                const hot = hotThreshold > 0 && own >= hotThreshold;
+                const mets = Object.entries(node.metrics || {})
+                    .filter(([k]) => KEY_METRICS.some(km => k.toLowerCase().includes(km)))
+                    .sort((a, b) => b[1] - a[1]).slice(0, 4)
+                    .map(([k, v]) => `${k}: ${fmt(k, v)}`).join(" · ");
+                div.innerHTML = `${depth ? '<span class="qp-toggle">└─ </span>' : ""}` +
+                    `<span class="op${hot ? " hot" : ""}">${hot ? "🔥 " : ""}${node.name}</span>` +
+                    (mets ? ` <span class="met">[${mets}]</span>` : "") +
+                    (node.detail && depth < 2 ? `<br><span class="det" style="padding-left:${depth*18+22}px">${node.detail.slice(0, 130)}</span>` : "");
+                const frag = document.createDocumentFragment();
+                frag.appendChild(div);
+                (node.children || []).forEach(c => frag.appendChild(render(c, depth + 1, hotThreshold)));
+                return frag;
+            }
+            const root = document.getElementById("qp-root");
+            plans.forEach(p => {
+                const det = document.createElement("details");
+                det.className = "qp-exec";
+                const dur = p.duration_ms ? (p.duration_ms >= 60000 ?
+                    (p.duration_ms/60000).toFixed(1) + " min" : (p.duration_ms/1000).toFixed(1) + " s") : "";
+                det.innerHTML = `<summary>#${p.execution_id} ${p.description || "(unnamed)"}<span class="qp-dur">${dur}</span></summary>`;
+                const tree = document.createElement("div");
+                tree.className = "qp-tree";
+                det.appendChild(tree);
+                let rendered = false;
+                det.addEventListener("toggle", () => {
+                    if (det.open && !rendered) {
+                        rendered = true;
+                        tree.appendChild(render(p.plan, 0, maxWork(p.plan) * 0.5));
+                    }
+                });
+                root.appendChild(det);
+            });
+            // auto-open the longest execution
+            if (plans.length) {
+                let hottest = plans.reduce((a, b) => (b.duration_ms || 0) > (a.duration_ms || 0) ? b : a);
+                const idx = plans.indexOf(hottest);
+                root.children[idx] && (root.children[idx].open = true);
+            }
+        })();
+        </script>
+        {% endif %}
+
+        <!-- Config audit: recommended vs submitted, computed server-side -->
+        {% if result.config_audit %}
+        <section class="section">
+            <h2>Config audit — recommended vs submitted</h2>
+            <p class="page-subtitle" style="margin-bottom:8px">
+                Computed deterministically from the event log. "not captured" = submit-only
+                parameters (e.g. executor disk) that event logs never carry — check your
+                actual submit parameters for those.
+            </p>
+            <table class="rec-table">
+                <tr><th style="text-align:left">Property</th><th style="text-align:left">Recommended</th><th style="text-align:left">Submitted</th><th style="text-align:left">Status</th></tr>
+                {% for r in result.config_audit %}
+                {% if r.status != 'match' %}
+                <tr>
+                    <td style="font-family:monospace;font-size:0.78rem">{{ r.key }}</td>
+                    <td style="font-family:monospace;font-size:0.78rem">{{ r.recommended }}</td>
+                    <td style="font-family:monospace;font-size:0.78rem">{{ r.submitted }}</td>
+                    <td>{% if r.status == 'differs' %}<span style="color:var(--orange);font-weight:600">differs</span>
+                        {% elif r.status == 'absent' %}<span style="color:var(--red);font-weight:600">absent</span>
+                        {% else %}<span style="color:var(--ink-muted)">not captured in event log</span>{% endif %}</td>
+                </tr>
+                {% endif %}
+                {% endfor %}
+            </table>
+            <p class="page-subtitle" style="margin-top:8px">
+                {{ result.config_audit | selectattr('status', 'equalto', 'match') | list | length }} of
+                {{ result.config_audit | length }} recommended properties already match.
+            </p>
+        </section>
+        {% endif %}
+
+        <!-- Source Config -->
+        <section class="section">
+            <h2>Source Spark Config</h2>
+            {% if result.spark_config_source %}
+            <div class="config-block source-config">
+                <pre><code>{% for key, value in result.spark_config_source.items()|sort %}{{ key }} = {{ value }}
+{% endfor %}</code></pre>
+            </div>
+            {% endif %}
+        </section>
+
+<script>
+    // Ask-AI grounding: the full analysis shown on this page
+    window.aiPageContext = () => ({
+        page: "config-advisor-results",
+        analysis: {{ result | tojson }},
+    });
+
+    function copyConfigs(elementId) {
+        const el = document.getElementById(elementId);
+        const text = el.textContent;
+        navigator.clipboard.writeText(text).then(() => {
+            const btn = el.parentElement.querySelector('.copy-btn');
+            btn.textContent = 'Copied!';
+            setTimeout(() => btn.textContent = 'Copy', 2000);
+        });
+    }
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary

Adds a FastAPI web UI to the EMR Serverless Config Advisor with an EMR-console-style shell, plus extractor improvements it depends on.

### Config Advisor
- Upload raw Spark event logs directly — EMR Serverless or EMR on EC2; plain / `.gz` / `.zstd` / rolling `events_N` files, or a `.zip` of the `eventlog_v2_*` directory — or pre-extracted `task_stage_summary` JSONs. Extraction happens server-side (pure Python, no Spark runtime).
- Bottleneck classification, cost- and performance-optimized worker/config recommendations.
- **Run cost**: billed vCPU-h/GB-h/storage via the EMR API when the run is in the same account (exact, matches console); labeled lifetime-based estimate otherwise, with the estimation bias documented.
- **Query plans**: Spark-UI-SQL-tab-style operator trees per execution with accumulator-resolved metrics (rows, bytes, spill, peak memory) and per-operator failure attribution (which stage failed on which operator, reasons, sample error).
- **Config audit**: deterministic recommended-vs-submitted comparison with `match / differs / absent / not-captured-in-event-log` statuses.

### EC2 → Serverless migration workbench
- EC2 event logs auto-detected (`spark.emr_cluster_id`) and routed through the migration branch for translated Serverless configs.
- Upload EC2 baseline + Serverless attempt together for a migration-mode comparison to troubleshoot performance/cost regressions after migrating.

### Compare two runs
- Metric deltas with better-side highlighting, noise-filtered config diff, per-stage CPU-per-GB analysis with an automatic verdict that localizes contention/GC/write-path changes.

### Observability
- Live driver/executor dashboards (heap vs heap-max, ProcessTree RSS, CPU, GC, disk, active tasks, job/stage/task status) backed by a self-hosted Prometheus (Spark GraphiteSink → graphite_exporter pipeline). Application → Job run selector via the EMR Serverless API.

### Ask AI (optional)
- Embedded assistant using Bedrock Converse tool-use: pulls submitted confs (GetJobRun), Prometheus metrics, session analyses; t-shirt sizing for brand-new jobs. Includes grounding guardrails: it must quote the deterministic config audit rather than reconstructing comparisons, knows event-log blind spots (submit-only params), and calibrates failure questions against actual failure counts.

### Extractor improvements (`python_extractor.py`)
- Capture **all** submitted `spark.*` properties (the fixed allowlist silently dropped `spark.network.timeout`, `dynamicAllocation.minExecutors`, etc., making them look unset downstream).
- Per-stage CPU time in `stage_summary` ("Executor CPU Time" is nanoseconds in event logs despite naming).
- Query-plan extraction (`extract_query_plans`) with AQE final plans, metric resolution from driver + task accumulators, and failure attribution via stage↔operator accumulator mapping.
- Handle newer Spark's 3-tuple `ExecutorMetricsUpdate` format (was crashing on unpack).

## Dependencies and licensing
This PR adds no vendored third-party code. Runtime dependencies are installed by the user: FastAPI/uvicorn/Jinja2/boto3 (pip; MIT/BSD/Apache-2.0), Chart.js loaded from CDN at runtime (MIT). The optional Observability backend talks to a user-operated Prometheus over HTTP only (Apache-2.0; nothing linked or redistributed here).

## Testing
- Upload paths validated with Serverless and EC2 event logs (single-file, gz, zstd rolling, zipped directories) plus legacy extracted JSONs.
- Cost figures validated against `billedResourceUtilization` (billed path byte-exact; estimator bias measured and documented).
- Query-plan failure attribution validated on a run with executor OOM (exit 137) — correctly distinguishes the origin operator from downstream FetchFailed casualties.
- Compare and migration flows validated end-to-end with real event-log pairs.

Run instructions in `utilities/EMR-Serverless-Config-Advisor/WEBUI_README.md`.
