### PR TITLE
fix(config-advisor): worker-shape-aware disk sizing + running-job health check

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/WEBUI_README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/WEBUI_README.md
@@ -27,6 +27,18 @@ FastAPI web UI for the Config Advisor with an EMR-console-style shell.
 - **Observability**: live driver/executor dashboards (heap, RSS, CPU, GC,
   disk, tasks, job status) from a self-hosted Prometheus (see
   `bucket-agent/docs/METRICS_OBSERVABILITY_STACK.md` for the stack).
+- **Job health (running jobs)**: a "Check health" action on the home page's
+  job table for RUNNING runs (also available to the Ask AI agent as the
+  `check_job_health` tool). Correlates four independent checks into one
+  verdict — healthy / degraded / unhealthy / insufficient signal:
+  - EMR job state and state details
+  - task-activity stall detection from Prometheus ("RUNNING but no active
+    tasks for 30+ min"); degrades gracefully for uninstrumented jobs
+  - driver stderr from S3 scanned against the curated failure-signature
+    table — catches unhandled exceptions before the job reaches a terminal
+    state (EMR Serverless pushes logs to S3 periodically, so this evidence
+    can lag an in-flight run by minutes; the result says so)
+  - elapsed time vs the P95 of prior same-name successful runs (30 days)
 - **Ask AI**: embedded agentic assistant (Bedrock Converse tool-use) with
   tools over the EMR Serverless API, Prometheus, the analyses, and a
   t-shirt-sizing tool for brand-new jobs.

--- a/utilities/EMR-Serverless-Config-Advisor/app.py
+++ b/utilities/EMR-Serverless-Config-Advisor/app.py
@@ -237,8 +237,9 @@ PRODUCT CAPABILITIES — never claim the UI lacks these; direct users to them:
   Serverless needs). The result IS the migration recommendation.
 - 'Compare two runs' on the same page diffs two event logs side by side:
   metric deltas, config diff, per-stage CPU-per-GB analysis.
-- Home page lists applications/job runs with Optimize / Troubleshoot /
-  Upgrade actions; Observability shows live metrics for metrics-enabled runs.
+- Home page lists applications/job runs with Optimize / Health (running
+  runs) / Troubleshoot (failed runs) / Upgrade actions; Observability shows
+  live metrics for metrics-enabled runs.
 
 GROUNDING DISCIPLINE: always state WHICH run/application id an answer is
 based on. If the user references a run or file that is NOT the one in your
@@ -284,6 +285,11 @@ You have tools. USE THEM before answering — do not guess:
 - run_config_advisor: full pipeline on a job run's event log — bottleneck
   classification + cost/perf recommendations (slow, 30-120s; use for
   "optimize this job")
+- check_job_health: correlated health verdict for a RUNNING job — state,
+  task-activity stall detection, driver stderr signature scan, duration vs
+  same-name history. Present the per-check evidence, flag stale-S3-log and
+  no-metrics caveats the checks report, and say which check drove the
+  verdict. For finished failed runs prefer troubleshoot_job.
 - troubleshoot_job: failure evidence — state details, driver stderr errors,
   and the AWS managed Spark Troubleshooting Agent analysis when configured
 - get_application_details: release label vs latest EMR, capacity, network
@@ -583,6 +589,194 @@ def _tool_run_config_advisor(job_run_id: str) -> dict:
     return result
 
 
