### PR TITLE
feat: add emr-serverless-unified-history-server utility

### DIFF
--- a/utilities/emr-serverless-unified-history-server/.gitignore
+++ b/utilities/emr-serverless-unified-history-server/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/utilities/emr-serverless-unified-history-server/README.md
+++ b/utilities/emr-serverless-unified-history-server/README.md
@@ -1,0 +1,238 @@
+# EMR Serverless Unified History Server
+
+Run a **single Spark History Server** that shows every job from **all** your EMR
+Serverless applications — regardless of how many applications you use.
+
+## Problem
+
+EMR Serverless writes each job run's Spark event log under a deeply nested,
+per-application, per-run S3 path:
+
+```
+s3://<log-bucket>/logs/applications/<app-id>/jobs/<job-run-id>/sparklogs/eventlog_v2_<job-run-id>/...
+```
+
+A Spark History Server reads one flat log directory
+(`spark.history.fs.logDirectory`). Because every application and job run uses a
+different prefix, there is no single directory an SHS can point at — so there is
+no unified view across applications.
+
+This is a regression for teams migrating from EMR on EC2, where the long-lived
+cluster's History Server showed every job in one place.
+
+## Solution
+
+An event-driven pipeline that aggregates Spark event logs in near real-time:
+
+```
+EMR-S app A ─┐
+EMR-S app B ─┼─▶ s3://SRC/logs/applications/<app-id>/jobs/<run-id>/sparklogs/eventlog_v2_<run-id>/...
+EMR-S app C ─┘            │
+                          │  S3 Event Notification (s3:ObjectCreated:*)
+                          ▼
+                   Lambda copy_handler ── server-side CopyObject ──▶ s3://DST/logs/eventlog_v2_<run-id>/...
+                                                                              ▲
+                                         Spark History Server ────────────────┘
+                                         spark.history.fs.logDirectory=s3://DST/logs/
+```
+
+The Lambda:
+1. **Filters** — only objects whose key contains `/sparklogs/` are processed;
+   driver/executor logs are skipped
+2. **Flattens** — rewrites the key by dropping everything before `sparklogs/`,
+   so all runs land in one directory (job-run IDs are globally unique — no collisions)
+3. **Copies server-side** — `CopyObject` moves bytes within S3; the Lambda never
+   downloads data, so duration is independent of file size and same-region
+   transfer is free
+
+## Architecture
+
+```mermaid
+flowchart LR
+    A[EMR Serverless app A] -- writes logs --> SRC[(Source bucket)]
+    B[EMR Serverless app B] -- writes logs --> SRC
+    SRC -- "S3 Event Notification" --> L[Lambda copy_handler]
+    L -- "CopyObject (filtered + flattened)" --> DST[(Destination bucket)]
+    L -. failed invocations .-> DLQ[SQS DLQ]
+    SHS[Spark History Server] -- reads --> DST
+```
+
+## Deployment
+
+### Prerequisites
+
+- AWS CLI configured with appropriate credentials
+- An EMR Serverless application with `logUri` pointing to an S3 bucket
+
+### Deploy the CloudFormation stack
+
+```bash
+export STACK=emr-serverless-unified-shs
+export SRC_BUCKET=my-emr-logs-source-$(aws sts get-caller-identity --query Account --output text)
+export DST_BUCKET=my-emr-logs-dest-$(aws sts get-caller-identity --query Account --output text)
+
+aws cloudformation deploy \
+  --stack-name "$STACK" \
+  --template-file template.yaml \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides \
+      SourceBucketName="$SRC_BUCKET" \
+      DestinationBucketName="$DST_BUCKET" \
+      LogPrefix=logs/applications/ \
+      DestinationPrefix=logs/
+```
+
+### Configure EMR Serverless to write logs to the source bucket
+
+Set `monitoringConfiguration.s3MonitoringConfiguration.logUri` to
+`s3://<SRC_BUCKET>/logs/` when creating or running your EMR Serverless
+application/job.
+
+### Set up the Spark History Server
+
+Point any SHS (EC2, container, or local) at the destination bucket:
+
+```properties
+# spark-defaults.conf
+spark.history.fs.logDirectory=s3a://<DST_BUCKET>/logs/
+spark.hadoop.fs.s3a.aws.credentials.provider=com.amazonaws.auth.InstanceProfileCredentialsProvider
+spark.history.fs.update.interval=10s
+```
+
+<details>
+<summary>EC2 setup from scratch (Amazon Linux 2023)</summary>
+
+```bash
+sudo dnf install -y java-17-amazon-corretto-headless
+curl -sSLo /tmp/spark.tgz https://archive.apache.org/dist/spark/spark-3.5.6/spark-3.5.6-bin-hadoop3.tgz
+sudo tar xzf /tmp/spark.tgz -C /opt && sudo ln -s /opt/spark-3.5.6-bin-hadoop3 /opt/spark
+
+# S3A jars (versions must match Spark's bundled Hadoop 3.3.4)
+cd /opt/spark/jars
+sudo curl -sSLO https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar
+sudo curl -sSLO https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar
+
+# Configure and start
+cat <<EOF | sudo tee /opt/spark/conf/spark-defaults.conf
+spark.history.fs.logDirectory=s3a://${DST_BUCKET}/logs/
+spark.hadoop.fs.s3a.aws.credentials.provider=com.amazonaws.auth.InstanceProfileCredentialsProvider
+spark.history.fs.update.interval=10s
+EOF
+
+sudo /opt/spark/sbin/start-history-server.sh
+# UI available at http://<host>:18080
+```
+
+The EC2 instance's IAM role needs `s3:GetObject` and `s3:ListBucket` on the
+destination bucket.
+</details>
+
+## Testing
+
+```bash
+# 1. Simulate an EMR Serverless event log write
+echo "test event log" > /tmp/events_0_test
+aws s3 cp /tmp/events_0_test \
+  "s3://$SRC_BUCKET/logs/applications/app-123/jobs/run-abc/sparklogs/eventlog_v2_run-abc/events_0_run-abc"
+
+# 2. Verify it landed flattened in the SHS directory (within seconds)
+aws s3 ls "s3://$DST_BUCKET/logs/eventlog_v2_run-abc/"
+
+# 3. Negative test: a driver log should be skipped
+aws s3 cp /tmp/events_0_test \
+  "s3://$SRC_BUCKET/logs/applications/app-123/jobs/run-abc/SPARK_DRIVER/stderr.gz"
+aws s3 ls "s3://$DST_BUCKET/logs/" --recursive | grep stderr  # expect no output
+
+# 4. Check Lambda logs
+aws logs tail "/aws/lambda/$STACK-s3-log-copy" --since 5m
+```
+
+### Unit tests
+
+```bash
+cd lambda
+python -m pytest test_copy_handler.py -v
+# or
+python -m unittest test_copy_handler -v
+```
+
+## Cost
+
+At 30,000 notified objects/day (~17% are event logs based on typical EMR
+Serverless workloads):
+
+| Component | Monthly |
+|---|---|
+| Lambda requests | $0.18 |
+| Lambda duration (135 ms avg, 128 MB) | $0.24 |
+| S3 COPY (~5,100 event logs/day) | $0.77 |
+| S3 GET (~5,100/day) | $0.06 |
+| Data transfer (same region) | $0.00 |
+| **Pipeline total** | **~$1.30/month** |
+
+Cost scales with object count, not object size — server-side copy makes a 7 GB
+file cost the same as a 70 MB file.
+
+The SHS host is the real cost driver if dedicated (~$30/month for t3.medium).
+Run SHS on shared compute or on-demand to minimize.
+
+## How it works
+
+| Component | Detail |
+|---|---|
+| Lambda | Python 3.12, 128 MB, 60s timeout, boto3 adaptive retries |
+| IAM | Least privilege: `s3:GetObject` on source, `s3:PutObject`/`AbortMultipartUpload` on destination |
+| Trigger | `s3:ObjectCreated:*` with prefix filter `logs/applications/` |
+| DLQ | SQS, 14-day retention, for failed async invocations |
+| IaC | Single CloudFormation template (`template.yaml`) |
+
+### Key mapping
+
+```
+source: logs/applications/<app-id>/jobs/<run-id>/sparklogs/eventlog_v2_<run-id>/events_0_<run-id>
+dest:   logs/eventlog_v2_<run-id>/events_0_<run-id>
+```
+
+Everything after the `sparklogs/` segment is kept. The `appstatus_*` marker file
+is copied too — the History Server needs it to recognize rolling event logs.
+
+## Assumptions and limitations
+
+- **Same region, same account.** For cross-account: grant the Lambda role
+  `s3:PutObject` on the destination via a bucket policy, and use Bucket Owner
+  Enforced object ownership on the destination.
+- **No backfill.** Only objects created after deployment are copied. Seed
+  existing logs with: `aws s3 sync s3://$SRC s3://$DST --exclude "*" --include "*sparklogs*"`
+- **At-least-once delivery.** S3 events may be delivered more than once; copies
+  are idempotent (same key) so duplicates are harmless.
+- **Objects > 5 GiB** use multipart `UploadPartCopy` automatically.
+- **KMS-encrypted buckets** need `kms:Decrypt` (source key) and
+  `kms:GenerateDataKey` (destination key) on the Lambda role.
+- **One notification config per event/prefix pair.** If you need more consumers,
+  migrate to S3 → EventBridge or S3 → SNS fan-out.
+
+## Production hardening
+
+- [ ] `spark.history.fs.cleaner.enabled=true` with a retention period — the flat
+  directory accumulates all runs; unbounded growth slows SHS
+- [ ] S3 lifecycle policy on the destination aligned with the cleaner retention
+- [ ] CloudWatch alarm on DLQ depth and a `Failed to copy` metric filter
+- [ ] Authentication in front of the SHS UI (ALB + OIDC/SSO)
+- [ ] One-time backfill of recent event logs for teams migrating from EMR on EC2
+- [ ] Keep SHS at the same or newer Spark minor version as your EMR release
+
+## Cleanup
+
+```bash
+aws s3 rm "s3://$SRC_BUCKET" --recursive
+aws s3 rm "s3://$DST_BUCKET" --recursive
+aws cloudformation delete-stack --stack-name "$STACK"
+```
+
+## Security
+
+See [CONTRIBUTING](https://github.com/aws-samples/aws-emr-utilities/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## License
+
+This project is licensed under the MIT-0 License. See the [LICENSE](https://github.com/aws-samples/aws-emr-utilities/blob/main/LICENSE) file.

--- a/utilities/emr-serverless-unified-history-server/lambda/copy_handler.py
+++ b/utilities/emr-serverless-unified-history-server/lambda/copy_handler.py
@@ -1,0 +1,132 @@
+"""
+S3 Event-Driven Spark Event Log Copy Lambda
+
+Triggered by S3 Event Notifications (s3:ObjectCreated:*) on the source bucket where
+EMR Serverless writes job logs. Copies ONLY Spark event logs (objects under a
+`sparklogs/` path segment) to the destination bucket, flattening them into a single
+Spark History Server log directory:
+
+    source:      logs/applications/<app-id>/jobs/<job-run-id>/sparklogs/eventlog_v2_<job-run-id>/events_0_<job-run-id>
+    destination: logs/eventlog_v2_<job-run-id>/events_0_<job-run-id>
+
+This lets one Spark History Server (spark.history.fs.logDirectory=s3://<dest>/logs/)
+load applications from many EMR Serverless applications and job runs. All other log
+objects (driver/executor stderr/stdout, archived, job-metadata) are skipped.
+
+Environment variables:
+    DESTINATION_BUCKET  (required) - target bucket name
+    DESTINATION_PREFIX  (optional) - SHS log directory prefix (default: "logs/")
+
+Memory: 128 MB | Timeout: 60s
+"""
+
+import json
+import logging
+import os
+import urllib.parse
+
+import boto3
+from botocore.config import Config
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+s3 = boto3.client("s3", config=Config(retries={"max_attempts": 3, "mode": "adaptive"}))
+
+DESTINATION_BUCKET = os.environ["DESTINATION_BUCKET"]
+DESTINATION_PREFIX = os.environ.get("DESTINATION_PREFIX", "logs/")
+
+SPARKLOGS_MARKER = "/sparklogs/"
+
+# copy_object supports up to 5 GiB. Larger objects need multipart UploadPartCopy.
+COPY_OBJECT_MAX_BYTES = 5 * 1024 * 1024 * 1024
+
+
+def destination_key_for(source_key):
+    """Map a source key to its flattened SHS destination key, or None to skip."""
+    idx = source_key.find(SPARKLOGS_MARKER)
+    if idx == -1:
+        return None
+    return DESTINATION_PREFIX + source_key[idx + len(SPARKLOGS_MARKER):]
+
+
+def lambda_handler(event, context):
+    """Process S3 event notification records. Logs and continues on per-object errors."""
+    records = event.get("Records", [])
+    copied, skipped, failed = 0, 0, 0
+
+    for record in records:
+        try:
+            source_bucket = record["s3"]["bucket"]["name"]
+            source_key = urllib.parse.unquote_plus(record["s3"]["object"]["key"])
+            size = record["s3"]["object"].get("size", 0)
+        except KeyError:
+            logger.error("Malformed record, skipping: %s", json.dumps(record))
+            failed += 1
+            continue
+
+        destination_key = destination_key_for(source_key)
+        if destination_key is None:
+            skipped += 1
+            logger.info("Skipped (not a spark event log): s3://%s/%s", source_bucket, source_key)
+            continue
+
+        try:
+            if size > COPY_OBJECT_MAX_BYTES:
+                _multipart_copy(source_bucket, source_key, destination_key, size)
+            else:
+                s3.copy_object(
+                    CopySource={"Bucket": source_bucket, "Key": source_key},
+                    Bucket=DESTINATION_BUCKET,
+                    Key=destination_key,
+                )
+            copied += 1
+            logger.info(
+                "Copied s3://%s/%s -> s3://%s/%s (%d bytes)",
+                source_bucket, source_key, DESTINATION_BUCKET, destination_key, size,
+            )
+        except Exception:
+            failed += 1
+            logger.exception(
+                "Failed to copy s3://%s/%s -> s3://%s/%s",
+                source_bucket, source_key, DESTINATION_BUCKET, destination_key,
+            )
+
+    result = {"copied": copied, "skipped": skipped, "failed": failed, "total": len(records)}
+    logger.info("Batch complete: %s", json.dumps(result))
+    return result
+
+
+def _multipart_copy(source_bucket, source_key, destination_key, size):
+    """Multipart server-side copy for objects > 5 GiB."""
+    part_size = 1 * 1024 * 1024 * 1024  # 1 GiB parts
+    mpu = s3.create_multipart_upload(Bucket=DESTINATION_BUCKET, Key=destination_key)
+    upload_id = mpu["UploadId"]
+    try:
+        parts = []
+        part_number = 1
+        offset = 0
+        while offset < size:
+            last_byte = min(offset + part_size, size) - 1
+            resp = s3.upload_part_copy(
+                Bucket=DESTINATION_BUCKET,
+                Key=destination_key,
+                UploadId=upload_id,
+                PartNumber=part_number,
+                CopySource={"Bucket": source_bucket, "Key": source_key},
+                CopySourceRange=f"bytes={offset}-{last_byte}",
+            )
+            parts.append({"ETag": resp["CopyPartResult"]["ETag"], "PartNumber": part_number})
+            offset = last_byte + 1
+            part_number += 1
+        s3.complete_multipart_upload(
+            Bucket=DESTINATION_BUCKET,
+            Key=destination_key,
+            UploadId=upload_id,
+            MultipartUpload={"Parts": parts},
+        )
+    except Exception:
+        s3.abort_multipart_upload(
+            Bucket=DESTINATION_BUCKET, Key=destination_key, UploadId=upload_id
+        )
+        raise

--- a/utilities/emr-serverless-unified-history-server/lambda/test_copy_handler.py
+++ b/utilities/emr-serverless-unified-history-server/lambda/test_copy_handler.py
@@ -1,0 +1,123 @@
+"""Unit tests for copy_handler — no AWS access required (S3 client mocked)."""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+os.environ["DESTINATION_BUCKET"] = "dest-bucket"
+
+import copy_handler
+
+
+def s3_event(records):
+    return {"Records": [
+        {"s3": {"bucket": {"name": b}, "object": {"key": k, "size": s}}}
+        for b, k, s in records
+    ]}
+
+
+EVENTLOG_KEY = (
+    "logs/applications/00g72ravf2a45t09/jobs/00g72rcefave480b/"
+    "sparklogs/eventlog_v2_00g72rcefave480b/events_0_00g72rcefave480b"
+)
+APPSTATUS_KEY = (
+    "logs/applications/00g72ravf2a45t09/jobs/00g72rcefave480b/"
+    "sparklogs/eventlog_v2_00g72rcefave480b/appstatus_00g72rcefave480b"
+)
+STDERR_KEY = (
+    "logs/applications/00g72ravf2a45t09/jobs/00g72rcefave480b/"
+    "SPARK_DRIVER/stderr.gz"
+)
+
+
+class TestCopyHandler(unittest.TestCase):
+    def setUp(self):
+        self.mock_s3 = MagicMock()
+        patcher = patch.object(copy_handler, "s3", self.mock_s3)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_eventlog_copied_to_flat_shs_directory(self):
+        event = s3_event([("src-bucket", EVENTLOG_KEY, 337_647)])
+        result = copy_handler.lambda_handler(event, None)
+        self.assertEqual(result, {"copied": 1, "skipped": 0, "failed": 0, "total": 1})
+        self.mock_s3.copy_object.assert_called_once_with(
+            CopySource={"Bucket": "src-bucket", "Key": EVENTLOG_KEY},
+            Bucket="dest-bucket",
+            Key="logs/eventlog_v2_00g72rcefave480b/events_0_00g72rcefave480b",
+        )
+
+    def test_appstatus_marker_also_copied(self):
+        event = s3_event([("src-bucket", APPSTATUS_KEY, 2)])
+        result = copy_handler.lambda_handler(event, None)
+        self.assertEqual(result["copied"], 1)
+        self.assertEqual(
+            self.mock_s3.copy_object.call_args.kwargs["Key"],
+            "logs/eventlog_v2_00g72rcefave480b/appstatus_00g72rcefave480b",
+        )
+
+    def test_non_eventlog_objects_skipped(self):
+        event = s3_event([
+            ("src-bucket", STDERR_KEY, 5157),
+            ("src-bucket", "logs/applications/app/jobs/run/job-metadata.log", 218),
+            ("src-bucket", "logs/applications/app/jobs/run/SPARK_EXECUTOR/1/stdout.gz", 1806),
+        ])
+        result = copy_handler.lambda_handler(event, None)
+        self.assertEqual(result, {"copied": 0, "skipped": 3, "failed": 0, "total": 3})
+        self.mock_s3.copy_object.assert_not_called()
+
+    def test_multiple_apps_and_jobs_flatten_into_same_directory(self):
+        keys = [
+            ("src-bucket", "logs/applications/APP_A/jobs/RUN_1/sparklogs/eventlog_v2_RUN_1/events_0_RUN_1", 10),
+            ("src-bucket", "logs/applications/APP_B/jobs/RUN_2/sparklogs/eventlog_v2_RUN_2/events_0_RUN_2", 10),
+        ]
+        copy_handler.lambda_handler(s3_event(keys), None)
+        dest_keys = [c.kwargs["Key"] for c in self.mock_s3.copy_object.call_args_list]
+        self.assertEqual(dest_keys, [
+            "logs/eventlog_v2_RUN_1/events_0_RUN_1",
+            "logs/eventlog_v2_RUN_2/events_0_RUN_2",
+        ])
+
+    def test_url_encoded_key_is_decoded(self):
+        event = s3_event([("src-bucket", "logs/applications/a/jobs/r/sparklogs/eventlog%3Dv2/file+1", 100)])
+        copy_handler.lambda_handler(event, None)
+        self.assertEqual(
+            self.mock_s3.copy_object.call_args.kwargs["Key"],
+            "logs/eventlog=v2/file 1",
+        )
+
+    def test_error_logged_and_batch_continues(self):
+        self.mock_s3.copy_object.side_effect = [Exception("AccessDenied"), None]
+        event = s3_event([
+            ("src-bucket", "logs/applications/a/jobs/r1/sparklogs/e1/f1", 10),
+            ("src-bucket", "logs/applications/a/jobs/r2/sparklogs/e2/f2", 10),
+        ])
+        result = copy_handler.lambda_handler(event, None)
+        self.assertEqual(result, {"copied": 1, "skipped": 0, "failed": 1, "total": 2})
+
+    def test_malformed_record_skipped(self):
+        result = copy_handler.lambda_handler({"Records": [{"s3": {}}]}, None)
+        self.assertEqual(result, {"copied": 0, "skipped": 0, "failed": 1, "total": 1})
+
+    def test_large_object_uses_multipart(self):
+        size = 6 * 1024**3  # 6 GiB > 5 GiB copy_object limit
+        self.mock_s3.create_multipart_upload.return_value = {"UploadId": "u1"}
+        self.mock_s3.upload_part_copy.return_value = {"CopyPartResult": {"ETag": "e"}}
+        event = s3_event([("src-bucket", EVENTLOG_KEY, size)])
+        result = copy_handler.lambda_handler(event, None)
+        self.assertEqual(result["copied"], 1)
+        self.mock_s3.copy_object.assert_not_called()
+        self.assertEqual(self.mock_s3.upload_part_copy.call_count, 6)  # 6 x 1 GiB parts
+        self.mock_s3.complete_multipart_upload.assert_called_once()
+
+    def test_multipart_aborts_on_failure(self):
+        self.mock_s3.create_multipart_upload.return_value = {"UploadId": "u1"}
+        self.mock_s3.upload_part_copy.side_effect = Exception("boom")
+        event = s3_event([("src-bucket", EVENTLOG_KEY, 6 * 1024**3)])
+        result = copy_handler.lambda_handler(event, None)
+        self.assertEqual(result["failed"], 1)
+        self.mock_s3.abort_multipart_upload.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/utilities/emr-serverless-unified-history-server/template.yaml
+++ b/utilities/emr-serverless-unified-history-server/template.yaml
@@ -1,0 +1,224 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Event-driven Spark event log aggregation: S3 Event Notification on the source
+  bucket (EMR Serverless log destination) triggers a Lambda that copies ONLY Spark
+  event logs (under sparklogs/) into a single flat Spark History Server log
+  directory in the destination bucket. Includes SQS DLQ for failed async invocations.
+
+Parameters:
+  SourceBucketName:
+    Type: String
+    Description: Name for the source bucket (must be globally unique)
+  DestinationBucketName:
+    Type: String
+    Description: Name for the destination bucket (must be globally unique)
+  LogPrefix:
+    Type: String
+    Default: logs/applications/
+    Description: Only objects under this prefix trigger the copy Lambda
+  DestinationPrefix:
+    Type: String
+    Default: logs/
+    Description: >
+      Spark History Server log directory in the destination bucket. Event logs land
+      at <DestinationPrefix>eventlog_v2_<job-run-id>/... regardless of source app/job.
+
+Resources:
+
+  # ---------- Destination bucket ----------
+  DestinationBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref DestinationBucketName
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+  # ---------- DLQ for failed async Lambda invocations ----------
+  CopyDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub '${AWS::StackName}-copy-dlq'
+      MessageRetentionPeriod: 1209600  # 14 days
+
+  # ---------- Lambda execution role ----------
+  CopyFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: { Service: lambda.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: S3CopyLeastPrivilege
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectTagging
+                Resource: !Sub 'arn:aws:s3:::${SourceBucketName}/*'
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:PutObjectTagging
+                  - s3:AbortMultipartUpload
+                Resource: !Sub 'arn:aws:s3:::${DestinationBucketName}/*'
+        - PolicyName: DlqSend
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: sqs:SendMessage
+                Resource: !GetAtt CopyDlq.Arn
+
+  # ---------- Lambda function ----------
+  CopyFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub '${AWS::StackName}-s3-log-copy'
+      Runtime: python3.12
+      Handler: index.lambda_handler
+      MemorySize: 128
+      Timeout: 60
+      Role: !GetAtt CopyFunctionRole.Arn
+      DeadLetterConfig:
+        TargetArn: !GetAtt CopyDlq.Arn
+      Environment:
+        Variables:
+          DESTINATION_BUCKET: !Ref DestinationBucketName
+          DESTINATION_PREFIX: !Ref DestinationPrefix
+      Code:
+        ZipFile: |
+          import json, logging, os, urllib.parse
+          import boto3
+          from botocore.config import Config
+
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+          s3 = boto3.client("s3", config=Config(retries={"max_attempts": 3, "mode": "adaptive"}))
+          DESTINATION_BUCKET = os.environ["DESTINATION_BUCKET"]
+          DESTINATION_PREFIX = os.environ.get("DESTINATION_PREFIX", "logs/")
+          SPARKLOGS_MARKER = "/sparklogs/"
+          COPY_OBJECT_MAX_BYTES = 5 * 1024 * 1024 * 1024
+
+          def destination_key_for(source_key):
+              idx = source_key.find(SPARKLOGS_MARKER)
+              if idx == -1:
+                  return None
+              return DESTINATION_PREFIX + source_key[idx + len(SPARKLOGS_MARKER):]
+
+          def lambda_handler(event, context):
+              records = event.get("Records", [])
+              copied, skipped, failed = 0, 0, 0
+              for record in records:
+                  try:
+                      source_bucket = record["s3"]["bucket"]["name"]
+                      source_key = urllib.parse.unquote_plus(record["s3"]["object"]["key"])
+                      size = record["s3"]["object"].get("size", 0)
+                  except KeyError:
+                      logger.error("Malformed record, skipping: %s", json.dumps(record))
+                      failed += 1
+                      continue
+                  destination_key = destination_key_for(source_key)
+                  if destination_key is None:
+                      skipped += 1
+                      logger.info("Skipped (not a spark event log): s3://%s/%s", source_bucket, source_key)
+                      continue
+                  try:
+                      if size > COPY_OBJECT_MAX_BYTES:
+                          _multipart_copy(source_bucket, source_key, destination_key, size)
+                      else:
+                          s3.copy_object(
+                              CopySource={"Bucket": source_bucket, "Key": source_key},
+                              Bucket=DESTINATION_BUCKET, Key=destination_key)
+                      copied += 1
+                      logger.info("Copied s3://%s/%s -> s3://%s/%s (%d bytes)",
+                                  source_bucket, source_key, DESTINATION_BUCKET, destination_key, size)
+                  except Exception:
+                      failed += 1
+                      logger.exception("Failed to copy s3://%s/%s -> s3://%s/%s",
+                                       source_bucket, source_key, DESTINATION_BUCKET, destination_key)
+              result = {"copied": copied, "skipped": skipped, "failed": failed, "total": len(records)}
+              logger.info("Batch complete: %s", json.dumps(result))
+              return result
+
+          def _multipart_copy(source_bucket, source_key, destination_key, size):
+              part_size = 1 * 1024 * 1024 * 1024
+              mpu = s3.create_multipart_upload(Bucket=DESTINATION_BUCKET, Key=destination_key)
+              upload_id = mpu["UploadId"]
+              try:
+                  parts, part_number, offset = [], 1, 0
+                  while offset < size:
+                      last_byte = min(offset + part_size, size) - 1
+                      resp = s3.upload_part_copy(
+                          Bucket=DESTINATION_BUCKET, Key=destination_key,
+                          UploadId=upload_id, PartNumber=part_number,
+                          CopySource={"Bucket": source_bucket, "Key": source_key},
+                          CopySourceRange=f"bytes={offset}-{last_byte}")
+                      parts.append({"ETag": resp["CopyPartResult"]["ETag"], "PartNumber": part_number})
+                      offset = last_byte + 1
+                      part_number += 1
+                  s3.complete_multipart_upload(
+                      Bucket=DESTINATION_BUCKET, Key=destination_key,
+                      UploadId=upload_id, MultipartUpload={"Parts": parts})
+              except Exception:
+                  s3.abort_multipart_upload(
+                      Bucket=DESTINATION_BUCKET, Key=destination_key, UploadId=upload_id)
+                  raise
+
+  # ---------- Permission for S3 to invoke the Lambda ----------
+  S3InvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref CopyFunction
+      Action: lambda:InvokeFunction
+      Principal: s3.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
+      SourceArn: !Sub 'arn:aws:s3:::${SourceBucketName}'
+
+  # ---------- Source bucket with event notification ----------
+  SourceBucket:
+    Type: AWS::S3::Bucket
+    DependsOn: S3InvokePermission
+    Properties:
+      BucketName: !Ref SourceBucketName
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      NotificationConfiguration:
+        LambdaConfigurations:
+          - Event: 's3:ObjectCreated:*'
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: !Ref LogPrefix
+            Function: !GetAtt CopyFunction.Arn
+
+Outputs:
+  SourceBucket:
+    Value: !Ref SourceBucket
+  DestinationBucket:
+    Value: !Ref DestinationBucket
+  CopyFunctionArn:
+    Value: !GetAtt CopyFunction.Arn
+  DlqUrl:
+    Value: !Ref CopyDlq


### PR DESCRIPTION
## Summary

- Adds a new utility that provides a **unified Spark History Server** for EMR Serverless by aggregating event logs from all applications into a single flat S3 directory
- Uses S3 Event Notifications + Lambda for near real-time (~1-2s lag), server-side copy (zero data transfer cost within region)
- Includes CloudFormation template, Lambda source with unit tests, and full documentation

## Motivation

Teams migrating from EMR on EC2 lose the single-pane History Server experience — on EMR Serverless, each application's logs are nested under a different prefix, so no single SHS can read them all. This utility restores that unified view.

## What's included

| File | Purpose |
|---|---|
| `template.yaml` | CloudFormation: buckets, Lambda, IAM role, S3 event notification, DLQ |
| `lambda/copy_handler.py` | Lambda source — filters sparklogs, flattens keys, server-side CopyObject |
| `lambda/test_copy_handler.py` | 9 unit tests (no AWS access required) |
| `README.md` | Architecture, deployment, testing, cost estimate, production hardening |

## Cost

~$1.30/month at 30,000 notified objects/day (event-log-only mode). The SHS host is the real cost driver if dedicated.

## Test plan

- [x] All 9 unit tests pass locally (`python -m unittest test_copy_handler -v`)
- [x] End-to-end verified with 3 real EMR Serverless job runs (emr-7.9.0) across 3 applications
- [x] Verified SHS lists all runs with full job/stage drill-down, including live-appearing runs
- [x] CloudFormation template validates cleanly (`aws cloudformation validate-template`)