### PR TITLE
feat(config-advisor): optional driver/executor logs upload — stderr signature evidence in web UI

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/WEBUI_README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/WEBUI_README.md
@@ -12,6 +12,13 @@ FastAPI web UI for the Config Advisor with an EMR-console-style shell.
   (Spark-UI-SQL-tab-style operator trees with metrics and per-operator
   failure attribution), and a deterministic recommended-vs-submitted config
   audit.
+  Optionally attach a .zip of driver/executor stderr (driver log plus the
+  stderr of any failed executors — EMR Serverless `SPARK_DRIVER`/
+  `SPARK_EXECUTOR` and YARN `container_*` layouts are auto-detected): a
+  curated signature scan adds the *why* the event log can't show — heap OOM
+  vs container RSS kill vs disk full vs S3 throttling vs execution-memory
+  contention — with excerpts, and corroboration notes on the bottleneck
+  verdict.
 - **EC2 → Serverless migration**: EC2 event logs are auto-detected and get
   migration-translated configs; upload the EC2 baseline and a Serverless
   attempt together for a migration-mode comparison.

--- a/utilities/EMR-Serverless-Config-Advisor/app.py
+++ b/utilities/EMR-Serverless-Config-Advisor/app.py
@@ -37,6 +37,7 @@ from fastapi.templating import Jinja2Templates
 
 # Import the fine tuner for recommendations
 from emr_s_fine_tuner import generate_dual_recommendations
+from log_evidence import corroboration_notes, extract_log_evidence
 
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -276,7 +277,10 @@ You have tools. USE THEM before answering — do not guess:
 - query_prometheus: any PromQL range query for drill-down (metric names use
   labels app_id=<job_run_id>, exec_id=driver|1|2|…)
 - get_recent_analyses: Config Advisor results analyzed this session
-  (bottleneck scores, recommended cost/perf configs)
+  (bottleneck scores, recommended cost/perf configs, log-evidence summaries)
+- get_log_evidence: full stderr excerpts/stack traces when the user attached
+  the optional driver/executor logs zip to an analysis — quote the actual
+  error instead of inferring failure causes from metrics
 - run_config_advisor: full pipeline on a job run's event log — bottleneck
   classification + cost/perf recommendations (slow, 30-120s; use for
   "optimize this job")