+def _fetch_driver_stderr(app_id: str, job_run_id: str, jr: dict):
+    """(text, error) — driver stderr from the job's S3 monitoring location.
+
+    Works for RUNNING jobs too, with a caveat the callers surface: EMR
+    Serverless pushes logs to S3 periodically, so the text can be minutes
+    stale for an in-flight run.
+    """
+    log_uri = (jr.get("configurationOverrides", {})
+                 .get("monitoringConfiguration", {})
+                 .get("s3MonitoringConfiguration", {})
+                 .get("logUri", ""))
+    if not log_uri:
+        return None, "job has no S3 monitoring logUri"
+    stderr_key = (f"{log_uri.rstrip('/')}/applications/{app_id}/jobs/"
+                  f"{job_run_id}/SPARK_DRIVER/stderr.gz")
+    try:
+        import boto3
+        s3 = boto3.client("s3", region_name=AWS_REGION)
+        m = re.match(r"s3://([^/]+)/(.+)", stderr_key)
+        obj = s3.get_object(Bucket=m.group(1), Key=m.group(2))
+        text = gzip.decompress(obj["Body"].read()).decode("utf-8", "replace")
+        return text, None
+    except Exception as e:
+        return None, f"could not fetch driver stderr: {e}"
+
+
+def _duration_history(app_id: str, job_run_id: str, job_name: str) -> dict:
+    """Completed same-name runs on this application, for duration-anomaly
+    comparison. Bounded to one list_job_runs page window (30 days) because
+    the API throttles at very low TPS."""
+    created_after = datetime.now(timezone.utc) - timedelta(days=30)
+    durations = []
+    try:
+        for page in _emr().get_paginator("list_job_runs").paginate(
+            applicationId=app_id, createdAtAfter=created_after,
+        ):
+            for prior in page["jobRuns"]:
+                if prior["id"] == job_run_id or prior.get("state") != "SUCCESS":
+                    continue
+                if prior.get("name", prior["id"]) != job_name:
+                    continue
+                start, end = prior.get("createdAt"), prior.get("updatedAt")
+                if start and end:
+                    durations.append((end - start).total_seconds() / 60)
+    except Exception as e:
+        return {"error": f"could not list prior runs: {e}"}
+    if not durations:
+        return {"note": f"no successful runs named '{job_name}' on this "
+                        "application in 30 days — no duration baseline"}
+    durations.sort()
+    p95 = durations[min(len(durations) - 1, int(len(durations) * 0.95))]
+    return {"prior_success_count": len(durations),
+            "median_minutes": round(durations[len(durations) // 2], 1),
+            "p95_minutes": round(p95, 1)}
+
+
+# Signatures that are fatal-by-themselves on a running job, vs. churn that is
+# only concerning in combination (see log_evidence.SIGNATURES kill_signal note)
+_HEALTH_FATAL_SIGS = {"heap_oom", "gc_overhead", "container_rss_kill",
+                      "disk_full", "driver_max_result", "python_oom"}
+
+
+def _tool_check_job_health(job_run_id: str) -> dict:
+    """Correlated health verdict for a job run (designed for RUNNING ones).
+
+    Checks: EMR state; task activity from Prometheus (stall detection);
+    driver stderr scanned against the curated signature table; duration vs
+    same-name history. Each check carries its own evidence and degrades
+    independently — uninstrumented jobs still get state + stderr + history.
+    """
+    from log_evidence import scan_text
+
+    cfg = _tool_get_job_config(job_run_id)
+    if "error" in cfg:
+        return cfg
+    app_id = cfg["application_id"]
+    jr = _emr().get_job_run(applicationId=app_id, jobRunId=job_run_id)["jobRun"]
+    state = jr.get("state", "")
+    running = state in ("RUNNING", "SCHEDULED", "PENDING", "SUBMITTED")
+    started = jr.get("createdAt")
+    elapsed_min = round((datetime.now(timezone.utc) - started)
+                        .total_seconds() / 60, 1) if started else None
+
+    checks = []
+
+    def add(name, status, detail, **evidence):
+        checks.append({"check": name, "status": status, "detail": detail,
+                       **({"evidence": evidence} if evidence else {})})
+
+    # --- state ---
+    add("job_state", "ok" if state in ("RUNNING", "SUCCESS") else
+        "warn" if running else "bad",
+        f"{state}{' — ' + jr.get('stateDetails') if jr.get('stateDetails') else ''}",
+        elapsed_minutes=elapsed_min)
+
+    # --- task activity (Prometheus; instrumented jobs only) ---
+    try:
+        end = int(time.time())
+        params = urllib.parse.urlencode({
+            "query": f'sum(spark_executor_threadpool_activeTasks{{app_id="{job_run_id}"}})',
+            "start": end - 6 * 3600, "end": end, "step": "60s"})
+        with urllib.request.urlopen(
+            f"{PROMETHEUS_URL}/api/v1/query_range?{params}", timeout=15,
+        ) as resp:
+            series = json.load(resp)["data"]["result"]
+        if not series:
+            add("task_activity", "unknown",
+                "no metrics in Prometheus — job not instrumented with the "
+                "GraphiteSink confs; stall detection unavailable")
+        else:
+            vals = series[0]["values"]
+            last_active = next((float(ts) for ts, v in reversed(vals)
+                                if float(v) > 0), None)
+            idle_min = (round((end - last_active) / 60, 1)
+                        if last_active else None)
+            if not running:
+                add("task_activity", "ok",
+                    "job finished — activity check not applicable")
+            elif last_active is None:
+                add("task_activity", "bad",
+                    "RUNNING but no task has been active in the 6h metrics "
+                    "window", active_tasks_now=float(vals[-1][1]))
+            elif idle_min is not None and idle_min > 30:
+                add("task_activity", "bad",
+                    f"RUNNING but no active tasks for {idle_min} min — "
+                    "likely stalled (driver wedged, deadlock, or waiting on "
+                    "an external dependency)", idle_minutes=idle_min)
+            else:
+                add("task_activity", "ok",
+                    f"tasks active {idle_min} min ago",
+                    active_tasks_now=float(vals[-1][1]))
+    except Exception as e:
+        add("task_activity", "unknown", f"prometheus unavailable: {e}")
+
+    # --- driver stderr signatures ---
+    text, fetch_err = _fetch_driver_stderr(app_id, job_run_id, jr)
+    if text is None:
+        add("driver_log", "unknown", fetch_err)
+    else:
+        sigs = scan_text(text)
+        fatal = [s for s in sigs if s["id"] in _HEALTH_FATAL_SIGS]
+        churn = [s for s in sigs if s["id"] not in _HEALTH_FATAL_SIGS]
+        note = ("S3 logs lag a running job by minutes — evidence may be "
+                "stale" if running else None)
+        if fatal:
+            add("driver_log", "bad",
+                "; ".join(f"{s['title']} ×{s['count']}" for s in fatal),
+                signatures=[{k: s[k] for k in
+                             ("id", "title", "meaning", "count", "excerpts")}
+                            for s in fatal], freshness=note)
+        elif churn:
+            add("driver_log", "warn",
+                "; ".join(f"{s['title']} ×{s['count']}" for s in churn),
+                signatures=[{k: s[k] for k in
+                             ("id", "title", "meaning", "count")}
+                            for s in churn], freshness=note)
+        else:
+            add("driver_log", "ok", "no known failure signatures in driver "
+                "stderr", freshness=note)
+
+    # --- duration vs history ---
+    hist = _duration_history(app_id, job_run_id, cfg.get("name", job_run_id))
+    if "p95_minutes" in hist and elapsed_min is not None and running:
+        if elapsed_min > hist["p95_minutes"]:
+            add("duration", "warn",
+                f"running {elapsed_min} min, past the P95 of "
+                f"{hist['p95_minutes']} min over {hist['prior_success_count']} "
+                "prior successes", **hist)
+        else:
+            add("duration", "ok",
+                f"{elapsed_min} min elapsed vs P95 {hist['p95_minutes']} min",
+                **hist)
+    else:
+        add("duration", "unknown",
+            hist.get("note") or hist.get("error") or
+            "job finished — see state check")
+
+    order = {"bad": 0, "warn": 1, "unknown": 2, "ok": 3}
+    worst = min((c["status"] for c in checks), key=order.get)
+    return {
+        "job_run_id": job_run_id,
+        "application_id": app_id,
+        "verdict": {"bad": "unhealthy", "warn": "degraded",
+                    "unknown": "insufficient signal", "ok": "healthy"}[worst],
+        "checks": checks,
+    }
+
+
 def _tool_troubleshoot_job(job_run_id: str) -> dict:
     """Failure evidence for a job run: state details + driver stderr tail.
 
@@ -604,30 +798,17 @@ def _tool_troubleshoot_job(job_run_id: str) -> dict:
     }
 
     # Driver stderr tail from the S3 monitoring location
-    log_uri = (jr.get("configurationOverrides", {})
-                 .get("monitoringConfiguration", {})
-                 .get("s3MonitoringConfiguration", {})
-                 .get("logUri", ""))
-    if log_uri:
-        stderr_key = (f"{log_uri.rstrip('/')}/applications/{app_id}/jobs/"
-                      f"{job_run_id}/SPARK_DRIVER/stderr.gz")
-        try:
-            import boto3
-            s3 = boto3.client("s3", region_name=AWS_REGION)
-            m = re.match(r"s3://([^/]+)/(.+)", stderr_key)
-            obj = s3.get_object(Bucket=m.group(1), Key=m.group(2))
-            text = gzip.decompress(obj["Body"].read()).decode("utf-8", "replace")
-            # Errors cluster at the end; keep exception lines + the tail
-            lines = text.splitlines()
-            err_lines = [ln for ln in lines
-                         if re.search(r"ERROR|Exception|OutOfMemory|Killed|137",
-                                      ln)][-40:]
-            out["driver_stderr_errors"] = err_lines
-            out["driver_stderr_tail"] = lines[-60:]
-        except Exception as e:
-            out["driver_stderr_error"] = f"could not fetch driver stderr: {e}"
+    text, fetch_err = _fetch_driver_stderr(app_id, job_run_id, jr)
+    if text is not None:
+        # Errors cluster at the end; keep exception lines + the tail
+        lines = text.splitlines()
+        err_lines = [ln for ln in lines
+                     if re.search(r"ERROR|Exception|OutOfMemory|Killed|137",
+                                  ln)][-40:]
+        out["driver_stderr_errors"] = err_lines
+        out["driver_stderr_tail"] = lines[-60:]
     else:
-        out["driver_stderr_error"] = "job has no S3 monitoring logUri"
+        out["driver_stderr_error"] = fetch_err
 
     # Optional: AWS managed Spark Troubleshooting Agent (SigV4 MCP endpoint)
     if SPARK_TROUBLESHOOTING_MCP_URL:
@@ -778,6 +959,15 @@ CHAT_TOOLS = [
         }},
     }},
     {"toolSpec": {
+        "name": "check_job_health",
+        "description": "Correlated health verdict for a job run, designed for RUNNING jobs: EMR state, task-activity stall detection (Prometheus, instrumented jobs), driver stderr scanned against the curated failure-signature table, and elapsed time vs the P95 of prior same-name successes. Returns healthy/degraded/unhealthy/insufficient-signal with per-check evidence. Use for 'is this job OK?' questions; for post-mortem on failed runs prefer troubleshoot_job.",
+        "inputSchema": {"json": {
+            "type": "object",
+            "properties": {"job_run_id": {"type": "string"}},
+            "required": ["job_run_id"],
+        }},
+    }},
+    {"toolSpec": {
         "name": "troubleshoot_job",
         "description": "Gather failure evidence for a job run: state details, submitted confs, driver stderr error lines and tail from S3, and (when configured) the AWS managed Spark Troubleshooting Agent's analysis. Use for failed or cancelled runs.",
         "inputSchema": {"json": {
@@ -869,6 +1059,8 @@ def _run_chat_tool(name: str, tool_input: dict):
         return _tool_get_log_evidence(tool_input["application_id"])
     if name == "run_config_advisor":
         return _tool_run_config_advisor(tool_input["job_run_id"])
+    if name == "check_job_health":
+        return _tool_check_job_health(tool_input["job_run_id"])
     if name == "troubleshoot_job":
         return _tool_troubleshoot_job(tool_input["job_run_id"])
     if name == "get_application_details":
@@ -1022,6 +1214,54 @@ def classify_bottleneck(metrics: dict) -> dict:
     }
 
 
+# EMR Serverless worker tiers by vCPU — matches the recommender's vocabulary
+_WORKER_TIERS = {4: "Small", 8: "Medium", 16: "Large", 32: "XLarge"}
+
+
+def _source_worker(cfg: dict) -> dict | None:
+    """Submitted worker shape from the event-log Spark conf, for the
+    results/compare banners.
+
+    Serverless: cores + heap -> billed worker memory (heap x overhead factor
+    rounded up to the whole GB, same rule as _run_cost). Disk and disk.type
+    are submit-only params that only appear when they were passed as --conf;
+    absence means "not captured", never "default" (see
+    _CONFS_INVISIBLE_IN_EVENT_LOGS).
+    """
+    if not cfg:
+        return None
+    import math
+    is_ec2 = bool(cfg.get("spark.emr_cluster_id"))
+    try:
+        cores = int(str(cfg.get("spark.executor.cores", "")).strip())
+    except ValueError:
+        cores = None
+    heap = str(cfg.get("spark.executor.memory", "")) or None
+    overhead = 1 + float(cfg.get("spark.emr-serverless.memoryOverheadFactor",
+                                 cfg.get("spark.kubernetes.memoryOverheadFactor",
+                                         0.1)))
+    dyn = str(cfg.get("spark.dynamicAllocation.enabled", "")).lower() == "true"
+    out = {
+        "platform": "emr-ec2" if is_ec2 else "emr-serverless",
+        "tier": None if is_ec2 or cores is None else _WORKER_TIERS.get(cores),
+        "cores": cores,
+        "heap": heap,
+        "billed_memory_gb": (math.ceil(_parse_mem_gb(heap) * overhead)
+                             if heap and not is_ec2 else None),
+        "dynamic_allocation": dyn,
+        "min_executors": cfg.get("spark.dynamicAllocation.minExecutors"),
+        "max_executors": (cfg.get("spark.dynamicAllocation.maxExecutors") if dyn
+                          else cfg.get("spark.executor.instances")),
+        "driver_cores": cfg.get("spark.driver.cores"),
+        "driver_memory": cfg.get("spark.driver.memory"),
+    }
+    if not is_ec2:
+        out["disk"] = cfg.get("spark.emr-serverless.executor.disk")
+        out["disk_type"] = cfg.get("spark.emr-serverless.executor.disk.type")
+        out["driver_disk"] = cfg.get("spark.emr-serverless.driver.disk")
+    return out
+
+
 def analyze_uploaded_file(json_path: str) -> dict:
     """Run the full analysis on an uploaded extracted JSON file.
 
@@ -1087,6 +1327,7 @@ def analyze_uploaded_file(json_path: str) -> dict:
         "source_platform": ("emr-ec2" if data.get("spark_config", {}).get("spark.emr_cluster_id")
                             else "emr-serverless"),
         "spark_config_source": data.get("spark_config", {}),
+        "source_worker": _source_worker(data.get("spark_config", {})),
     }
     try:
         result["_executor_summary"] = {

--- a/utilities/EMR-Serverless-Config-Advisor/emr_s_fine_tuner.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_s_fine_tuner.py
@@ -289,6 +289,20 @@ def _compute_exec_limits(input_gb: float, vcpu: int, partitions: int = 0,
             cores = min(work * mult + 30, orig_vcpu * 1.1)
         else:
             cores = max(work * 1.1, orig_vcpu * 1.1) if orig_vcpu > 0 else work * 1.1
+            # No idle-trim on healthy sources (the former Rule 4). The
+            # 2026-07-25 replicated-workload A/B (max 17 vs 15, same config
+            # otherwise) tested exactly the trim mechanism: wall-clock
+            # flat, billed vCPU-h ROSE 87.6 -> 93.6 (+6.8% cost). Under
+            # DRA + per-second billing a lower cap doesn't release the
+            # measured idle — idle_core_percentage is WITHIN-executor core
+            # gaps (skew/contention), so the narrower fleet just holds the
+            # same executors alive longer. The rule's founding evidence
+            # (a 600 -> 432 vCPU win on the same workload) was confounded with an
+            # 8c -> 16c worker shape change. Rule 3 above owns genuine
+            # over-provisioning (eff < 0.40); re-add a trim only when the
+            # extractor exposes fleet-level TASKLESS-executor time
+            # (executor_timeline today records only add/remove events,
+            # not per-executor busy spans).
 
     max_exec = max(4, int(cores / vcpu))  # EMR Serverless minimum is 4
 
@@ -332,39 +346,145 @@ def _compute_exec_limits(input_gb: float, vcpu: int, partitions: int = 0,
     return max_exec, min_exec
 
 
+# shuffle_optimized disk throughput (GB/s) by worker vCPU x disk size —
+# the EMR Serverless service-side tier table (verified empirically via
+# per-tier disk benchmark runs on each worker shape).
+# Entries: (min_disk_gib, throughput_gbps), largest tier first. KEY FACT:
+# on <=8 vCPU workers every size >=170G serves the SAME 250 MiB/s — a
+# bigger disk on a small worker buys capacity only, never bandwidth.
+_DISK_THROUGHPUT_TIERS = {
+    8:  [(170, 0.250), (0, 0.125)],
+    16: [(1000, 0.500), (170, 0.250), (0, 0.125)],
+    32: [(2000, 1.000), (1500, 0.750), (1000, 0.500), (170, 0.250), (0, 0.125)],
+}
+
+
+def _disk_tiers_for_vcpu(worker_vcpu: int) -> list:
+    if worker_vcpu <= 8:
+        return _DISK_THROUGHPUT_TIERS[8]
+    if worker_vcpu <= 16:
+        return _DISK_THROUGHPUT_TIERS[16]
+    return _DISK_THROUGHPUT_TIERS[32]
+
+
 def _calculate_executor_disk(shuffle_write_gb: float, disk_spill_gb: float,
-                             memory_spill_gb: float, max_executors: int) -> str:
-    """Attach shuffle_optimized disk for shuffle-intensive jobs.
-    Shuffle-optimized disks provide higher IOPS and faster disk access,
-    benefiting jobs with significant shuffle operations or disk spill.
-    For non-shuffle workloads, default disk avoids unnecessary cost.
-    
-    Disk tier selection also considers IOPS/throughput needs:
-      - 200G + 16c: 250 MiB/s, 3,000 IOPS (small shuffle)
-      - 1000G + 16c: 500 MiB/s, 6,000 IOPS (medium shuffle)
-      - 2000G + 16c: 500 MiB/s, 16,000 IOPS (large shuffle, IOPS-bound)
-    
-    For massive shuffle (>10 TB), the IOPS tier matters more than capacity.
+                             max_executors: int, worker_vcpu: int = 4,
+                             stages: list = None,
+                             fetch_wait_pct: float = 0.0,
+                             mode: str = "cost") -> str:
+    """Attach shuffle_optimized disk sized from per-executor need and
+    measured serving demand — never from fleet-total volume.
+
+    Field validation (replicated customer ETL, 2026-07: 2.26TB fleet
+    shuffle, 9.7x spill):
+    this function's old fleet-total rule (>2000G shuffle -> 2000G disk)
+    billed $8/run for disks whose throughput tier was IDENTICAL to 200G —
+    per the control-plane table above, 8c workers cap at 250 MiB/s at any
+    size. The same job then ran healthier on 500G (fetch-wait 3.1%) and,
+    on 16c workers where 1000G is a real tier, fastest at 1000G. Replica
+    matrix confirmed the tier boundary directly: 16c@500G ran 1.5x the
+    task-hours of 16c@1000G on the same data.
+
+    Three independent constraints, each tiered by THIS worker's table:
+
+    1. CAPACITY — this executor's share of shuffle write + disk spill,
+       x1.5 for uneven distribution. (Memory-spill bytes are the same data
+       as disk-spill bytes pre-compression — counting both double-counts.)
+    2. SERVING — peak sustained per-host disk IO must fit the tier's
+       throughput with x1.5 headroom. Sizes from workload arithmetic, not
+       from what disk the source ran with (evidence-conditioned-on-
+       treatment guard). If NO tier on this worker shape can sustain the
+       demand (8c fleet needing >250 MiB/s), disk cannot fix it — take the
+       biggest useful tier and leave worker-shape escalation to the sizing
+       matrix, which is the actual cure.
+       IOPS floor: throughput tiers are flat across sizes on 8c, but IOPS
+       still scale with size (~3K@200G -> ~16K@2000G), and high-fan-in
+       shuffle serving is IOPS-bound. A/B 2026-07-25 (replicated customer job, 92x8c, 1.7TB
+       peak-stage shuffle): 200G ran +17.5% wall vs 2000G with shuffle
+       write inflated 3365->3979 GB; a prior disk sweep on the same job
+       was monotonic — 500G=730s/$8.42, 1000G=531s/$6.79, 2000G=404s/$4.85
+       (biggest disk fastest AND cheapest). So when serving demand exceeds
+       the base tier on a flat-throughput shape, floor at 1000G, and at
+       2000G once demand crosses half the shape's ceiling. Shapes with
+       real throughput tiers (16c/32c) already land on large disks via
+       the throughput math — their demand-sized picks won their A/Bs.
+    3. EVIDENCE — observed serving harm (FetchFailed retries, or
+       fetch-wait > 10%) escalates one tier boundary when a higher tier
+       EXISTS for this shape. PR #191 harm-gate pattern: volume alone is
+       not evidence.
+    4. PERF MODE floors at the shape's MAX-throughput tier. Demand math
+       sizes serving (shuffle read fan-out over hosts) but spill I/O
+       scales with the CORES doing the work, not the host count — a big
+       perf fleet passes the serving check while every worker still
+       writes/merges its spill through the base tier. Replica matrix:
+       the healthy/degraded boundary tracked per-vCPU disk bandwidth
+       (~31 MiB/s/vCPU healthy, ~15.6 degraded at 1.4-1.5x task-hours),
+       and each shape reaches ~31 exactly at its top tier — 8c@170G+,
+       16c@1000G, 32c@2000G. Perf mode pays for wall-clock; shipping it
+       on a half-bandwidth disk defeats the mode. Cost mode keeps
+       demand-based sizing (spill-tolerant by definition).
     """
-    total_shuffle_and_spill = shuffle_write_gb + disk_spill_gb + memory_spill_gb
-    if total_shuffle_and_spill < 20:
+    landed = shuffle_write_gb + disk_spill_gb
+    if landed < 20:
         return ""  # Minimal shuffle — default disk sufficient
-    
-    # IOPS-tier selection: for large shuffle, bump to 2000G for 16K IOPS
-    # regardless of per-executor capacity needs.
-    # Rationale: shuffle blocks are typically 16-200 KB; serving them is
-    # IOPS-bound, not throughput-bound. 2000G gives 16K IOPS vs 3K at 200G.
-    if shuffle_write_gb > 10000:
-        return "2000G"  # Massive shuffle: need 16K IOPS tier
-    if shuffle_write_gb > 2000:
-        return "2000G"  # Large shuffle: 16K IOPS helps significantly
-    if shuffle_write_gb > 500:
-        return "1000G"  # Medium shuffle: 6K IOPS tier
-    
-    # Small-to-moderate shuffle: size by capacity
-    per_exec = total_shuffle_and_spill / max(max_executors, 1)
-    disk_gb = max(200, min(2000, int(per_exec * 1.5 / 20) * 20 + 20))
-    return f"{disk_gb}G"
+    hosts = max(max_executors, 1)
+    tiers = _disk_tiers_for_vcpu(worker_vcpu)
+
+    # 1) capacity
+    per_exec = landed / hosts
+    capacity_gb = max(200, min(2000, int(per_exec * 1.5 / 20) * 20 + 20))
+
+    # 2) serving demand: peak sustained per-host disk IO across real stages
+    demand = 0.0
+    for s in (stages or []):
+        dur = s.get("duration_sec") or 0
+        if dur <= 30:
+            continue  # too short for reliable rate; can't be rate-limiting
+        io_gb = ((s.get("shuffle_read_gb") or 0)
+                 + (s.get("shuffle_write_gb") or 0)
+                 + (s.get("disk_spill_gb") or 0))
+        demand = max(demand, io_gb / dur / hosts)
+    # smallest tier on THIS worker shape that sustains demand x1.5;
+    # if none does, the largest tier is the best disk can do here
+    tier_floor = 200
+    needed = demand * 1.5
+    if needed > tiers[-1][1]:  # above the base 125 MiB/s tier
+        sustaining = [min_gib for min_gib, gbps in tiers if gbps >= needed]
+        tier_floor = max(200, min(sustaining) if sustaining else tiers[0][0])
+        # IOPS floor (see docstring): on shapes whose throughput ceiling is
+        # flat across sizes, the throughput table alone says "bigger buys
+        # nothing" — but serving-bound stages are IOPS-bound and IOPS scale
+        # with size. Floor at 1000G; 2000G once demand crosses half the
+        # shape's ceiling.
+        shape_ceiling = tiers[0][1]
+        flat_throughput = len({gbps for _, gbps in tiers if gbps > tiers[-1][1]}) <= 1
+        if flat_throughput:
+            tier_floor = max(tier_floor,
+                             2000 if needed >= shape_ceiling * 0.5 else 1000)
+
+    # 3) evidence escalation: one tier boundary up, where one exists.
+    # On flat-throughput shapes the throughput table has no boundary above
+    # 200G, which left FetchFailed fleets on the 3K-IOPS disk — escalate
+    # up the IOPS ladder (200 -> 1000 -> 2000) instead. Evidence of harm
+    # trumps demand arithmetic (PR #191 pattern), so this applies even
+    # when the serving check above did not fire.
+    fetch_fail = any("FetchFailed" in (s.get("failure_reason") or "")
+                     for s in (stages or []))
+    if fetch_fail or fetch_wait_pct > 10:
+        flat = len({gbps for _, gbps in tiers if gbps > tiers[-1][1]}) <= 1
+        if flat:
+            tier_floor = 2000 if tier_floor >= 1000 else 1000
+        else:
+            boundaries = sorted(min_gib for min_gib, _ in tiers if min_gib > 0)
+            higher = [b for b in boundaries if b > tier_floor]
+            if higher:
+                tier_floor = higher[0]
+
+    # 4) perf mode: floor at this shape's max-throughput tier (see above)
+    if mode == "performance":
+        tier_floor = max(tier_floor, tiers[0][0], 200)
+
+    return f"{max(capacity_gb, tier_floor)}G"
 
 
 def _max_partition_bytes(input_gb: float, advisory_bytes: int = 0) -> str:
@@ -797,7 +917,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             # stages that spilled AND failed (fetch-fail/executor-death
             # retry loops) get their sort footprint sized into partitions.
             # Steady-state spill on succeeding stages is the workload's
-            # proven operating point (search-health class spills 6-14x data
+            # proven operating point (steady-spill class: 6-14x data
             # moved and wins on big workers) — boosting those inflated proven
             # 1000-partition configs to 8-11k.
             # Memory spill is the uncompressed sort footprint; disk spill is
@@ -884,31 +1004,65 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
         # its share of total shuffle write under full fan-in). A spill-discounted
         # compute answer can be correct on cores yet collapse on serving.
         #
-        # The binding constraint is the per-host SERVING RATE:
-        #     shuffle_write_gb / hosts / target_duration_sec
-        # not raw GB/host (a longer job serves the same bytes more slowly) and
-        # not connection count alone (connections × per-connection volume is
-        # what saturates Netty/TCP — the rate captures the product). This is
-        # network/fan-in bound, NOT disk bound: thresholds sit ~6x below the
-        # 0.244 GB/s shuffle_optimized GP3 per-executor throughput.
+        # The floor has TWO terms, because serving fails two different ways:
         #
-        # Calibration (validated production workload, ~14-17TB shuffle write):
-        #   0.057 GB/s/host demanded (82 hosts, 62min compute budget)
-        #          → fetch timeouts → unregisterOutputOnHost storms →
-        #            congestion collapse (301 min, 75% fetch-wait)
-        #   0.033 GB/s/host (300 hosts, 25min) → healthy (45% fetch-wait)
-        #   0.021 GB/s/host (118 EC2 hosts, 95min) → completed (48% fetch-wait)
-        # Safe ceiling: 0.04 GB/s/host — above the healthiest observed run,
-        # well below the observed collapse point.
+        # DISK term — fleet disk bandwidth must sustain the peak-stage IO
+        # rate. Per-host capacity is the worker shape's best shuffle_optimized
+        # tier (see _DISK_THROUGHPUT_TIERS; 8c caps at
+        # 0.25 GB/s at ANY disk size, 16c reaches 0.5 at 1000G, 32c 1.0 at
+        # 2000G). Tier-aware calibration (replica benchmark matrix, 7 cells):
+        # every config at ~31 MiB/s/vCPU fleet disk bandwidth ran healthy,
+        # every config below ran degraded-to-collapsed, ordering exactly by
+        # this metric. The previous flat 0.04 GB/s/host constant conflated
+        # this term with fan-in and over-floored healthy fleets (production
+        # 16c@1000G ran clean at 0.10 GB/s/host, 2.5x that constant).
+        #
+        # NETWORK fan-in term — connections x per-connection volume
+        # saturating Netty/TCP, independent of disk. Calibration (~14-17TB
+        # shuffle write, many sub-100KB blocks): 0.057 GB/s/host → congestion
+        # collapse (301min, 75% fetch-wait); 0.033 → healthy. Ceiling 0.04.
+        # Applied ONLY on evidence of fan-in distress (source fetch-wait >10%
+        # or FetchFailed retries) — the PR #191 harm-gate pattern. Without
+        # the gate this term masquerades as a disk limit and inflates floors
+        # on jobs whose own runs prove serving is fine (a healthy replica at 8.4%
+        # fetch-wait was floored 27→31 for nothing).
         SAFE_SERVING_GBPS = 0.04
         _serve_target_cost_h = duration
         _serve_target_perf_h = (max(duration * 0.25, min(duration, 20.0 / 60.0))
                                 if is_ec2 else duration)
 
+        # Peak-stage serving demand (GB/s): the rate the fleet must sustain.
+        # Only stages that are a meaningful share of the job bind the floor —
+        # a short burst (e.g. 1TB in 49s inside a 38min job) doubling in
+        # length is invisible at job level, but sizing the fleet to preserve
+        # its rate inflated one migration fixture's fleet by 80%. Stages
+        # shorter than 5% of the job (or 120s) size nothing; if they slow
+        # down on the new fleet, the job-level cost is by construction <5%.
+        _min_binding_sec = max(120.0, (duration or 0) * 3600 * 0.05)
+        _peak_io_gbps = 0.0
+        for _s in (stages_raw or []):
+            _dur = _s.get("duration_sec") or 0
+            if _dur < _min_binding_sec:
+                continue
+            _io = ((_s.get("shuffle_read_gb") or 0)
+                   + (_s.get("shuffle_write_gb") or 0)
+                   + (_s.get("disk_spill_gb") or 0))
+            _peak_io_gbps = max(_peak_io_gbps, _io / _dur)
+
+        _fanin_evidence = (shuffle_fetch_wait_pct > 10
+                           or any("FetchFailed" in (s.get("failure_reason") or "")
+                                  for s in (stages_raw or [])))
+
         def _serving_floor(target_h):
             if s_out_gb <= 1000 or target_h <= 0:
                 return 0
-            return int(math.ceil(s_out_gb / (SAFE_SERVING_GBPS * target_h * 3600)))
+            avg_gbps = s_out_gb / (target_h * 3600)
+            demand = max(_peak_io_gbps, avg_gbps)
+            best_tier_gbps = _disk_tiers_for_vcpu(worker_cfg["vcpu"])[0][1]
+            disk_hosts = int(math.ceil(demand * 1.5 / best_tier_gbps))
+            net_hosts = (int(math.ceil(avg_gbps / SAFE_SERVING_GBPS))
+                         if _fanin_evidence else 0)
+            return max(disk_hosts, net_hosts)
 
         _floor_cost = _serving_floor(_serve_target_cost_h)
         if _floor_cost > max_exec_cost:
@@ -925,9 +1079,11 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
 
         # Account for EC2 spill conservatively: Serverless has more memory per core
         # and AQE reduces spill, but not to zero. Use 10% of observed spill as safety floor.
-        _eff_disk_spill = disk_spill_gb * 0.1
-        _eff_mem_spill = spill_gb * 0.1
-        executor_disk_cost = _calculate_executor_disk(s_out_gb, _eff_disk_spill, _eff_mem_spill, max_exec_cost)
+        _eff_disk_spill = disk_spill_gb * (0.1 if is_ec2 else 1.0)
+        executor_disk_cost = _calculate_executor_disk(
+            s_out_gb, _eff_disk_spill, max_exec_cost,
+            worker_vcpu=worker_cfg["vcpu"],
+            stages=stages_raw, fetch_wait_pct=shuffle_fetch_wait_pct)
         # Performance-optimized
         max_exec_perf_init, min_exec_perf = _compute_exec_limits(
             i_in_gb, worker_cfg["vcpu"], 0, mem_pct, cpu_pct, idle_pct, spill_gb, mode="performance",
@@ -973,7 +1129,11 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
                 if _new_max_p != max_exec_perf:
                     max_exec_perf = _new_max_p
                     min_exec_perf = max(1, min(max_exec_perf - 2, max(5, max_exec_perf // 3)))
-        executor_disk_perf = _calculate_executor_disk(s_out_gb, _eff_disk_spill, _eff_mem_spill, max_exec_perf)
+        executor_disk_perf = _calculate_executor_disk(
+            s_out_gb, _eff_disk_spill, max_exec_perf,
+            worker_vcpu=worker_cfg["vcpu"],
+            stages=stages_raw, fetch_wait_pct=shuffle_fetch_wait_pct,
+            mode="performance")
         
         # Build base metrics
         base_metrics = {
@@ -1112,7 +1272,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
             spill_ratio = spill_gb / shuffle_total_gb
             
             # Advisory: don't set — let EMR defaults handle (64MB + AQE coalesces as needed)
-            # Setting advisory explicitly risks spill (1GB advisory caused 158TB spill on sup-trvlr-bml)
+            # Setting advisory explicitly risks spill (1GB advisory caused 158TB spill on one replicated workload)
             # EMR's default AQE coalescing is safe and effective for all workload sizes
             
             # Partitions: if spill is significant relative to shuffle, compute from zero-spill formula.
@@ -1334,7 +1494,10 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
                          io_r["min_mem"] + (-(-(io_mem - io_r["min_mem"]) // io_r["mem_step"])) * io_r["mem_step"]))
             io_max = max_exec_cost * io_mult
             io_min = min_exec_cost * io_mult
-            io_disk = _calculate_executor_disk(s_out_gb, disk_spill_gb, spill_gb, io_max)
+            io_disk = _calculate_executor_disk(
+                s_out_gb, _eff_disk_spill, io_max,
+                worker_vcpu=io_r["vcpu"],
+                stages=stages_raw, fetch_wait_pct=shuffle_fetch_wait_pct)
             io_cfg = {"vcpu": io_r["vcpu"], "memory": io_mem}
             # Temporarily swap worker_cfg for build_spark_cfg
             saved_cfg, saved_type = worker_cfg, worker_type

--- a/utilities/EMR-Serverless-Config-Advisor/log_evidence.py
+++ b/utilities/EMR-Serverless-Config-Advisor/log_evidence.py
@@ -242,6 +242,43 @@ def _flush_excerpt(hit, buf, source, exec_id, filename):
     })
 
 
+def _format_hits(hits: dict) -> list:
+    """Signature hit dicts -> the public signatures list, ordered by the
+    SIGNATURES table (severity of what they explain), zero-count elided."""
+    signatures = []
+    for sig in SIGNATURES:
+        h = hits[sig["id"]]
+        if not h["count"]:
+            continue
+        signatures.append({
+            "id": sig["id"],
+            "title": sig["title"],
+            "meaning": sig["meaning"],
+            "refines": sig["refines"],
+            "count": h["count"],
+            "sources": {f"{src}{' ' + eid if eid else ''}": n
+                        for (src, eid), n in sorted(
+                            h["sources"].items(),
+                            key=lambda kv: -kv[1])[:10]},
+            "excerpts": h["excerpts"],
+        })
+    return signatures
+
+
+def scan_text(text: str, source: str = "driver", exec_id=None,
+              filename: str = "stderr") -> list:
+    """Scan one already-decoded log text against the signature table.
+
+    Same element shape as extract_log_evidence()["signatures"] — lets the
+    running-job health check reuse the curated table on a driver stderr
+    fetched straight from S3, without building a zip.
+    """
+    hits = {s["id"]: {"count": 0, "sources": {}, "excerpts": []}
+            for s in SIGNATURES}
+    _scan_stream(io.StringIO(text), source, exec_id, filename, hits)
+    return _format_hits(hits)
+
+
 def extract_log_evidence(zip_path) -> dict:
     """Scan a zip of driver/executor logs; return structured evidence.
 
@@ -269,26 +306,8 @@ def extract_log_evidence(zip_path) -> dict:
             except Exception:
                 files_skipped += 1
 
-    signatures = []
-    for sig in SIGNATURES:
-        h = hits[sig["id"]]
-        if not h["count"]:
-            continue
-        signatures.append({
-            "id": sig["id"],
-            "title": sig["title"],
-            "meaning": sig["meaning"],
-            "refines": sig["refines"],
-            "count": h["count"],
-            "sources": {f"{src}{' ' + eid if eid else ''}": n
-                        for (src, eid), n in sorted(
-                            h["sources"].items(),
-                            key=lambda kv: -kv[1])[:10]},
-            "excerpts": h["excerpts"],
-        })
-
     return {
-        "signatures": signatures,
+        "signatures": _format_hits(hits),
         "files_scanned": files_scanned,
         "files_skipped": max(files_skipped, 0),
         "sources": source_counts,

--- a/utilities/EMR-Serverless-Config-Advisor/static/advisor.css
+++ b/utilities/EMR-Serverless-Config-Advisor/static/advisor.css
@@ -17,6 +17,26 @@
 
 .app-id { font-family: monospace; font-size: 0.85rem; color: var(--ink-muted); }
 
+/* Source worker banner — the submitted worker shape, always visible */
+.source-worker-banner {
+    display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+    background: var(--card-bg); border: 1px solid var(--card-border);
+    border-left: 4px solid var(--blue); border-radius: var(--radius);
+    padding: 0.7rem 1rem; margin-bottom: 1rem;
+}
+.source-worker-banner.compact { border-left-width: 3px; padding: 0.4rem 0.6rem; margin: 8px 0 0; }
+.swb-caption { font-size: 0.78rem; color: var(--ink-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.swb-chip {
+    font-family: 'SF Mono', Menlo, monospace; font-size: 0.82rem; font-weight: 600;
+    color: var(--ink); background: #F7F8FA; border: 1px solid var(--card-border);
+    border-radius: 6px; padding: 3px 10px; white-space: nowrap;
+}
+.source-worker-banner.compact .swb-chip { font-size: 0.72rem; padding: 2px 7px; }
+.swb-chip.tier { color: #fff; background: var(--blue); border-color: var(--blue); }
+.swb-chip.disk { color: #6B5CA8; background: #F4F2FB; border-color: var(--purple); }
+.swb-chip.unknown { color: var(--ink-muted); font-weight: 400; font-style: italic; cursor: help; }
+.swb-chip.muted { color: var(--ink-muted); font-weight: 400; }
+
 .back-link { color: var(--blue); text-decoration: none; font-size: 0.9rem; display: inline-block; margin-bottom: 0.5rem; }
 .back-link:hover { text-decoration: underline; }
 

--- a/utilities/EMR-Serverless-Config-Advisor/static/console.css
+++ b/utilities/EMR-Serverless-Config-Advisor/static/console.css
@@ -316,6 +316,8 @@ body.console {
 .act-btn.troubleshoot:not(:disabled):hover { background: #FDF1EF; }
 .act-btn.upgrade:not(:disabled) { border-color: #FFAD4A; color: #FFAD4A; }
 .act-btn.upgrade:not(:disabled):hover { background: #FFF6EA; }
+.act-btn.health:not(:disabled) { border-color: #5CB85C; color: #5CB85C; }
+.act-btn.health:not(:disabled):hover { background: #EFF8EF; }
 
 /* ===== Ask AI chat widget ===== */
 #aiFab {

--- a/utilities/EMR-Serverless-Config-Advisor/templates/compare_results.html
+++ b/utilities/EMR-Serverless-Config-Advisor/templates/compare_results.html
@@ -48,10 +48,26 @@
 {% endif %}
 {% endif %}
 
+{% macro worker_chips(w) %}
+  {% if w %}
+  <div class="source-worker-banner compact">
+    {% if w.cores %}<span class="swb-chip tier">{{ w.cores }} vCPU{% if w.tier %} · {{ w.tier }}{% endif %}</span>{% endif %}
+    {% if w.heap %}<span class="swb-chip">{{ w.heap }} heap{% if w.billed_memory_gb %} → {{ w.billed_memory_gb }} GB{% endif %}</span>{% endif %}
+    {% if w.platform == 'emr-serverless' %}
+      {% if w.disk %}<span class="swb-chip disk">{{ w.disk }}{% if w.disk_type %} · {{ w.disk_type }}{% endif %}</span>
+      {% else %}<span class="swb-chip unknown" title="submit-only parameter — absence from the event log does NOT mean it wasn't set">disk not captured</span>{% endif %}
+    {% endif %}
+    {% if w.max_executors %}<span class="swb-chip">{% if w.dynamic_allocation %}{{ w.min_executors or '?' }}–{{ w.max_executors }} exec{% else %}{{ w.max_executors }} exec{% endif %}</span>{% endif %}
+    {% if w.platform == 'emr-ec2' %}<span class="swb-chip muted">EC2</span>{% endif %}
+  </div>
+  {% endif %}
+{% endmacro %}
+
 <div class="run-head">
   <div class="run-card a">
     <span class="tag">RUN A</span>
     <div class="fname">{{ a.source_filename }}</div>
+    {{ worker_chips(a.source_worker) }}
     <div style="margin-top:8px">
       <span class="bottleneck-badge {{ a.bottleneck.primary|lower|replace(' ', '-') }}">{{ a.bottleneck.primary }}</span>
       <span class="bottleneck-score">{{ a.bottleneck.primary_score }}/100</span>
@@ -60,12 +76,24 @@
   <div class="run-card b">
     <span class="tag">RUN B</span>
     <div class="fname">{{ b.source_filename }}</div>
+    {{ worker_chips(b.source_worker) }}
     <div style="margin-top:8px">
       <span class="bottleneck-badge {{ b.bottleneck.primary|lower|replace(' ', '-') }}">{{ b.bottleneck.primary }}</span>
       <span class="bottleneck-score">{{ b.bottleneck.primary_score }}/100</span>
     </div>
   </div>
 </div>
+
+{% set wa, wb = a.source_worker, b.source_worker %}
+{% if wa and wb and (wa.cores != wb.cores or wa.heap != wb.heap or wa.disk != wb.disk or wa.max_executors != wb.max_executors) %}
+<div class="flash" style="background:#FFF6EA;border:1px solid #FFAD4A;color:#8A5A1F;">
+  <b>Different worker shapes</b> — metric deltas below mix workload changes with sizing changes:
+  {% if wa.cores != wb.cores %} vCPU {{ wa.cores }} → {{ wb.cores }};{% endif %}
+  {% if wa.heap != wb.heap %} heap {{ wa.heap }} → {{ wb.heap }};{% endif %}
+  {% if wa.disk != wb.disk %} disk {{ wa.disk or 'not captured' }} → {{ wb.disk or 'not captured' }};{% endif %}
+  {% if wa.max_executors != wb.max_executors %} max executors {{ wa.max_executors }} → {{ wb.max_executors }}{% endif %}
+</div>
+{% endif %}
 
 {% if a.run_cost and b.run_cost and (a.run_cost.source != 'billed' or b.run_cost.source != 'billed') %}
 <div class="flash" style="background:#FFF6EA;border:1px solid #FFAD4A;color:#8A5A1F;">

--- a/utilities/EMR-Serverless-Config-Advisor/templates/landing.html
+++ b/utilities/EMR-Serverless-Config-Advisor/templates/landing.html
@@ -76,6 +76,7 @@ fetch("/api/metrics/apps?hours=48").then(r => r.json()).then(j => {
 
 // ===== Applications & job runs table with Optimize / Troubleshoot / Upgrade =====
 const FAILED_STATES = ["FAILED", "CANCELLED", "CANCELLING"];
+const RUNNING_STATES = ["RUNNING", "SCHEDULED", "PENDING", "SUBMITTED"];
 
 // Home page context for the Ask-AI panel (set when an action button is clicked)
 let aiCtx = { page: "home" };
@@ -131,6 +132,7 @@ function renderOverview(data) {
             const tb = document.createElement("tbody");
             app.jobs.forEach(job => {
                 const failed = FAILED_STATES.includes(job.state);
+                const running = RUNNING_STATES.includes(job.state);
                 const tr = document.createElement("tr");
                 tr.innerHTML = `
                     <td class="job-name">${job.name}${job.hasMetrics ? ` <a class="mlink" href="/metrics-dashboard?app_id=${job.id}" title="open in Observability">📈</a>` : ""}</td>
@@ -139,13 +141,18 @@ function renderOverview(data) {
                     <td class="mono">${job.createdAt.slice(0, 16).replace("T", " ")}</td>
                     <td class="td-actions">
                         <button class="act-btn optimize">Optimize</button>
-                        <button class="act-btn troubleshoot" ${failed ? "" : "disabled"}
-                            title="${failed ? "Diagnose this failed run" : "Enabled for failed/cancelled runs"}">Troubleshoot</button>
+                        ${running ? `<button class="act-btn health"
+                            title="${job.hasMetrics ? "Full health check: stall detection, driver log scan, duration vs history" : "Health check (no live metrics for this run — state, driver log, and duration history only)"}">Check health</button>`
+                        : `<button class="act-btn troubleshoot" ${failed ? "" : "disabled"}
+                            title="${failed ? "Diagnose this failed run" : "Enabled for failed/cancelled runs"}">Troubleshoot</button>`}
                     </td>`;
                 tr.querySelector(".optimize").addEventListener("click", () =>
                     askAgent(`Optimize job run ${job.id} (${job.name}). Run run_config_advisor on it${job.hasMetrics ? " and cross-check with get_metrics_snapshot" : ""}, then give me the recommended worker sizing and Spark configs with the reasoning, cost vs performance.`,
                              { application_id: app.id, job_run_id: job.id }));
-                tr.querySelector(".troubleshoot").addEventListener("click", () =>
+                if (running) tr.querySelector(".health").addEventListener("click", () =>
+                    askAgent(`Check the health of job run ${job.id} (${job.name}), currently ${job.state}. Use check_job_health, give me the verdict with the evidence behind each check, and if anything is degraded or unhealthy say what to do about it.`,
+                             { application_id: app.id, job_run_id: job.id }));
+                else tr.querySelector(".troubleshoot").addEventListener("click", () =>
                     askAgent(`Troubleshoot job run ${job.id} (${job.name}) which is ${job.state}. Use troubleshoot_job, identify the root cause from the state details and driver stderr, and give the fix.`,
                              { application_id: app.id, job_run_id: job.id }));
                 tb.appendChild(tr);

--- a/utilities/EMR-Serverless-Config-Advisor/templates/results.html
+++ b/utilities/EMR-Serverless-Config-Advisor/templates/results.html
@@ -12,6 +12,34 @@
 <h1 class="page-title">Analysis Results</h1>
 <p class="page-subtitle">{{ result.application_name }} <span class="app-id">({{ result.application_id }})</span></p>
 
+{% if result.source_worker %}{% set w = result.source_worker %}
+<div class="source-worker-banner">
+    <span class="swb-caption">This run used</span>
+    {% if w.cores %}
+    <span class="swb-chip tier">{{ w.cores }} vCPU{% if w.tier %} · {{ w.tier }}{% endif %}</span>
+    {% endif %}
+    {% if w.heap %}
+    <span class="swb-chip">{{ w.heap }} heap{% if w.billed_memory_gb %} → {{ w.billed_memory_gb }} GB worker{% endif %}</span>
+    {% endif %}
+    {% if w.platform == 'emr-serverless' %}
+        {% if w.disk %}
+        <span class="swb-chip disk">{{ w.disk }} disk{% if w.disk_type %} · {{ w.disk_type }}{% endif %}</span>
+        {% else %}
+        <span class="swb-chip unknown" title="spark.emr-serverless.executor.disk is a submit-only parameter — absence from the event log does NOT mean it wasn't set. Check the submitted job parameters.">disk not captured in event log</span>
+        {% endif %}
+    {% endif %}
+    {% if w.max_executors %}
+    <span class="swb-chip">{% if w.dynamic_allocation %}{{ w.min_executors or '?' }}–{{ w.max_executors }} executors (dynamic){% else %}{{ w.max_executors }} executors{% endif %}</span>
+    {% endif %}
+    {% if w.driver_cores or w.driver_memory %}
+    <span class="swb-chip muted">driver {{ w.driver_cores }}c / {{ w.driver_memory }}{% if w.driver_disk %} / {{ w.driver_disk }} disk{% endif %}</span>
+    {% endif %}
+    {% if w.platform == 'emr-ec2' %}
+    <span class="swb-chip muted">EMR on EC2 source</span>
+    {% endif %}
+</div>
+{% endif %}
+
 {% if result.source_platform == 'emr-ec2' %}
 <div class="flash" style="background:#EDF6FC;border:1px solid #4DA3D4;color:#2F6E96;">
   <b>EMR on EC2 source detected</b> — recommendations below are the
@@ -190,6 +218,8 @@
                         <tr><td>Min Executors</td><td>{{ result.cost_recommendation.worker.min_executors }}</td></tr>
                         <tr><td>Total vCPU</td><td>{{ result.cost_recommendation.worker.total_vcpu_capacity }}</td></tr>
                         <tr><td>Total Memory</td><td>{{ result.cost_recommendation.worker.total_memory_capacity }} GB</td></tr>
+                        {% set cd = result.cost_recommendation.spark_configs or {} %}
+                        <tr><td>Disk</td><td>{{ cd.get('spark.emr-serverless.executor.disk', '20G (default)') }}{% if cd.get('spark.emr-serverless.executor.disk.type') %} · {{ cd.get('spark.emr-serverless.executor.disk.type') }}{% endif %}</td></tr>
                         {% if result.cost_recommendation.shuffle_tuned %}
                         <tr><td>Partitions</td><td>{{ result.cost_recommendation.shuffle_tuned.partitions }}</td></tr>
                         {% endif %}
@@ -212,6 +242,8 @@
                         <tr><td>Min Executors</td><td>{{ result.perf_recommendation.worker.min_executors }}</td></tr>
                         <tr><td>Total vCPU</td><td>{{ result.perf_recommendation.worker.total_vcpu_capacity }}</td></tr>
                         <tr><td>Total Memory</td><td>{{ result.perf_recommendation.worker.total_memory_capacity }} GB</td></tr>
+                        {% set pd = result.perf_recommendation.spark_configs or {} %}
+                        <tr><td>Disk</td><td>{{ pd.get('spark.emr-serverless.executor.disk', '20G (default)') }}{% if pd.get('spark.emr-serverless.executor.disk.type') %} · {{ pd.get('spark.emr-serverless.executor.disk.type') }}{% endif %}</td></tr>
                         {% if result.perf_recommendation.shuffle_tuned %}
                         <tr><td>Partitions</td><td>{{ result.perf_recommendation.shuffle_tuned.partitions }}</td></tr>
                         {% endif %}

--- a/utilities/EMR-Serverless-Config-Advisor/tests/golden_baseline.json
+++ b/utilities/EMR-Serverless-Config-Advisor/tests/golden_baseline.json
@@ -83,6 +83,24 @@
     "field_reports/windowsort_fetchfail_00g72m8n01eb1g0b: NEW app not in golden baseline"
    ],
    "reason": "Field fixes: (1) worker section now syncs with dynamicAllocation confs when build_spark_cfg raises them (the 11 remaining diffs are exactly this pre-existing inconsistency resolving); (2) spill-aware partition boost for stages that spilled AND failed (fetch-fail retry loops) \u2014 field-validated 4016~=4000 proven fix on 8.5T-spill window sort, harm-gated so steady-state spilling jobs (search-health class) keep proven 1000-part configs; (3) collect-heavy driver sizing from Task Metrics Result Size (2.64G collected -> 8c/54G driver, matching Parth's validated $0.44 run) + never below proven source driver; (4) stage-attempt dedupe (extractor emitted one row per retry attempt each carrying full aggregate \u2014 4x-retried stage summed 4x spill). New field_reports fixture set pins both: windowsort_fetchfail_00g72m8n01eb1g0b (Geethanjali, parts 4016 + 8c/54G driver) and collect_heavy_omp_00g6tp1n6gqmio0b (Parth OMP, 8c/54G driver, Small workers)"
+  },
+  {
+   "changed_lines": 12,
+   "changes": [
+    "b12/eventlog_v2_00g5r691f5lfu80b [cost] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'",
+    "b12/eventlog_v2_00g5r691f5lfu80b [performance] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'",
+    "ec2_migration/application_1780907816475_0003 [cost] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'",
+    "ec2_migration/application_1780907816475_0003 [performance] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'",
+    "ec2_migration/eventlog_v2_00g6a2fp048ffg0b [cost] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'",
+    "ec2_migration/eventlog_v2_00g6a2fp048ffg0b [performance] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'",
+    "ec2_migration/eventlog_v2_00g6asko6orfro0b [cost] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'",
+    "ec2_migration/eventlog_v2_00g6asko6orfro0b [performance] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'",
+    "ec2_migration/eventlog_v2_00g6avf7opopio0b [cost] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'",
+    "ec2_migration/eventlog_v2_00g6avf7opopio0b [performance] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'",
+    "ec2_migration/eventlog_v2_00g6bunn7pe8do0b [cost] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'",
+    "ec2_migration/eventlog_v2_00g6bunn7pe8do0b [performance] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'"
+   ],
+   "reason": "tier-aware disk sizing: A/B-validated 2026-07-25 on replicated production workloads \u2014 16c 2000G->1000G won on both test jobs (-13.3% wall/-18% cost and -8.6%/-13.9%); 8c IOPS floor + FetchFailed IOPS-ladder escalation keep serving-bound fleets on 1000G+"
   }
  ],
  "snapshot": {
@@ -143,7 +161,7 @@
     "cost": {
      "spark_configs.spark.dynamicAllocation.maxExecutors": "24",
      "spark_configs.spark.dynamicAllocation.minExecutors": "8",
-     "spark_configs.spark.emr-serverless.executor.disk": "2000G",
+     "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
      "spark_configs.spark.sql.optimizer.excludedRules": "org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit",
      "spark_configs.spark.sql.shuffle.partitions": "1574",
@@ -156,7 +174,7 @@
     "performance": {
      "spark_configs.spark.dynamicAllocation.maxExecutors": "24",
      "spark_configs.spark.dynamicAllocation.minExecutors": "8",
-     "spark_configs.spark.emr-serverless.executor.disk": "2000G",
+     "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
      "spark_configs.spark.sql.optimizer.excludedRules": "org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit",
      "spark_configs.spark.sql.shuffle.partitions": "1574",
@@ -437,7 +455,7 @@
     "cost": {
      "spark_configs.spark.dynamicAllocation.maxExecutors": "76",
      "spark_configs.spark.dynamicAllocation.minExecutors": "25",
-     "spark_configs.spark.emr-serverless.executor.disk": "2000G",
+     "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
      "spark_configs.spark.sql.optimizer.excludedRules": "org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit",
      "spark_configs.spark.sql.shuffle.partitions": "1000",
@@ -450,7 +468,7 @@
     "performance": {
      "spark_configs.spark.dynamicAllocation.maxExecutors": "306",
      "spark_configs.spark.dynamicAllocation.minExecutors": "102",
-     "spark_configs.spark.emr-serverless.executor.disk": "2000G",
+     "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
      "spark_configs.spark.sql.optimizer.excludedRules": "org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit",
      "spark_configs.spark.sql.shuffle.partitions": "1000",
@@ -465,7 +483,7 @@
     "cost": {
      "spark_configs.spark.dynamicAllocation.maxExecutors": "43",
      "spark_configs.spark.dynamicAllocation.minExecutors": "14",
-     "spark_configs.spark.emr-serverless.executor.disk": "2000G",
+     "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
      "spark_configs.spark.sql.shuffle.partitions": "1478",
      "worker.max_executors": 43,
@@ -477,7 +495,7 @@
     "performance": {
      "spark_configs.spark.dynamicAllocation.maxExecutors": "43",
      "spark_configs.spark.dynamicAllocation.minExecutors": "14",
-     "spark_configs.spark.emr-serverless.executor.disk": "2000G",
+     "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
      "spark_configs.spark.sql.shuffle.partitions": "1478",
      "worker.max_executors": 43,
@@ -491,7 +509,7 @@
     "cost": {
      "spark_configs.spark.dynamicAllocation.maxExecutors": "46",
      "spark_configs.spark.dynamicAllocation.minExecutors": "15",
-     "spark_configs.spark.emr-serverless.executor.disk": "2000G",
+     "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
      "spark_configs.spark.sql.shuffle.partitions": "1340",
      "worker.max_executors": 46,
@@ -503,7 +521,7 @@
     "performance": {
      "spark_configs.spark.dynamicAllocation.maxExecutors": "66",
      "spark_configs.spark.dynamicAllocation.minExecutors": "22",
-     "spark_configs.spark.emr-serverless.executor.disk": "2000G",
+     "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
      "spark_configs.spark.sql.shuffle.partitions": "1340",
      "worker.max_executors": 66,
@@ -517,7 +535,7 @@
     "cost": {
      "spark_configs.spark.dynamicAllocation.maxExecutors": "552",
      "spark_configs.spark.dynamicAllocation.minExecutors": "184",
-     "spark_configs.spark.emr-serverless.executor.disk": "2000G",
+     "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
      "spark_configs.spark.sql.optimizer.excludedRules": "org.apache.spark.sql.catalyst.optimizer.InferWindowGroupLimit",
      "spark_configs.spark.sql.shuffle.partitions": "4100",
@@ -530,7 +548,7 @@
     "performance": {
      "spark_configs.spark.dynamicAllocation.maxExecutors": "552",
      "spark_configs.spark.dynamicAllocation.minExecutors": "276",
-     "spark_configs.spark.emr-serverless.executor.disk": "2000G",
+     "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
      "spark_configs.spark.sql.shuffle.partitions": "4100",
      "worker.max_executors": 552,
@@ -544,7 +562,7 @@
     "cost": {
      "spark_configs.spark.dynamicAllocation.maxExecutors": "330",
      "spark_configs.spark.dynamicAllocation.minExecutors": "110",
-     "spark_configs.spark.emr-serverless.executor.disk": "2000G",
+     "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
      "spark_configs.spark.sql.shuffle.partitions": "5622",
      "worker.max_executors": 330,
@@ -556,7 +574,7 @@
     "performance": {
      "spark_configs.spark.dynamicAllocation.maxExecutors": "495",
      "spark_configs.spark.dynamicAllocation.minExecutors": "165",
-     "spark_configs.spark.emr-serverless.executor.disk": "2000G",
+     "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
      "spark_configs.spark.sql.shuffle.partitions": "5622",
      "worker.max_executors": 495,

--- a/utilities/EMR-Serverless-Config-Advisor/tests/test_log_evidence.py
+++ b/utilities/EMR-Serverless-Config-Advisor/tests/test_log_evidence.py
@@ -17,7 +17,7 @@ import zipfile
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from log_evidence import (SIGNATURES, corroboration_notes,
-                          extract_log_evidence)
+                          extract_log_evidence, scan_text)
 
 FAILURES = []
 
@@ -137,6 +137,23 @@ def test_corroboration():
           all("corroborates" in n for n in mem + iops))
 
 
+def test_scan_text():
+    print("scan_text: zip-free path used by check_job_health")
+    text = (CANONICAL["heap_oom"]
+            + "\n\tat org.apache.spark.Foo.bar(Foo.java:1)\n"
+            + CANONICAL["disk_full"] + "\n" + CANONICAL["disk_full"] + "\n")
+    sigs = scan_text(text)
+    ids = {s["id"]: s for s in sigs}
+    check("heap_oom found", "heap_oom" in ids)
+    check("disk_full counted twice", ids.get("disk_full", {}).get("count") == 2)
+    check("source tagged driver",
+          ids["heap_oom"]["sources"].get("driver") == 1)
+    check("excerpt keeps stack head",
+          "Foo.java:1" in ids["heap_oom"]["excerpts"][0]["text"])
+    check("clean text yields no signatures",
+          scan_text("26/07/24 INFO SparkContext: Running Spark 3.5.6\n") == [])
+
+
 def test_empty_and_clean():
     print("edge cases: no log files / clean logs")
     zp = make_zip({"random.json": "{}"})
@@ -155,6 +172,7 @@ if __name__ == "__main__":
     test_signature_table()
     test_layouts_and_scan()
     test_corroboration()
+    test_scan_text()
     test_empty_and_clean()
     print()
     if FAILURES:


### PR DESCRIPTION
## What

Three changes to the EMR Serverless Config Advisor, validated by A/B runs on replicated production-shaped workloads:

### 1. Worker-shape-aware disk sizing (`emr_s_fine_tuner.py`)

Replaces the fleet-total-volume disk rule (`>2000G shuffle -> 2000G disk`) with sizing from the EMR Serverless `shuffle_optimized` throughput tier table (throughput by worker vCPU × disk size, verified empirically per shape):

- **Capacity**: per-executor share of shuffle write + disk spill (×1.5) — never fleet totals. Memory-spill bytes are the same data as disk-spill bytes pre-compression, so only disk spill counts.
- **Serving**: peak sustained per-host disk IO must fit the tier's throughput with ×1.5 headroom, computed from stage arithmetic.
- **IOPS floor**: 8-vCPU workers serve the same 250 MiB/s at every size ≥170G, but IOPS still scale with size (~3K@200G → ~16K@2000G) and fan-in serving is IOPS-bound. When serving demand exceeds the base tier on a flat-throughput shape, floor at 1000G (2000G once demand crosses half the shape's ceiling).
- **Evidence escalation**: FetchFailed / fetch-wait >10% climbs one tier boundary; on flat-throughput shapes it climbs the IOPS ladder instead (no higher throughput boundary exists).
- **Perf mode** floors at the shape's max-throughput tier.

Also removes the idle-trim on healthy Serverless sources: an A/B on its founding workload (maxExecutors 17 vs 15, same config) showed cap-trimming a healthy DRA fleet doesn't reclaim within-executor core idle — repeat runs flipped the cost sign (both within DRA noise). Rule 3 continues to own genuine over-provisioning (eff < 0.40).

### 2. `log_evidence.scan_text()` (refactor)

Extracts signature-hit formatting into `_format_hits` and adds `scan_text()` to run the curated signature table over a single decoded log text (no zip needed). Output shape identical to `extract_log_evidence()['signatures']`.

### 3. Running-job health check (Web UI)

`check_job_health`: correlated verdict for a RUNNING job — state + duration vs the job name's own success history, resource trajectory, and driver-stderr signature scan with fatal signatures (heap OOM, GC overhead, container RSS kill) separated from churn. Home page gets a Health action; results/compare views get worker-shape banners.

## Validation

A/B pairs on replicated production-shaped workloads (EMR Serverless, ARM64, one knob per pair — full config otherwise identical):

| workload | shape | arms | wall | cost |
|---|---|---|---|---|
| ETL job A (shuffle-heavy joins) | 16c ×46 | 2000G vs 1000G | **−13.3%** | **−18.0%** |
| ETL job B (window aggregation, steady spill) | 16c ×32 | 2000G vs 1000G | **−8.6%** | **−13.9%** |
| ETL job C (high fan-in shuffle) | 8c ×92 | 2000G vs 200G | +17.5% (200G regressed) | −5.0% |

The job-C regression is what motivated the IOPS floor: at 200G the 8c fleet's shuffle write inflated 3365→3979 GB (re-fetch amplification). A disk sweep on the same job was monotonic — wall-clock and cost both improved at every step up from 500G to 2000G — so the rule now keeps serving-bound 8c fleets at 1000G+ (job C lands back on 2000G).

- Unit tests: 5/5 pass
- Golden gate: regenerated with `--update-golden --reason` — 12 diffs, all A/B-validated 16c 2000G→1000G downsizes; `PASS: 22 apps, 4 fixture sets`