@@ -756,6 +760,15 @@ CHAT_TOOLS = [
         "inputSchema": {"json": {"type": "object", "properties": {}}},
     }},
     {"toolSpec": {
+        "name": "get_log_evidence",
+        "description": "Full driver/executor stderr signature evidence — error excerpts and stack traces — for an analysis where the user attached the optional logs zip. Use to quote the ACTUAL error (heap OOM vs container RSS kill vs disk full vs S3 throttle) instead of inferring failure causes from event-log metrics.",
+        "inputSchema": {"json": {
+            "type": "object",
+            "properties": {"application_id": {"type": "string", "description": "application_id from get_recent_analyses"}},
+            "required": ["application_id"],
+        }},
+    }},
+    {"toolSpec": {
         "name": "run_config_advisor",
         "description": "Run the FULL Config Advisor pipeline on a finished job run: downloads its Spark event log from S3, extracts metrics, and returns bottleneck classification plus cost- and performance-optimized worker/config recommendations. Takes 30-120s. Use for 'optimize this job' requests.",
         "inputSchema": {"json": {
@@ -802,6 +815,44 @@ CHAT_TOOLS = [
 ]
 
 
+def _analyses_without_excerpts() -> list:
+    """Recent analyses with log-evidence excerpts elided — signature titles,
+    counts, and notes stay; the full stack traces live behind
+    get_log_evidence so every get_recent_analyses call isn't paying for
+    them."""
+    out = []
+    for a in _RECENT_ANALYSES:
+        ev = a.get("log_evidence")
+        if not ev:
+            out.append(a)
+            continue
+        a = dict(a)
+        a["log_evidence"] = {
+            **{k: v for k, v in ev.items() if k != "signatures"},
+            "signatures": [{k: v for k, v in s.items() if k != "excerpts"}
+                           for s in ev["signatures"]],
+            "excerpts_available": "call get_log_evidence for stack traces",
+        }
+        out.append(a)
+    return out
+
+
+def _tool_get_log_evidence(application_id: str) -> dict:
+    """Full log-signature evidence (incl. excerpts/stack traces) for an
+    analysis run this session with a driver/executor logs upload."""
+    for a in _RECENT_ANALYSES:
+        if a.get("application_id") == application_id:
+            ev = a.get("log_evidence")
+            if ev:
+                return {"application_id": application_id, "log_evidence": ev}
+            return {"error": f"analysis for {application_id} has no log "
+                    "evidence — the user did not attach a driver/executor "
+                    "logs zip. Ask them to re-run Analyze with the optional "
+                    "logs upload."}
+    return {"error": f"no analysis for {application_id} this session — "
+            "check get_recent_analyses for available ids"}
+
+
 def _run_chat_tool(name: str, tool_input: dict):
     if name == "get_job_config":
         return _tool_get_job_config(tool_input["job_run_id"])
@@ -812,8 +863,10 @@ def _run_chat_tool(name: str, tool_input: dict):
         return _tool_query_prometheus(tool_input["query"],
                                       int(tool_input.get("hours", 6)))
     if name == "get_recent_analyses":
-        return {"analyses": _RECENT_ANALYSES or
+        return {"analyses": _analyses_without_excerpts() or
                 "none this session — ask the user to run one in Config Advisor"}
+    if name == "get_log_evidence":
+        return _tool_get_log_evidence(tool_input["application_id"])
     if name == "run_config_advisor":
         return _tool_run_config_advisor(tool_input["job_run_id"])
     if name == "troubleshoot_job":
@@ -1228,8 +1281,35 @@ def _prepare_analysis_input(upload_path: Path) -> Path:
     return _extract_raw_event_log(upload_path)
 
 
+async def _attach_log_evidence(result: dict, logs_file) -> None:
+    """Scan an optional driver/executor-logs zip and attach the evidence.
+
+    Additive only: a bad or empty logs upload never fails the event-log
+    analysis — it degrades to a note on the result. Corroboration notes
+    refine the bottleneck verdict; they never re-score it.
+    """
+    logs_path = None
+    try:
+        logs_path = await _save_upload(logs_file)
+        evidence = extract_log_evidence(logs_path)
+        if not evidence["files_scanned"]:
+            result["log_evidence_error"] = (
+                "No driver/executor log files found in the logs zip — "
+                "expected SPARK_DRIVER/stderr.gz, SPARK_EXECUTOR/<id>/"
+                "stderr.gz, YARN container_*/ dirs, or *.log files")
+            return
+        evidence["notes"] = corroboration_notes(evidence, result.get("bottleneck"))
+        result["log_evidence"] = evidence
+    except Exception as e:
+        result["log_evidence_error"] = f"Log scan failed: {e}"
+    finally:
+        if logs_path:
+            logs_path.unlink(missing_ok=True)
+
+
 @app.post("/analyze")
-async def analyze(request: Request, file: UploadFile = File(...)):
+async def analyze(request: Request, file: UploadFile = File(...),
+                  logs_file: UploadFile = File(None)):
     if not file.filename:
         return _redirect_with_error("No file selected")
     if not Path(file.filename).suffix.lower() in ANALYZE_EXTS:
@@ -1237,6 +1317,11 @@ async def analyze(request: Request, file: UploadFile = File(...)):
             "Upload a task_stage_summary JSON, or a raw Spark event log "
             "(plain / .gz / rolling events_* file, or .zip of an "
             "eventlog_v2 directory)")
+    if logs_file is not None and logs_file.filename and \
+            not logs_file.filename.lower().endswith(".zip"):
+        return _redirect_with_error(
+            "Driver/executor logs must be a .zip (driver stderr plus the "
+            "stderr of any failed executors)")
 
     try:
         upload_path = await _save_upload(file)
@@ -1254,6 +1339,9 @@ async def analyze(request: Request, file: UploadFile = File(...)):
 
     if "error" in result:
         return _redirect_with_error(result["error"])
+
+    if logs_file is not None and logs_file.filename:
+        await _attach_log_evidence(result, logs_file)
 
     result.pop("_stages", None)
     return templates.TemplateResponse(
@@ -1761,11 +1849,14 @@ async def api_chat(request: Request):
 
 
 @app.post("/api/analyze")
-async def api_analyze(file: UploadFile = File(...)):
+async def api_analyze(file: UploadFile = File(...),
+                      logs_file: UploadFile = File(None)):
     """JSON API endpoint for programmatic access.
 
     Accepts a task_stage_summary JSON or a raw Spark event log
     (plain / .gz / rolling / .zip) — raw logs are extracted server-side.
+    Optional `logs_file`: a .zip of driver/executor stderr for log-signature
+    evidence (adds `log_evidence` to the response).
     """
     if not file.filename or Path(file.filename).suffix.lower() not in ANALYZE_EXTS:
         return JSONResponse(
@@ -1785,6 +1876,9 @@ async def api_analyze(file: UploadFile = File(...)):
         return JSONResponse({"error": str(e)}, status_code=500)
     finally:
         upload_path.unlink(missing_ok=True)
+
+    if logs_file is not None and logs_file.filename:
+        await _attach_log_evidence(result, logs_file)
 
     return JSONResponse(result)
 

--- a/utilities/EMR-Serverless-Config-Advisor/log_evidence.py
+++ b/utilities/EMR-Serverless-Config-Advisor/log_evidence.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Driver/executor stderr signature extraction for the Config Advisor UI.
+
+The event log records WHAT happened (spill, task failure, executor lost);
+stderr records WHY (heap OOM vs cgroup kill vs disk full vs S3 throttling).
+This module scans an uploaded zip of driver/executor logs against a curated
+signature table and returns structured evidence that refines — never
+contradicts — the event-log-based analysis.
+
+Curated regexes only: unknown lines produce no signal rather than a wrong
+one, which keeps the output stable across Spark/EMR releases.
+"""
+
+import gzip
+import io
+import re
+import zipfile
+from pathlib import PurePosixPath
+
+# Hard caps so a pathological upload can't stall the request thread
+MAX_FILES = 400            # driver + failed executors, not a 400-worker fleet
+MAX_BYTES_PER_FILE = 256 * 1024 * 1024
+MAX_EXCERPTS_PER_SIG = 5
+EXCERPT_CONTEXT_LINES = 4  # lines kept after a match (stack trace head)
+EXCERPT_MAX_CHARS = 1600
+
+# Each signature: what to look for, what it means, and which knob it moves.
+# `refines` names the bottleneck dimension the evidence corroborates so the
+# results page can annotate the classifier's verdict without re-scoring it.
+SIGNATURES = [
+    {
+        "id": "heap_oom",
+        "pattern": re.compile(r"java\.lang\.OutOfMemoryError(?!:\s*GC overhead)"
+                              r"(?::\s*[^\n]{0,80})?"),
+        "title": "JVM heap OutOfMemoryError",
+        "meaning": "Executor (or driver) JVM heap exhausted — raise "
+                   "spark.executor.memory / spark.driver.memory, not overhead.",
+        "refines": "Memory Constrained",
+    },
+    {
+        "id": "gc_overhead",
+        "pattern": re.compile(r"java\.lang\.OutOfMemoryError:\s*GC overhead limit exceeded"),
+        "title": "GC overhead limit exceeded",
+        "meaning": "Heap technically not exhausted but GC is thrashing — "
+                   "raise executor memory or cut per-task footprint "
+                   "(fewer cores per executor, smaller partitions).",
+        "refines": "Memory Constrained",
+    },
+    {
+        "id": "container_rss_kill",
+        "pattern": re.compile(
+            r"(killed by YARN for exceeding (?:physical )?memory limits"
+            r"|Container killed on request\. Exit code is 137"
+            r"|exceeding memory limits[^\n]{0,120}"
+            r"|Out of memory: Killed process)"),
+        "title": "Container killed by memory limit (RSS/cgroup)",
+        "meaning": "Whole-container RSS breached the limit — off-heap/native/"
+                   "Python memory, not JVM heap. Raise "
+                   "spark.emr-serverless.memoryOverheadFactor (or "
+                   "memoryOverhead), not executor.memory.",
+        "refines": "Memory Constrained",
+    },
+    {
+        "id": "disk_full",
+        "pattern": re.compile(r"No space left on device"),
+        "title": "Local disk full",
+        "meaning": "Shuffle/spill filled local disk — raise "
+                   "spark.emr-serverless.executor.disk or use "
+                   "disk.type=shuffle_optimized.",
+        "refines": "IOPS Bound",
+    },
+    {
+        "id": "fetch_failed",
+        "pattern": re.compile(r"FetchFailed(?:Exception)?[^\n]{0,100}"),
+        "title": "Shuffle fetch failure",
+        "meaning": "Executor could not fetch shuffle blocks — usually the "
+                   "serving executor died (check for OOM/kill signatures) or "
+                   "network timeout; consider fewer, larger executors and "
+                   "spark.network.timeout.",
+        "refines": "Network Bound",
+    },
+    {
+        "id": "s3_throttle",
+        "pattern": re.compile(r"(Slow Down|503 Slow ?Down|ThrottlingException"
+                              r"|Please reduce your request rate)"),
+        "title": "S3 throttling (503 Slow Down)",
+        "meaning": "S3 request-rate throttling — slow tasks are retry storms, "
+                   "not compute. Tune partition sizes / "
+                   "fs.s3.maxRetries+backoff instead of adding workers.",
+        "refines": "IOPS Bound",
+    },
+    {
+        "id": "driver_max_result",
+        "pattern": re.compile(r"bigger than spark\.driver\.maxResultSize[^\n]{0,80}"
+                              r"|Total size of serialized results[^\n]{0,120}"),
+        "title": "Driver maxResultSize exceeded",
+        "meaning": "collect()/broadcast pulled too much to the driver — raise "
+                   "spark.driver.maxResultSize and driver memory, or avoid "
+                   "the collect.",
+        "refines": None,
+    },
+    {
+        "id": "broadcast_timeout",
+        "pattern": re.compile(r"Could not execute broadcast in \d+ secs"
+                              r"|broadcastTimeout"),
+        "title": "Broadcast timeout",
+        "meaning": "Broadcast join side too large or driver overloaded — "
+                   "raise spark.sql.broadcastTimeout or lower "
+                   "spark.sql.autoBroadcastJoinThreshold.",
+        "refines": None,
+    },
+    {
+        "id": "task_memory_contention",
+        "pattern": re.compile(r"TaskMemoryManager[^\n]{0,40}"
+                              r"(Failed to acquire|Failed to allocate)[^\n]{0,80}"),
+        "title": "Execution-memory contention (TaskMemoryManager)",
+        "meaning": "Concurrent tasks contending for execution memory forces "
+                   "early spill — fewer cores per executor (e.g. 8→4) "
+                   "relieves it even when total memory looks sufficient.",
+        "refines": "Memory Constrained",
+    },
+    {
+        "id": "python_oom",
+        "pattern": re.compile(r"((?<![a-zA-Z])MemoryError(?![a-zA-Z])"
+                              r"|Python worker exited unexpectedly"
+                              r"|pyspark\.errors[^\n]{0,60}MemoryError)"),
+        "title": "Python worker memory failure",
+        "meaning": "PySpark worker (off-heap) ran out of memory — raise "
+                   "memoryOverheadFactor or spark.executor.pyspark.memory; "
+                   "heap settings won't help.",
+        "refines": "Memory Constrained",
+    },
+    {
+        "id": "executor_lost",
+        "pattern": re.compile(r"ExecutorLostFailure \(executor \d+ exited[^\n]{0,120}"),
+        "title": "Executor lost",
+        "meaning": "Executors exiting mid-stage — correlate with OOM/kill/disk "
+                   "signatures above to find the root cause; casualties "
+                   "re-run work and inflate cost.",
+        "refines": None,
+    },
+    {
+        "id": "kill_signal",
+        "pattern": re.compile(r"(Executor is exiting due to.{0,80}"
+                              r"|RECEIVED SIGNAL TERM|SIGTERM|SIGKILL)"),
+        "title": "Executor received kill signal",
+        "meaning": "External termination (scale-in, cgroup kill, host issue) — "
+                   "if paired with memory-limit signatures it's an OOM kill; "
+                   "alone it's usually dynamic-allocation churn (benign).",
+        "refines": None,
+    },
+]
+
+# Log-file layouts we auto-detect inside the zip. Anything not matching is
+# still scanned if it looks like a log file, tagged source="unknown".
+_DRIVER_PAT = re.compile(r"(SPARK_DRIVER/|driver[^/]*\.(log|txt)(\.gz)?$"
+                         r"|container_\d+_\d+_\d+_000001/)", re.I)
+_EXEC_ID_PATS = (
+    re.compile(r"SPARK_EXECUTOR/(?P<id>[^/]+)/", re.I),          # EMR Serverless
+    re.compile(r"container_(?:\w+_)?\d+_\d+_\d+_(?P<id>\d{6})/"),  # YARN
+    re.compile(r"executor[-_](?P<id>\d+)", re.I),                 # loose naming
+)
+_LOGLIKE = re.compile(r"(std(err|out)|\.log|\.txt)(\.gz)?$", re.I)
+_SKIP = re.compile(r"(__MACOSX/|\.DS_Store$|events?_\d|eventlog|appstatus"
+                   r"|\.json$|\.crc$)", re.I)
+
+
+def _classify_member(name: str) -> tuple:
+    """(source, executor_id) for a zip member path; source in
+    driver|executor|unknown."""
+    if _DRIVER_PAT.search(name):
+        return "driver", None
+    for pat in _EXEC_ID_PATS:
+        m = pat.search(name)
+        if m:
+            return "executor", m.group("id").lstrip("0") or "0"
+    return "unknown", None
+
+
+def _iter_log_members(zf: zipfile.ZipFile):
+    """Yield (info, source, exec_id) for scannable log files in the zip."""
+    count = 0
+    for info in zf.infolist():
+        if info.is_dir() or _SKIP.search(info.filename):
+            continue
+        if not _LOGLIKE.search(info.filename):
+            continue
+        if info.file_size > MAX_BYTES_PER_FILE:
+            continue
+        source, exec_id = _classify_member(info.filename)
+        yield info, source, exec_id
+        count += 1
+        if count >= MAX_FILES:
+            return
+
+
+def _open_member(zf: zipfile.ZipFile, info: zipfile.ZipInfo):
+    """Text stream over a member, transparently gunzipping .gz."""
+    raw = zf.open(info)
+    if info.filename.endswith(".gz"):
+        raw = gzip.GzipFile(fileobj=raw)
+    return io.TextIOWrapper(raw, encoding="utf-8", errors="replace")
+
+
+def _scan_stream(stream, source, exec_id, filename, hits):
+    """Scan one log stream; accumulate counts and capped excerpts into
+    hits[sig_id]. Streams line-by-line — never loads the file. Context
+    capture runs alongside matching so a stack trace being excerpted can't
+    hide other signatures on the same lines."""
+    pending = []  # [sig_id, lines_remaining, buffer] per open excerpt
+    for line in stream:
+        line = line.rstrip("\n")
+        for p in pending:
+            p[2].append(line)
+            p[1] -= 1
+        done = [p for p in pending if p[1] <= 0 or not line.strip()]
+        for p in done:
+            _flush_excerpt(hits[p[0]], p[2], source, exec_id, filename)
+        pending = [p for p in pending if p not in done]
+
+        for sig in SIGNATURES:
+            if sig["pattern"].search(line):
+                h = hits[sig["id"]]
+                h["count"] += 1
+                key = (source, exec_id)
+                h["sources"][key] = h["sources"].get(key, 0) + 1
+                if (len(h["excerpts"]) < MAX_EXCERPTS_PER_SIG
+                        and not any(p[0] == sig["id"] for p in pending)):
+                    # capture the matched line + a few follow lines (stack head)
+                    pending.append([sig["id"], EXCERPT_CONTEXT_LINES, [line]])
+                break  # first matching signature wins for a line
+    for p in pending:
+        _flush_excerpt(hits[p[0]], p[2], source, exec_id, filename)
+
+
+def _flush_excerpt(hit, buf, source, exec_id, filename):
+    text = "\n".join(buf)[:EXCERPT_MAX_CHARS]
+    hit["excerpts"].append({
+        "source": source + (f" {exec_id}" if exec_id else ""),
+        "file": PurePosixPath(filename).name,
+        "text": text,
+    })
+
+
+def extract_log_evidence(zip_path) -> dict:
+    """Scan a zip of driver/executor logs; return structured evidence.
+
+    Returns {"signatures": [...], "files_scanned": n, "files_skipped": n,
+    "sources": {"driver": n, "executor": n, "unknown": n}} — signatures
+    sorted by severity of what they explain (order of SIGNATURES table),
+    each with count, per-source counts, and capped excerpts.
+    """
+    hits = {s["id"]: {"count": 0, "sources": {}, "excerpts": []}
+            for s in SIGNATURES}
+    files_scanned = 0
+    source_counts = {"driver": 0, "executor": 0, "unknown": 0}
+
+    with zipfile.ZipFile(zip_path) as zf:
+        members = list(_iter_log_members(zf))
+        files_skipped = sum(
+            1 for i in zf.infolist()
+            if not i.is_dir() and not _SKIP.search(i.filename)) - len(members)
+        for info, source, exec_id in members:
+            try:
+                with _open_member(zf, info) as stream:
+                    _scan_stream(stream, source, exec_id, info.filename, hits)
+                files_scanned += 1
+                source_counts[source] += 1
+            except Exception:
+                files_skipped += 1
+
+    signatures = []
+    for sig in SIGNATURES:
+        h = hits[sig["id"]]
+        if not h["count"]:
+            continue
+        signatures.append({
+            "id": sig["id"],
+            "title": sig["title"],
+            "meaning": sig["meaning"],
+            "refines": sig["refines"],
+            "count": h["count"],
+            "sources": {f"{src}{' ' + eid if eid else ''}": n
+                        for (src, eid), n in sorted(
+                            h["sources"].items(),
+                            key=lambda kv: -kv[1])[:10]},
+            "excerpts": h["excerpts"],
+        })
+
+    return {
+        "signatures": signatures,
+        "files_scanned": files_scanned,
+        "files_skipped": max(files_skipped, 0),
+        "sources": source_counts,
+    }
+
+
+def corroboration_notes(evidence: dict, bottleneck: dict) -> list:
+    """Notes linking log signatures to the event-log bottleneck verdict.
+
+    Additive only: log evidence sharpens the classifier's diagnosis (e.g.
+    'Memory Constrained' → 'heap OOM, raise executor.memory') but never
+    overrides or re-scores it.
+    """
+    notes = []
+    primary = (bottleneck or {}).get("primary", "")
+    for sig in evidence.get("signatures", []):
+        if sig["refines"] and sig["refines"] == primary:
+            notes.append(
+                f"Log evidence corroborates the {primary} verdict: "
+                f"{sig['title']} ({sig['count']}×). {sig['meaning']}")
+    return notes
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+    print(json.dumps(extract_log_evidence(sys.argv[1]), indent=2))

--- a/utilities/EMR-Serverless-Config-Advisor/templates/config_advisor.html
+++ b/utilities/EMR-Serverless-Config-Advisor/templates/config_advisor.html
@@ -30,6 +30,16 @@
             </div>
             <input type="file" name="file" id="file-input" accept=".json,.zip,.gz,.lz4,.zstd,.inprogress" required>
         </div>
+        <label class="cmp-slot" style="margin-top:10px">
+            <span class="cmp-tag a">LOGS &middot; OPTIONAL</span>
+            <input type="file" name="logs_file" id="logs-input" accept=".zip">
+        </label>
+        <p class="drop-hint" style="margin:6px 0 0">
+            Optional: a .zip of the driver log plus the stderr of any failed
+            executors (not the whole fleet). Adds root-cause evidence — heap
+            OOM vs container kill vs disk full vs S3 throttling — that the
+            event log alone can't show.
+        </p>
         <button type="submit" class="btn-analyze" id="btn-submit" disabled>
             <span class="btn-text">Analyze</span>
             <span class="btn-loading" style="display:none;">Analyzing... (raw event logs can take a minute)</span>

--- a/utilities/EMR-Serverless-Config-Advisor/templates/results.html
+++ b/utilities/EMR-Serverless-Config-Advisor/templates/results.html
@@ -87,6 +87,51 @@
             </div>
         </section>
 
+        <!-- Log evidence: driver/executor stderr signatures (optional upload) -->
+        {% if result.log_evidence_error %}
+        <div class="flash" style="background:#FFF6EA;border:1px solid #FFAD4A;color:#8A5A1F;">
+            <b>Driver/executor logs:</b> {{ result.log_evidence_error }}
+        </div>
+        {% endif %}
+        {% if result.log_evidence %}
+        <section class="section">
+            <h2>Log evidence — driver/executor stderr</h2>
+            <p class="drop-hint" style="margin-bottom:12px">
+                {{ result.log_evidence.files_scanned }} log file(s) scanned
+                ({{ result.log_evidence.sources.driver }} driver,
+                {{ result.log_evidence.sources.executor }} executor).
+                Signatures below explain <i>why</i> — the event-log verdict
+                above says <i>what</i>.
+            </p>
+            {% for note in result.log_evidence.notes %}
+            <div class="flash" style="background:#EDF6EC;border:1px solid #7AC58F;color:#1D5A2C;margin-bottom:8px;">
+                {{ note }}
+            </div>
+            {% endfor %}
+            {% if not result.log_evidence.signatures %}
+            <p class="drop-hint">No known failure signatures found — the logs
+                look clean. Slowness is likely explained by the event-log
+                analysis alone.</p>
+            {% endif %}
+            {% for sig in result.log_evidence.signatures %}
+            <details class="log-sig" style="border:1px solid var(--card-border);border-radius:8px;padding:10px 14px;margin-bottom:8px;">
+                <summary style="cursor:pointer;">
+                    <b>{{ sig.title }}</b>
+                    <span class="bottleneck-score" style="margin-left:8px">{{ "{:,}".format(sig.count) }}&times;</span>
+                    <span class="drop-hint" style="margin-left:8px">
+                        {%- for src, n in sig.sources.items() %}{{ src }} ({{ n }}){{ ", " if not loop.last }}{% endfor -%}
+                    </span>
+                </summary>
+                <p style="margin:8px 0">{{ sig.meaning }}</p>
+                {% for ex in sig.excerpts %}
+                <pre style="background:#F7F8FA;border:1px solid var(--card-border);border-radius:6px;padding:8px 10px;font-size:0.72rem;overflow-x:auto;white-space:pre-wrap;"><b>{{ ex.source }} — {{ ex.file }}</b>
+{{ ex.text }}</pre>
+                {% endfor %}
+            </details>
+            {% endfor %}
+        </section>
+        {% endif %}
+
         <!-- IO Metrics -->
         <section class="section">
             <h2>I/O Profile</h2>

--- a/utilities/EMR-Serverless-Config-Advisor/tests/test_log_evidence.py
+++ b/utilities/EMR-Serverless-Config-Advisor/tests/test_log_evidence.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Unit tests for log_evidence.py — curated stderr signature extraction.
+
+Builds synthetic zips in-memory covering both log layouts (EMR Serverless
+SPARK_DRIVER/SPARK_EXECUTOR and YARN container_*) plus noise files, and
+asserts every signature in the table fires on its canonical line and does
+not fire on look-alikes.
+
+Usage: python3 tests/test_log_evidence.py
+Exit codes: 0 = pass, 1 = failure.
+"""
+import gzip
+import io
+import os
+import sys
+import zipfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from log_evidence import (SIGNATURES, corroboration_notes,
+                          extract_log_evidence)
+
+FAILURES = []
+
+
+def check(name, cond, detail=""):
+    if cond:
+        print(f"  PASS {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+def make_zip(members: dict) -> str:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        for name, text in members.items():
+            data = text.encode()
+            if name.endswith(".gz"):
+                data = gzip.compress(data)
+            z.writestr(name, data)
+    import tempfile
+    f = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
+    f.write(buf.getvalue())
+    f.close()
+    return f.name
+
+
+# One canonical stderr line per signature id
+CANONICAL = {
+    "heap_oom": "26/07/09 ERROR Executor: java.lang.OutOfMemoryError: Java heap space",
+    "gc_overhead": "java.lang.OutOfMemoryError: GC overhead limit exceeded",
+    "container_rss_kill": "Container killed on request. Exit code is 137",
+    "disk_full": "java.io.IOException: No space left on device",
+    "fetch_failed": "org.apache.spark.shuffle.FetchFailedException: Failed to connect to host:7337",
+    "s3_throttle": "Please reduce your request rate. (Status Code: 503; Error Code: SlowDown)",
+    "driver_max_result": "Total size of serialized results of 15 tasks (2.1 GiB) is bigger than spark.driver.maxResultSize (1024.0 MiB)",
+    "broadcast_timeout": "Could not execute broadcast in 300 secs.",
+    "task_memory_contention": "26/07/09 ERROR TaskMemoryManager: Failed to acquire 1048576 bytes of memory, got 0",
+    "python_oom": "26/07/09 ERROR PythonRunner: MemoryError",
+    "executor_lost": "ExecutorLostFailure (executor 628 exited caused by one of the running tasks) Reason: Unknown executor exit code (0)",
+    "kill_signal": "26/07/09 ERROR CoarseGrainedExecutorBackend: RECEIVED SIGNAL TERM",
+}
+
+# Lines that pattern-match naively but must NOT fire the named signature
+NEGATIVES = {
+    "heap_oom": "java.lang.OutOfMemoryError: GC overhead limit exceeded",
+    "s3_throttle": "NettyBlockTransferService' on port 42503.",
+    "python_oom": "ignoring OutOfMemoryErrors from foo",
+}
+
+
+def test_signature_table():
+    print("signature table: every id fires on its canonical line")
+    for sig in SIGNATURES:
+        line = CANONICAL[sig["id"]]
+        first_match = next((s["id"] for s in SIGNATURES
+                            if s["pattern"].search(line)), None)
+        check(f"{sig['id']} fires first", first_match == sig["id"],
+              f"(got {first_match})")
+
+    print("signature table: negatives don't fire")
+    for sig_id, line in NEGATIVES.items():
+        sig = next(s for s in SIGNATURES if s["id"] == sig_id)
+        check(f"{sig_id} negative", not sig["pattern"].search(line)
+              or next(s["id"] for s in SIGNATURES
+                      if s["pattern"].search(line)) != sig_id)
+
+
+def test_layouts_and_scan():
+    print("zip scan: layouts, noise skipping, counting, excerpts")
+    zp = make_zip({
+        "SPARK_DRIVER/stderr.gz":
+            CANONICAL["heap_oom"] + "\n\tat org.apache.spark.Foo.bar(Foo.java:1)\n"
+            + CANONICAL["driver_max_result"] + "\n",
+        "SPARK_EXECUTOR/12/stderr.gz":
+            CANONICAL["disk_full"] + "\n" + CANONICAL["disk_full"] + "\n",
+        "app_1/container_1770841089578_0001_01_000042/stderr":
+            CANONICAL["container_rss_kill"] + "\n",
+        # noise: must be skipped entirely
+        "eventlog_v2_00gx/events_1_00gx": '{"Event":"SparkListenerLogStart"}\n',
+        "__MACOSX/._junk": "x",
+        "extract.json": "{}",
+    })
+    ev = extract_log_evidence(zp)
+    os.unlink(zp)
+
+    check("3 files scanned", ev["files_scanned"] == 3, f"(got {ev['files_scanned']})")
+    check("driver detected", ev["sources"]["driver"] == 1)
+    check("executors detected", ev["sources"]["executor"] == 2)
+    ids = {s["id"]: s for s in ev["signatures"]}
+    check("heap_oom found", "heap_oom" in ids)
+    check("disk_full counted twice", ids.get("disk_full", {}).get("count") == 2)
+    check("yarn exec id parsed",
+          "executor 42" in ids.get("container_rss_kill", {}).get("sources", {}))
+    check("excerpt keeps stack head",
+          "Foo.java:1" in ids["heap_oom"]["excerpts"][0]["text"])
+    check("event log not scanned",
+          all("events_1" not in e["file"]
+              for s in ev["signatures"] for e in s["excerpts"]))
+
+
+def test_corroboration():
+    print("corroboration notes: additive, verdict-matched only")
+    zp = make_zip({"SPARK_EXECUTOR/1/stderr.gz":
+                   CANONICAL["heap_oom"] + "\n" + CANONICAL["disk_full"] + "\n"})
+    ev = extract_log_evidence(zp)
+    os.unlink(zp)
+    mem = corroboration_notes(ev, {"primary": "Memory Constrained"})
+    iops = corroboration_notes(ev, {"primary": "IOPS Bound"})
+    cpu = corroboration_notes(ev, {"primary": "CPU Constrained"})
+    check("memory verdict gets heap note",
+          any("OutOfMemoryError" in n for n in mem))
+    check("iops verdict gets disk note",
+          any("disk full" in n.lower() for n in iops))
+    check("cpu verdict gets no notes", cpu == [])
+    check("notes never re-score",
+          all("corroborates" in n for n in mem + iops))
+
+
+def test_empty_and_clean():
+    print("edge cases: no log files / clean logs")
+    zp = make_zip({"random.json": "{}"})
+    ev = extract_log_evidence(zp)
+    os.unlink(zp)
+    check("no scannable files", ev["files_scanned"] == 0)
+
+    zp = make_zip({"SPARK_DRIVER/stderr.gz":
+                   "26/07/09 INFO SparkContext: Running Spark version 3.5.6\n"})
+    ev = extract_log_evidence(zp)
+    os.unlink(zp)
+    check("clean log yields no signatures", ev["signatures"] == [])
+
+
+if __name__ == "__main__":
+    test_signature_table()
+    test_layouts_and_scan()
+    test_corroboration()
+    test_empty_and_clean()
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILURE(S): {FAILURES}")
+        sys.exit(1)
+    print("all log_evidence tests passed")


### PR DESCRIPTION
## What

Adds an optional **driver/executor logs upload** to the Config Advisor web UI's Analyze flow. The event log records *what* happened (spill, task failure, executor lost); stderr records *why* (heap OOM vs container RSS kill vs disk full vs S3 throttling). Attaching a .zip of the driver log — plus the stderr of any failed executors — adds root-cause evidence the event log alone can't show.

## How

- **`log_evidence.py` (new)**: curated table of 12 stderr signatures (JVM heap OOM, GC overhead, container RSS/cgroup kill, disk full, shuffle fetch failure, S3 503 throttling, driver maxResultSize, broadcast timeout, TaskMemoryManager execution-memory contention, Python worker OOM, executor lost, kill signal), each with a plain-English meaning and the config knob it moves. Curated regexes only — unknown lines produce **no signal** rather than a wrong one, keeping output stable across Spark/EMR releases. Files stream line-by-line from the zip (never loaded whole); file-count/size/excerpt caps bound the work. Auto-detects both EMR Serverless (`SPARK_DRIVER/`, `SPARK_EXECUTOR/<id>/`) and YARN (`container_*`) log layouts.
- **Analyze form**: optional `LOGS` slot (zip only). UI copy steers users to the driver log + failed executors, not a whole 400-worker fleet.
- **Results page**: a **Log evidence** panel after Bottleneck Classification — signature cards with counts, per-source breakdown, and quoted excerpts (stack-trace heads), plus corroboration notes that *refine* the event-log verdict (e.g. Memory Constrained → "heap OOM: raise executor.memory, not overhead" vs "container RSS kill: raise memoryOverheadFactor, not heap"). Notes are additive only — log evidence never re-scores or contradicts the event-log classification. A bad or empty logs zip degrades to a warning note; the event-log analysis is never blocked.
- **Ask AI**: new `get_log_evidence` tool so the assistant quotes the *actual* error excerpt instead of inferring failure causes from metrics; `get_recent_analyses` carries excerpt-elided summaries to stay light.
- **`/api/analyze`**: accepts the same optional `logs_file` part for programmatic use.

## Testing

- `tests/test_log_evidence.py`: 30 assertions — every signature fires on its canonical line and not on look-alikes (e.g. `heap_oom` vs `GC overhead limit exceeded`), both log layouts detected, noise files (event logs, `__MACOSX`, JSONs) skipped, excerpts keep stack heads, corroboration notes only attach to the matching verdict, clean logs yield no signatures.
- `tests/test_recommender_golden.py` still passes (18 apps) — recommendations unchanged.
- Live end-to-end: a production run's event log + its 18.5 MB driver stderr renders the panel (1,474× executor-lost with quoted excerpts) in ~0.6 s of scan time; analysis without a logs file is byte-identical to before; a non-zip logs file is rejected with a clear message.

No new dependencies (stdlib `zipfile`/`gzip`/`re` only). Follow-up to #187.