### PR TITLE
[emr-test-drive] Multi-scale comparison and correct Lake Formation filter enforcement testing

### DIFF
--- a/utilities/emr-test-drive/.gitignore
+++ b/utilities/emr-test-drive/.gitignore
@@ -13,3 +13,6 @@ share/
 *.html
 !docs/**/*.html
 .DS_Store
+
+# Real-account configs: contain account IDs, bucket names and role ARNs.
+configs-local/

--- a/utilities/emr-test-drive/CHANGELOG.md
+++ b/utilities/emr-test-drive/CHANGELOG.md
@@ -21,15 +21,20 @@ All notable changes to this project are documented here, following
   variants, and the harness asserts they were enforced. Disclosure beyond what a
   filter permits is a critical `FILTER_NOT_ENFORCED` correctness finding, which
   blocks the verdict.
+- Filter checks run once per variant as their own job under a least-privilege
+  reader role, not once per table format under the job role.
 - Filter operations run only for FGAC variants. Under plain Glue or full table
   access every row is legitimately visible, so asserting otherwise would
   manufacture a finding rather than detect one.
 
 ### Known limitations
-- **The data filter path is implemented but not yet validated against a live AWS
-  account.** Everything else in this release was validated on EMR Serverless
-  across two accounts. Offline coverage exercises the comparison and reporting
-  path only.
+- The data filter path has been exercised against a live account, which is how
+  two defects in it were found: the check ran as a Lake Formation administrator
+  (who bypasses filters, so a full-table read was reported as a disclosure), and
+  it was dispatched per table format although the filters are defined on one
+  table, so the identical query ran three times under three misleading labels.
+  Both are fixed. Enforcement itself has still not been observed succeeding
+  against a live account.
 - Nested (struct) filters are not implemented; the test bed has no nested column.
 - EMR on EC2 and EMR on EKS providers are not implemented.
 - Each run is independent; there is no cross-run trend view.

--- a/utilities/emr-test-drive/Makefile
+++ b/utilities/emr-test-drive/Makefile
@@ -28,6 +28,7 @@ configs:          ## every shipped config must parse
 
 security:         ## security regression tests (needs `make example` first)
 	python3 tests/test_security.py
+	python3 tests/test_ops_sync.py
 
 clean:            ## remove generated artifacts
 	rm -rf examples/offline/out runs share

--- a/utilities/emr-test-drive/README.md
+++ b/utilities/emr-test-drive/README.md
@@ -108,9 +108,15 @@ subclass, see [docs/design.md](docs/design.md).
 Lake Formation FGAC creates row, column and cell data filters and **asserts they
 were enforced**: a granted filter that returns more than it permits is reported
 as a critical correctness finding, because the job succeeds and the data is wrong
-in the direction of disclosure. This code path has not yet been validated against
-a live account — see [CHANGELOG.md](CHANGELOG.md). Nested (struct) filters are
-not implemented: the test bed has no nested column.
+in the direction of disclosure.
+
+The check runs as a **dedicated reader role** holding only the data cell filter
+grant, never as the job role. A Lake Formation administrator bypasses data cell
+filters and a table-wide `SELECT` grant supersedes them, so a read by the usual
+job role returns the whole table and proves nothing. If no such reader exists the
+finding is reported as informational and says enforcement was not tested, rather
+than claiming a disclosure. Nested (struct) filters are not implemented: the test
+bed has no nested column.
 
 ## Contributing
 

--- a/utilities/emr-test-drive/etd/assets/etd_job.py
+++ b/utilities/emr-test-drive/etd/assets/etd_job.py
@@ -179,6 +179,33 @@ def do_setup(spark, cfg: dict) -> dict:
     counts = {}
     for t in ("fact", "dim"):
         counts[t] = row_count(spark, f"{db}.{t}")
+
+    # External datasets. Registering a real dataset (TPC-DS, TPC-H, your own)
+    # lets the performance workload run representative queries instead of the
+    # synthetic test bed. The data must already sit under this run's data prefix:
+    # Lake Formation vends credentials only for locations it has registered, so a
+    # table pointing outside that prefix works under plain Glue and fails under
+    # FTA and FGAC -- which would look like a governance regression rather than a
+    # configuration mistake.
+    for name, location in sorted((cfg.get("external_tables") or {}).items()):
+        def reg(name=name, location=location):
+            spark.sql(f"DROP TABLE IF EXISTS {db}.{name}")
+            # Schema is inferred from the Parquet footer, so no DDL to maintain.
+            spark.sql(f"CREATE TABLE {db}.{name} USING parquet LOCATION '{location}'")
+            # A hive-partitioned layout (key=value directories) registers with no
+            # partitions in the catalog, and every query then scans nothing and
+            # returns zero rows -- which looks like empty data rather than a
+            # missing recovery step. RECOVER PARTITIONS is a no-op on an
+            # unpartitioned table, so it is unconditional.
+            try:
+                spark.sql(f"ALTER TABLE {db}.{name} RECOVER PARTITIONS")
+            except Exception as exc:  # noqa: BLE001
+                msg = str(exc)
+                if "not partitioned" not in msg and "PARTITION" not in msg.upper():
+                    raise
+        step(f"register_external:{name}", reg)
+        counts[name] = row_count(spark, f"{db}.{name}")
+
     return {"mode": "setup", "database": db, "steps": steps, "row_counts": counts,
             "spark_version": spark.version}
 
@@ -209,8 +236,6 @@ def do_functional(spark, cfg: dict) -> dict:
             pass
     leftover = purge_prefix(loc) + purge_prefix(
         f"{cfg['data_uri']}/{db}/etd_{fmt}_ctas_{suffix}/")
-
-    filter_evidence: dict = {}
 
     def sql(q):
         return lambda: spark.sql(q)
@@ -253,11 +278,6 @@ def do_functional(spark, cfg: dict) -> dict:
                 rec["orphaned_bytes"] = max(0, after.get("bytes", 0) - s3_before.get("bytes", 0))
         if expect_rows is not None and rec.get("row_count") is not None:
             rec["expected_row_count"] = expect_rows
-        # Recorded even when the assertion raised: the numbers are what make a
-        # non-enforcement finding actionable.
-        ev = filter_evidence.get(op.split("_")[0].lower())
-        if ev:
-            rec.update(ev)
         units.append(rec)
         print(f"[etd] {fmt}.{op} {rec['status']} {rec['duration_s']}s rows={rec.get('row_count')}")
 
@@ -286,65 +306,6 @@ def do_functional(spark, cfg: dict) -> dict:
                 sel.append(f"cast(null as string) as `{name}`")
         base.selectExpr(*sel).writeTo(tbl).append()
 
-    def filtered_read(kind: str, expect_expr: str, expect_cols):
-        """Read the fact table and assert Lake Formation applied the filter.
-
-        The assertion is the point, not the query. A granted data cell filter
-        that returns unfiltered rows or unfiltered columns is a governance
-        failure: the job succeeds, and the data is wrong in the direction of
-        disclosure. Granting whole-table SELECT exercises the FGAC code path but
-        proves nothing about enforcement, which is what this checks.
-
-        Expectations are computed from the table itself rather than hardcoded, so
-        they cannot drift from the test bed. Filters apply to the base fact
-        table, which no workload operation mutates, so the expected shape is
-        stable across variants.
-        """
-        def go():
-            base = f"{db}.fact"
-            visible = spark.table(base)
-            cols = sorted(f.name for f in visible.schema.fields)
-            rows = visible.count()
-
-            if expect_expr == FILTER_ALL_ROWS:
-                permitted = rows
-                row_enforced = None
-            else:
-                permitted = spark.sql(
-                    f"SELECT count(*) AS c FROM {base} WHERE {expect_expr}"
-                ).collect()[0]["c"]
-                row_enforced = rows == permitted
-
-            want_cols = sorted(expect_cols) if expect_cols else None
-            col_enforced = (cols == want_cols) if want_cols else None
-
-            # Disclosure beyond what the filter permits is the finding worth
-            # naming. Fewer rows than permitted is over-restriction: wrong, but
-            # not a disclosure, so it is recorded without raising.
-            over = bool(
-                (expect_expr != FILTER_ALL_ROWS and rows > permitted)
-                or (want_cols and not set(cols).issubset(set(want_cols)))
-            )
-
-            filter_evidence[kind] = {
-                "filter_kind": kind,
-                "rows_visible": rows,
-                "rows_permitted": permitted,
-                "columns_visible": cols,
-                "columns_permitted": want_cols,
-                "row_filter_enforced": row_enforced,
-                "column_filter_enforced": col_enforced,
-                "filter_over_disclosure": over,
-            }
-
-            if over:
-                raise AssertionError(
-                    f"data filter '{kind}' not enforced: {rows} rows visible, "
-                    f"{permitted} permitted; columns visible {cols}, "
-                    f"permitted {want_cols if want_cols else 'all'}"
-                )
-        return go
-
     handlers = {
         "CREATE_TABLE": lambda: run("CREATE_TABLE", sql(
             f"CREATE TABLE {tbl} (fact_id BIGINT, dim_id BIGINT, category STRING, amount DOUBLE) "
@@ -370,15 +331,6 @@ def do_functional(spark, cfg: dict) -> dict:
             f"VALUES (s.fact_id, s.dim_id, s.category, s.amount)")),
         "DF_WRITER_V2": lambda: run("DF_WRITER_V2", df_writer_v2),
         "DROP_TABLE": lambda: run("DROP_TABLE", sql(f"DROP TABLE {tbl}")),
-        # Lake Formation data cell filters. Only meaningful under FGAC: with plain
-        # Glue or full table access there is no filter to enforce, so the
-        # expected-support matrix marks these unsupported for those modes.
-        "ROW_FILTER": lambda: run(
-            "ROW_FILTER", filtered_read("row", FILTER_ROW_EXPR, None)),
-        "COLUMN_FILTER": lambda: run(
-            "COLUMN_FILTER", filtered_read("column", FILTER_ALL_ROWS, FILTER_COLUMN_COLS)),
-        "CELL_FILTER": lambda: run(
-            "CELL_FILTER", filtered_read("cell", FILTER_ROW_EXPR, FILTER_CELL_COLS)),
     }
 
     for op in ops:
@@ -467,9 +419,78 @@ def do_perf(spark, cfg: dict) -> dict:
 
 # ------------------------------------------------------------------------ main
 
+# ---------------------------------------------------------------- filter checks
+
+def do_filters(spark, cfg: dict) -> dict:
+    """Assert Lake Formation data cell filters were enforced.
+
+    Runs once per variant, not once per table format. The filters are defined on
+    the fact table, so dispatching this per format ran the identical query three
+    times and labelled the results parquet./iceberg./delta., implying a
+    format-specific test that does not exist.
+
+    This mode is submitted under a dedicated reader role rather than the job role.
+    A Lake Formation administrator bypasses data cell filters, and a table-wide
+    SELECT grant supersedes them, so a read by the job role proves nothing.
+    """
+    db = cfg["database"]
+    units = []
+
+    for kind, expr, cols in (
+        ("row", FILTER_ROW_EXPR, None),
+        ("column", FILTER_ALL_ROWS, FILTER_COLUMN_COLS),
+        ("cell", FILTER_ROW_EXPR, FILTER_CELL_COLS),
+    ):
+        op = f"{kind.upper()}_FILTER"
+        rec = {"name": op, "table_format": "n/a", "table_type": "managed",
+               "status": "SUCCESS", "error": None, "duration_s": None}
+        t0 = time.time()
+        try:
+            base = f"{db}.fact"
+            visible = spark.table(base)
+            vis_cols = sorted(f.name for f in visible.schema.fields)
+            rows = visible.count()
+            if expr == FILTER_ALL_ROWS:
+                permitted, row_enforced = rows, None
+            else:
+                permitted = spark.sql(
+                    f"SELECT count(*) AS c FROM {base} WHERE {expr}").collect()[0]["c"]
+                row_enforced = rows == permitted
+            want = sorted(cols) if cols else None
+            over = bool((expr != FILTER_ALL_ROWS and rows > permitted)
+                        or (want and not set(vis_cols).issubset(set(want))))
+            rec.update({
+                "filter_kind": kind,
+                "rows_visible": rows,
+                "rows_permitted": permitted,
+                "columns_visible": vis_cols,
+                "columns_permitted": want,
+                "row_filter_enforced": row_enforced,
+                "column_filter_enforced": (vis_cols == want) if want else None,
+                "filter_over_disclosure": over,
+            })
+            if over:
+                rec["status"] = "FAILED"
+                rec["error"] = (f"data filter '{kind}' not enforced: {rows} rows visible, "
+                                f"{permitted} permitted; columns {vis_cols}, "
+                                f"permitted {want if want else 'all'}")
+        except Exception as exc:  # noqa: BLE001
+            # A read that fails outright is a different finding from one that
+            # returns too much, and is recorded as such rather than as disclosure.
+            rec["status"] = "FAILED"
+            rec["error"] = f"{type(exc).__name__}: {exc}"[:2000]
+        rec["duration_s"] = round(time.time() - t0, 2)
+        units.append(rec)
+        print(f"[etd] filter.{kind} {rec['status']} "
+              f"rows={rec.get('rows_visible')}/{rec.get('rows_permitted')}")
+
+    return {"mode": "filters", "database": db, "units": units,
+            "spark_version": spark.version}
+
+
 def main() -> None:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--mode", required=True, choices=["setup", "functional", "perf"])
+    ap.add_argument("--mode", required=True, choices=["setup", "functional", "perf", "filters"])
     ap.add_argument("--config", required=True, help="JSON blob")
     ap.add_argument("--output", required=True, help="s3:// URI for the result document")
     args = ap.parse_args()
@@ -482,6 +503,8 @@ def main() -> None:
     try:
         if args.mode == "setup":
             payload = do_setup(spark, cfg)
+        elif args.mode == "filters":
+            payload = do_filters(spark, cfg)
         elif args.mode == "functional":
             payload = do_functional(spark, cfg)
         else:

--- a/utilities/emr-test-drive/etd/cli.py
+++ b/utilities/emr-test-drive/etd/cli.py
@@ -138,6 +138,9 @@ def cmd_setup(args) -> int:
     (d / "setup.json").write_text(json.dumps(
         {"run_id": orch.run_id, "asset_uri": state["asset_uri"],
          "applications": {v.variant_id: v.application_id for v in spec.variants},
+         # Persisted because `run` is a separate invocation and needs the filter
+         # reader role ARN that setup created.
+         "lakeformation": state.get("lakeformation") or {},
          "job_log": orch.job_log}, indent=2, default=str) + "\n")
     print(f"\nsetup complete — run_id {orch.run_id}\n  state: {d / 'setup.json'}")
     return 0

--- a/utilities/emr-test-drive/etd/compare.py
+++ b/utilities/emr-test-drive/etd/compare.py
@@ -54,7 +54,14 @@ class Run:
         return {w["workload_id"]: w for w in self.manifest["workloads"]}
 
     def payload(self, variant_id: str, workload_id: str) -> dict | None:
-        return self.units.get((variant_id, workload_id))
+        doc = self.units.get((variant_id, workload_id))
+        if doc is None:
+            return None
+        # Run-level facts some comparisons need -- for instance whether the job
+        # role is a Lake Formation administrator, which decides whether filter
+        # enforcement can be asserted at all. Shallow copy: the cached document
+        # is not mutated.
+        return {**doc, "run": self.manifest}
 
 
 def slug(workload_id: str) -> str:
@@ -161,7 +168,14 @@ def compare_functional(base: dict, cand: dict) -> dict:
                          "cand_status": cu["status"] if cu else "-",
                          "expected_base": (bu or {}).get("expected_state", "-"),
                          "expected_cand": (cu or {}).get("expected_state", "-"),
-                         "error": None, "table_type": (cu or bu).get("table_type")})
+                         "error": None, "table_type": (cu or bu).get("table_type"),
+                         # Same keys as a compared row. An operation present on
+                         # one side only is a legitimate asymmetry -- the Lake
+                         # Formation filter operations exist only under FGAC --
+                         # and the report should show it, not fail to render.
+                         "base_duration_s": (bu or {}).get("duration_s"),
+                         "cand_duration_s": (cu or {}).get("duration_s"),
+                         "lf_permissions": (cu or bu).get("lf_permissions") or []})
             continue
 
         bs, cs = bu["status"], cu["status"]
@@ -335,13 +349,30 @@ def compare_correctness(base: dict, cand: dict) -> list[dict]:
     # Lake Formation data filter not enforced. Reported on the candidate whether
     # or not the baseline did the same: unlike a performance delta, "both sides
     # disclose too much" is not a reason to stay quiet.
+    # An administrator bypasses data cell filters by design, so a full-table read
+    # is expected and reporting it as a disclosure is a false alarm. The finding is
+    # kept -- the run still could not verify enforcement -- but as information
+    # rather than a critical defect, and it no longer blocks the verdict.
+    # Assertable only when the filter check ran as a principal that filters
+    # actually apply to. Before the reader role existed this ran as the job role,
+    # which is typically a Lake Formation administrator, so a full-table read was
+    # correct behaviour being reported as a disclosure.
+    lf = ((cand.get("run") or {}).get("lake_formation")
+          or (base.get("run") or {}).get("lake_formation") or {})
+    assertable = bool(lf.get("filter_enforcement_assertable"))
     for cu in cand["units"]:
         if not cu.get("filter_over_disclosure"):
             continue
         label = f"{cu['table_format']}.{cu['name']}"
         bu = b.get(_fkey(cu))
         findings.append({
-            "category": "FILTER_NOT_ENFORCED", "severity": "critical",
+            "category": ("FILTER_NOT_ENFORCED" if assertable
+                         else "FILTER_ENFORCEMENT_NOT_ASSERTABLE"),
+            "severity": "critical" if assertable else "info",
+            "not_assertable_reason": (None if assertable else
+                ("no non-administrator reader principal was available, so the filter "
+                 "check ran as a principal that bypasses data cell filters; "
+                 "enforcement was not tested")),
             "unit_label": label,
             "table_format": cu["table_format"], "table_type": cu.get("table_type"),
             "pre_existing": bool(bu and bu.get("filter_over_disclosure")),
@@ -619,7 +650,12 @@ def build_comparison(run: Run, comparison: dict) -> dict:
     match = match_status(bv, cv, comparison)
 
     func_wid = next((w for w in run.workloads if run.workloads[w]["kind"] == "functional"), None)
-    perf_wid = next((w for w in run.workloads if run.workloads[w]["kind"] == "performance"), None)
+    # Every performance workload, in declaration order. A run can carry one per
+    # data scale (100g, 1t, 3t) and comparing only the first would silently
+    # discard the rest -- worse than not measuring them, because the report would
+    # look complete.
+    perf_wids = [w for w in run.workloads if run.workloads[w]["kind"] == "performance"]
+    perf_wid = perf_wids[0] if perf_wids else None
 
     fn = None
     if func_wid and run.payload(b_id, func_wid) and run.payload(c_id, func_wid):
@@ -629,18 +665,42 @@ def build_comparison(run: Run, comparison: dict) -> dict:
     if func_wid and run.payload(b_id, func_wid) and run.payload(c_id, func_wid):
         corr = compare_correctness(run.payload(b_id, func_wid), run.payload(c_id, func_wid))
 
-    perf = None
-    if perf_wid and run.payload(b_id, perf_wid) and run.payload(c_id, perf_wid):
-        perf = compare_perf(run.payload(b_id, perf_wid), run.payload(c_id, perf_wid),
-                            run.manifest["thresholds"], intent=comparison.get("intent", "upgrade_regression"))
+    performances = []
+    for wid in perf_wids:
+        bp, cp = run.payload(b_id, wid), run.payload(c_id, wid)
+        if not bp or not cp:
+            continue
+        performances.append({
+            "workload_id": wid,
+            "label": run.workloads[wid].get("label") or wid,
+            "perf": compare_perf(bp, cp, run.manifest["thresholds"],
+                                 intent=comparison.get("intent", "upgrade_regression")),
+        })
+    perf = performances[0]["perf"] if performances else None
+
+    # The verdict must consider every scale: a regression that only appears at the
+    # largest one is the whole point of measuring more than one. Counts are summed
+    # so the existing thresholds apply unchanged; the per-scale aggregates are left
+    # untouched for display, because a geomean across scales would be meaningless.
+    perf_for_verdict = perf
+    if len(performances) > 1:
+        merged_counts: dict = {}
+        rows: list = []
+        for entry in performances:
+            for k, v in (entry["perf"].get("counts") or {}).items():
+                if isinstance(v, (int, float)):
+                    merged_counts[k] = merged_counts.get(k, 0) + v
+            rows.extend(entry["perf"].get("rows") or [])
+        perf_for_verdict = {**perf, "counts": merged_counts, "rows": rows}
 
     cost = compare_cost(run, b_id, c_id)
-    verdict = overall_verdict(fn or {"counts": {}}, corr, perf, match,
+    verdict = overall_verdict(fn or {"counts": {}}, corr, perf_for_verdict, match,
                               intent=comparison.get("intent", "upgrade_regression"))
 
     return {
         "comparison": comparison, "baseline": bv, "candidate": cv, "match": match,
-        "functional": fn, "correctness": corr, "performance": perf, "cost": cost,
+        "functional": fn, "correctness": corr, "performance": perf,
+        "performances": performances, "cost": cost,
         "verdict": verdict,
     }
 

--- a/utilities/emr-test-drive/etd/lakeformation.py
+++ b/utilities/emr-test-drive/etd/lakeformation.py
@@ -333,6 +333,169 @@ def delete_data_filters(factory, spec, tables: list[str]) -> None:
             pass
 
 
+# --------------------------------------------------------- filter reader role
+#
+# Filter enforcement cannot be tested with the job role. That role is typically a
+# Lake Formation data lake administrator -- it was in the account this was built
+# against -- and an administrator bypasses data cell filters entirely, so a read
+# returns the whole table and the harness cannot tell a working deployment from a
+# broken one. A broad table-level SELECT grant has the same effect: the wider
+# grant wins over the filter.
+#
+# So the filter check runs as its own principal: a role that is not an
+# administrator and holds exactly one Lake Formation grant, the data cell filter.
+# If the read then returns more than the filter permits, that is a real finding.
+
+def filter_reader_role_name(spec) -> str:
+    return f"etd-{spec.name}-filter-reader"[:64]
+
+
+def ensure_filter_reader_role(factory, spec) -> str:
+    """Create (or reuse) the least-privilege principal used for filter checks.
+
+    IAM grants only what Lake Formation needs to vend credentials and what Spark
+    needs to write its own result document. Deliberately absent: any table or
+    database SELECT grant, and administrator status.
+    """
+    iam = factory.client("iam")
+    name = filter_reader_role_name(spec)
+    trust = {
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"Service": "emr-serverless.amazonaws.com"},
+            "Action": "sts:AssumeRole",
+        }],
+    }
+    try:
+        arn = iam.create_role(
+            RoleName=name,
+            AssumeRolePolicyDocument=json.dumps(trust),
+            Description="EMR Test Drive: least-privilege reader for Lake Formation filter checks",
+            Tags=[{"Key": "etd:managed", "Value": "true"},
+                  {"Key": "etd:run", "Value": spec.name}],
+        )["Role"]["Arn"]
+        print(f"  lf: created filter reader role {name}")
+    except Exception as exc:  # noqa: BLE001
+        if "EntityAlreadyExists" not in str(exc):
+            print(f"  lf: could not create filter reader role: {str(exc)[:200]}")
+            return ""
+        arn = iam.get_role(RoleName=name)["Role"]["Arn"]
+        print(f"  lf: reusing filter reader role {name}")
+
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            # Lake Formation vends the scoped credentials; without GetDataAccess
+            # the read fails outright rather than returning too much.
+            {"Effect": "Allow",
+             "Action": ["lakeformation:GetDataAccess", "lakeformation:GetTemporaryTablePermissions"],
+             "Resource": "*"},
+            # Catalog metadata only. No S3 read on the table data: under FGAC the
+            # record server reads on the caller's behalf, so direct S3 access
+            # would be a second path to the same bytes and would mask a filter
+            # that is not being applied.
+            {"Effect": "Allow",
+             "Action": ["glue:GetDatabase", "glue:GetDatabases", "glue:GetTable",
+                        "glue:GetTables", "glue:GetPartition", "glue:GetPartitions"],
+             "Resource": "*"},
+            # Where the job writes its own result document, and reads the asset.
+            {"Effect": "Allow",
+             "Action": ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
+             "Resource": [
+                 f"arn:aws:s3:::{spec.bucket}",
+                 f"arn:aws:s3:::{spec.bucket}/{spec.prefix}/{spec.name}/assets/*",
+                 f"arn:aws:s3:::{spec.bucket}/{spec.prefix}/{spec.name}/results/*",
+             ]},
+            {"Effect": "Allow",
+             "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents",
+                        "logs:DescribeLogStreams"],
+             "Resource": "*"},
+        ],
+    }
+    try:
+        iam.put_role_policy(RoleName=name, PolicyName="etd-filter-reader",
+                            PolicyDocument=json.dumps(policy))
+    except Exception as exc:  # noqa: BLE001
+        print(f"  lf: reader role policy failed: {str(exc)[:200]}")
+    return arn
+
+
+def grant_filters_to_reader(factory, spec, reader_arn: str, tables: list[str]) -> dict:
+    """Grant the reader SELECT on each data cell filter, and nothing wider.
+
+    Returns what was granted plus whether the reader is an administrator, which
+    the comparison layer uses to decide if the result means anything.
+    """
+    if not reader_arn:
+        return {"reader_arn": "", "granted": 0, "reader_is_lf_admin": None}
+    lf = factory.client("lakeformation")
+    principal = {"DataLakePrincipalIdentifier": reader_arn}
+    granted = 0
+    for f in data_filter_plan(spec, tables):
+        try:
+            lf.grant_permissions(
+                Principal=principal,
+                Resource={"DataCellsFilter": {
+                    "TableCatalogId": spec.account,
+                    "DatabaseName": spec.database,
+                    "TableName": f["table"],
+                    "Name": f["name"]}},
+                Permissions=["SELECT"])
+            granted += 1
+        except Exception as exc:  # noqa: BLE001
+            if "already exists" not in str(exc).lower():
+                print(f"  lf: reader grant on {f['name']} failed: {str(exc)[:160]}")
+    # The database must be describable for Spark to resolve the table at all.
+    try:
+        lf.grant_permissions(Principal=principal,
+                             Resource={"Database": {"Name": spec.database}},
+                             Permissions=["DESCRIBE"])
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        admins = lf.get_data_lake_settings()["DataLakeSettings"].get("DataLakeAdmins") or []
+        is_admin = reader_arn in {a.get("DataLakePrincipalIdentifier") for a in admins}
+    except Exception:  # noqa: BLE001
+        is_admin = None
+    print(f"  lf: granted SELECT on {granted} data filter(s) to the reader role"
+          f"{' (WARNING: reader is an administrator)' if is_admin else ''}")
+    return {"reader_arn": reader_arn, "granted": granted, "reader_is_lf_admin": is_admin}
+
+
+def delete_filter_reader_role(factory, spec) -> None:
+    iam = factory.client("iam")
+    name = filter_reader_role_name(spec)
+    for policy in ("etd-filter-reader",):
+        try:
+            iam.delete_role_policy(RoleName=name, PolicyName=policy)
+        except Exception:  # noqa: BLE001
+            pass
+    try:
+        iam.delete_role(RoleName=name)
+        print(f"  lf: deleted filter reader role {name}")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def job_role_is_lf_admin(factory, spec) -> bool:
+    """Is the job role a Lake Formation data lake administrator?
+
+    This matters for filter testing: an administrator has implicit full access to
+    every catalog resource and is not subject to data cell filters. Asserting that
+    a filter was enforced against an administrator therefore measures nothing, and
+    reporting the resulting full-table read as a disclosure would be a false
+    alarm -- which is exactly what happened before this check existed.
+    """
+    try:
+        admins = factory.client("lakeformation").get_data_lake_settings()[
+            "DataLakeSettings"].get("DataLakeAdmins") or []
+    except Exception:  # noqa: BLE001
+        return False
+    return spec.execution_role_arn in {
+        a.get("DataLakePrincipalIdentifier") for a in admins}
+
+
 def setup(factory, spec, caller_arn: str) -> dict:
     """Full Lake Formation test bed. Idempotent."""
     print("\n== lake formation test bed ==")
@@ -347,13 +510,24 @@ def setup(factory, spec, caller_arn: str) -> dict:
     filters = []
     if any(v.access_mode == "lf_fgac" for v in spec.variants):
         filters = create_data_filters(factory, spec, ["fact"])
-    return {"registration_role_arn": role_arn, "data_filters": filters}
+    reader = {}
+    if filters:
+        reader_arn = ensure_filter_reader_role(factory, spec)
+        reader = grant_filters_to_reader(factory, spec, reader_arn, ["fact"])
+    is_admin = job_role_is_lf_admin(factory, spec)
+    if is_admin and filters:
+        print("  lf: NOTE the job role is a data lake administrator, so data cell "
+              "filters do not apply to it; filter enforcement cannot be asserted "
+              "in this run")
+    return {"registration_role_arn": role_arn, "data_filters": filters,
+            "job_role_is_lf_admin": is_admin, "filter_reader": reader}
 
 
 def teardown(factory, spec) -> None:
     lf = factory.client("lakeformation")
     iam = factory.client("iam")
     delete_data_filters(factory, spec, ["fact"])
+    delete_filter_reader_role(factory, spec)
     arn = f"arn:aws:s3:::{spec.bucket}/{spec.prefix}/{spec.name}/data"
     try:
         lf.deregister_resource(ResourceArn=arn)

--- a/utilities/emr-test-drive/etd/live.py
+++ b/utilities/emr-test-drive/etd/live.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import concurrent.futures as cf
 import json
+import pathlib
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -38,6 +39,32 @@ FTA_CONF = {
 
 def access_mode_conf(v: Variant, spec: RunSpec) -> dict:
     """Job-level configuration implied by the variant's access mode."""
+    if v.access_mode == "hms":
+        # External Apache Hive metastore on Amazon RDS for MySQL over JDBC.
+        # EMR Serverless supports exactly two metastores: the Glue Data Catalog
+        # (the default) and an external Hive metastore. There is no local or
+        # embedded option -- an in-container Derby metastore would not survive
+        # between jobs, and this harness builds the test bed in one job and reads
+        # it from later ones.
+        #
+        # The Glue client factory is deliberately not set: if it were, Glue would
+        # win and this variant would silently measure Glue again. Schema
+        # auto-creation is on because the metastore database starts empty; for a
+        # metastore you care about, run schematool instead.
+        hms_cfg = spec.raw.get("hms") or {}
+        return {
+            "spark.hadoop.javax.jdo.option.ConnectionURL": hms_cfg.get("jdbc_url", ""),
+            "spark.hadoop.javax.jdo.option.ConnectionDriverName": "org.mariadb.jdbc.Driver",
+            "spark.hadoop.javax.jdo.option.ConnectionUserName": hms_cfg.get("user", ""),
+            "spark.hadoop.javax.jdo.option.ConnectionPassword": hms_cfg.get("password", ""),
+            "spark.hadoop.datanucleus.schema.autoCreateAll": "true",
+            "spark.hadoop.hive.metastore.schema.verification": "false",
+            "spark.sql.catalogImplementation": "hive",
+            # The MySQL/MariaDB JDBC driver is not on the EMR Serverless
+            # classpath; without it the metastore connection fails with
+            # ClassNotFoundException for org.mariadb.jdbc.Driver.
+            "spark.jars": hms_cfg.get("driver_jar", ""),
+        }
     if v.access_mode == "lf_fta":
         return dict(FTA_CONF)
     if v.access_mode == "lf_fgac":
@@ -159,12 +186,13 @@ class Orchestrator:
     # ------------------------------------------------------------- job helpers
 
     def _run_job(self, v: Variant, asset_uri: str, mode: str, job_cfg: dict,
-                 out_uri: str, extra_conf: dict, label: str) -> tuple[JobResult, dict | None]:
+                 out_uri: str, extra_conf: dict, label: str,
+                 execution_role_arn: str | None = None) -> tuple[JobResult, dict | None]:
         name = f"etd-{self.spec.name}-{v.variant_id}-{label}"[:255]
         job_id = self.provider.submit(
             v, name, asset_uri,
             ["--mode", mode, "--config", json.dumps(job_cfg), "--output", out_uri],
-            extra_conf)
+            extra_conf, execution_role_arn=execution_role_arn)
         print(f"  [{v.variant_id}] {label}: submitted {job_id}")
         t0 = time.time()
         res = self.provider.monitor(
@@ -185,6 +213,57 @@ class Orchestrator:
 
     # ------------------------------------------------------------------- setup
 
+    @property
+    def lf_state(self) -> dict:
+        """Lake Formation state from setup, reloaded from disk.
+
+        setup and run are separate CLI invocations, so anything held only on the
+        instance is gone by the time run needs it.
+        """
+        if getattr(self, "_lf_cache", None) is not None:
+            return self._lf_cache
+        state = dict(getattr(self, "_lf_state", {}) or {})
+        if not state:
+            try:
+                import json as _json
+                # Newest setup.json for this run name: `run` may carry a
+                # different run_id from the `setup` that created the resources.
+                paths = sorted((pathlib.Path("runs") / self.spec.name).glob("*/setup.json"),
+                               reverse=True)
+                for path in paths:
+                    state = (_json.loads(path.read_text()).get("lakeformation") or {})
+                    if state:
+                        break
+            except Exception:  # noqa: BLE001
+                state = {}
+        self._lf_cache = state
+        return state
+
+    def _lf_manifest_state(self) -> dict:
+        """Lake Formation facts the comparison layer needs.
+
+        Whether the job role is a data lake administrator decides if filter
+        enforcement can be asserted at all: an administrator bypasses data cell
+        filters, so a full-table read is correct behaviour rather than a
+        disclosure.
+        """
+        if not any(v.access_mode in ("lf_fta", "lf_fgac") for v in self.spec.variants):
+            return {}
+        try:
+            is_admin = lakeformation.job_role_is_lf_admin(self.factory, self.spec)
+        except Exception:  # noqa: BLE001
+            is_admin = None
+        reader = (self.lf_state or {}).get("filter_reader") or {}
+        return {
+            "job_role_is_lf_admin": (None if is_admin is None else bool(is_admin)),
+            # The principal the filter check actually ran as. Enforcement is only
+            # assertable when a reader exists and is not an administrator.
+            "filter_reader_arn": reader.get("reader_arn") or "",
+            "filter_reader_is_lf_admin": reader.get("reader_is_lf_admin"),
+            "filter_enforcement_assertable": bool(
+                reader.get("reader_arn") and not reader.get("reader_is_lf_admin")),
+        }
+
     def setup(self) -> dict:
         print(f"\n== setup ({len(self.spec.variants)} variant(s)) ==")
         asset_uri = self.stage_assets()
@@ -197,24 +276,47 @@ class Orchestrator:
                   f"{self.spec.database}, skipping generation")
             return {"asset_uri": asset_uri, "testbed": "existing"}
 
-        # Build the test bed once, on the baseline variant. Every variant reads
-        # the same physical data through the same Glue database.
+        # The test bed is built once per *catalog*, not once per run. Variants
+        # that share the Glue Data Catalog also share the tables, but a variant
+        # with its own metastore (access_mode: hms) starts with an empty catalog:
+        # it can read the same S3 data, yet none of the tables exist in its
+        # metastore, so every operation would fail with TABLE_OR_VIEW_NOT_FOUND
+        # and the report would show a catalog difference as a total outage.
+        #
+        # Grouping by catalog also keeps the data written once: the generated
+        # tables live at the same S3 locations, and a second pass over the same
+        # locations is a rewrite of identical content, not a second dataset.
         base = next(v for v in self.spec.variants if v.baseline)
+        catalog_reps = [base]
+        for v in self.spec.variants:
+            if v.access_mode == "hms" and v is not base:
+                catalog_reps.append(v)
         cfg = {
             "database": self.spec.database, "data_uri": self.spec.data_uri,
             "fact_rows": (tb.get("scale") or {}).get("fact_rows", 2_000_000),
             "dim_rows": (tb.get("scale") or {}).get("dim_rows", 20_000),
+            "external_tables": dict(self.spec.external_tables or {}),
             "variant_id": base.variant_id, "workload_id": "testbed",
             "release_label": base.release_label,
         }
-        out = f"{self.spec.results_uri}/{self.run_id}/testbed.json"
-        res, doc = self._run_job(base, asset_uri, "setup", cfg, out, {}, "testbed")
-        if not res.ok:
-            raise RuntimeError(f"Test bed setup failed: {res.state_details[:500]}")
+        docs = {}
+        for rep in catalog_reps:
+            cfg_rep = {**cfg, "variant_id": rep.variant_id,
+                       "release_label": rep.release_label}
+            label = "testbed" if rep is base else f"testbed-{rep.variant_id}"
+            out = f"{self.spec.results_uri}/{self.run_id}/{label}.json"
+            res, doc = self._run_job(rep, asset_uri, "setup", cfg_rep, out,
+                                     access_mode_conf(rep, self.spec), label)
+            if not res.ok:
+                raise RuntimeError(
+                    f"Test bed setup failed for {rep.variant_id}: {res.state_details[:500]}")
+            docs[rep.variant_id] = doc or {}
+        doc = docs.get(base.variant_id) or {}
         if doc:
             print(f"  testbed rows: {doc.get('row_counts')}")
 
         lf_state = self.setup_lakeformation()
+        self._lf_state = lf_state
         return {"asset_uri": asset_uri, "testbed": doc or {}, "lakeformation": lf_state}
 
     def setup_lakeformation(self) -> dict:
@@ -245,6 +347,33 @@ class Orchestrator:
             return "count"
         return "noop"
 
+    def _run_filters(self, v: Variant, asset_uri: str) -> dict | None:
+        """Run the data cell filter checks under the dedicated reader role.
+
+        Returns None when there is no reader role: without one the check would run
+        as the job role, which is typically a Lake Formation administrator and
+        therefore bypasses filters, producing a full-table read that looks like a
+        disclosure but proves nothing.
+        """
+        reader = ((self.lf_state or {}).get("filter_reader") or {}).get("reader_arn")
+        if not reader:
+            print(f"  [{v.variant_id}] filters: skipped, no reader role available")
+            return None
+        cfg = {"database": self.spec.database, "data_uri": self.spec.data_uri,
+               "variant_id": v.variant_id, "workload_id": "filters",
+               "release_label": v.release_label}
+        out = f"{self.spec.results_uri}/{self.run_id}/{v.variant_id}/filters.json"
+        res, doc = self._run_job(v, asset_uri, "filters", cfg, out,
+                                 access_mode_conf(v, self.spec), "filters",
+                                 execution_role_arn=reader)
+        if not res.ok:
+            print(f"  [{v.variant_id}] filters: {res.state} {res.state_details[:160]}")
+        for u in (doc or {}).get("units", []):
+            u["variant_id"] = v.variant_id
+            u["expected_state"] = "S"
+            u["expected_reason"] = "data cell filter granted to a non-administrator reader"
+        return doc
+
     def run(self, asset_uri: str) -> dict:
         print(f"\n== run {self.run_id} ==")
         # Always re-stage: otherwise a fix to the job script silently does not
@@ -259,6 +388,19 @@ class Orchestrator:
                 payload = (self._run_functional(v, w, asset_uri) if w.kind == "functional"
                            else self._run_perf(v, w, asset_uri))
                 out.append(((v.variant_id, w.workload_id), payload))
+            # Lake Formation filter enforcement, once per FGAC variant, under the
+            # least-privilege reader role. Attached to the functional workload so
+            # the findings appear alongside the other correctness evidence.
+            if v.access_mode == "lf_fgac":
+                fp = self._run_filters(v, asset_uri)
+                if fp:
+                    func_wid = next((w.workload_id for w in self.spec.workloads
+                                     if w.kind == "functional"), None)
+                    if func_wid:
+                        for key, payload in out:
+                            if key == (v.variant_id, func_wid) and payload:
+                                payload.setdefault("units", []).extend(fp.get("units", []))
+                                break
             return out
 
         with cf.ThreadPoolExecutor(max_workers=max(1, min(max_par, len(self.spec.variants)))) as ex:
@@ -432,8 +574,13 @@ class Orchestrator:
                               for v in self.spec.variants)
                 + f". Test bed: Glue database {self.spec.database}."),
             "variants": [v.to_manifest() for v in self.spec.variants],
+            # Queried here rather than carried from setup: setup and run are
+            # separate CLI invocations, so state held on the orchestrator instance
+            # during setup is gone by the time the manifest is written.
+            "lake_formation": self._lf_manifest_state(),
             "workloads": [{
                 "workload_id": w.workload_id, "kind": w.kind, "unit_kind": w.unit_kind,
+                "label": w.label or w.workload_id,
                 "iterations": w.iterations,
                 "description": (f"Operation matrix across {', '.join(w.formats)}"
                                 if w.kind == "functional"
@@ -459,27 +606,32 @@ class Orchestrator:
         return local_dir
 
 
+# The asset in etd/assets/etd_job.py runs on the cluster and imports pyspark at
+# module scope, so importing it here raises ModuleNotFoundError on a machine that
+# only orchestrates. The list is therefore duplicated, and tests/test_ops_sync.py
+# asserts the two copies agree so the duplication cannot drift silently.
+DEFAULT_OPERATIONS = [
+    "CREATE_TABLE", "INSERT_INTO", "SELECT", "DESCRIBE", "SHOW_CREATE_TABLE",
+    "CTAS", "INSERT_OVERWRITE", "ALTER_TABLE_ADD_COLUMN",
+    "UPDATE", "DELETE", "MERGE_INTO", "DF_WRITER_V2", "DROP_TABLE",
+]
+
+
 def _default_ops() -> list[str]:
-    from .assets.etd_job import DEFAULT_OPERATIONS  # local import: asset is standalone
     return list(DEFAULT_OPERATIONS)
-
-
-# Filter enforcement can only be asserted where a filter exists.
-FILTER_OPS = ["ROW_FILTER", "COLUMN_FILTER", "CELL_FILTER"]
 
 
 def _ops_for(w, v) -> list[str] | None:
     """Operations for this workload on this variant.
 
-    Returns None to mean "the harness default". The filter operations are
-    appended only for FGAC, and only when the workload did not name an explicit
-    list -- an explicit list is the operator's choice and is left alone.
+    Returns None to mean "the harness default"; an explicit list is the
+    operator's choice and is left alone.
     """
     if w.operations != "DEFAULT":
         return list(w.operations)
-    if v.access_mode != "lf_fgac":
-        return None
-    return _default_ops() + FILTER_OPS
+    # Filter operations are no longer part of the functional matrix: they are a
+    # separate job, run once per variant under a dedicated reader role.
+    return None
 
 
 def _pricing(region: str) -> dict:

--- a/utilities/emr-test-drive/etd/providers/emr_serverless.py
+++ b/utilities/emr-test-drive/etd/providers/emr_serverless.py
@@ -94,6 +94,11 @@ class EmrServerlessProvider:
                 {"classification": "spark-defaults", "properties": runtime_props}]
         if v.image_uri:
             kwargs["imageConfiguration"] = {"imageUri": v.image_uri}
+        if v.network:
+            kwargs["networkConfiguration"] = {
+                "subnetIds": list(v.network.get("subnet_ids") or []),
+                "securityGroupIds": list(v.network.get("security_group_ids") or []),
+            }
 
         resp = self.client.create_application(**kwargs)
         app_id = resp["applicationId"]
@@ -133,10 +138,15 @@ class EmrServerlessProvider:
         return " ".join(f"--conf {k}={val}" for k, val in conf.items())
 
     def submit(self, v: Variant, name: str, entry_point: str,
-               args: list[str], extra_conf: dict | None = None) -> str:
+               args: list[str], extra_conf: dict | None = None,
+               execution_role_arn: str | None = None) -> str:
         resp = self.client.start_job_run(
             applicationId=v.application_id,
-            executionRoleArn=self.spec.execution_role_arn,
+            # Overridable so a check can run under a different principal.
+            # Filter enforcement must be tested with a role that is not a
+            # Lake Formation administrator, since administrators bypass
+            # data cell filters.
+            executionRoleArn=(execution_role_arn or self.spec.execution_role_arn),
             name=name[:255],
             executionTimeoutMinutes=int(self.spec.safety["job_timeout_minutes"]),
             tags=self.spec.resource_tags(v),

--- a/utilities/emr-test-drive/etd/report.py
+++ b/utilities/emr-test-drive/etd/report.py
@@ -791,24 +791,24 @@ def sec_functional(fn: dict, scope_id: str) -> str:
             f'<tr data-verdict="{e(r["verdict"])}" data-format="{e(r["table_format"])}" '
             f'data-tabletype="{e(r.get("table_type") or "")}">'
             f'<td class="mono">{e(r["operation"])}</td><td>{e(r["table_format"])}</td>'
-            f'<td style="color:var(--ink2)">{e(r["table_type"])}</td>'
+            f'<td style="color:var(--ink2)">{e(r.get("table_type") or "")}</td>'
             f'<td>{chip(r["verdict"])}</td>'
             f'<td>{e(r["base_status"])}</td><td>{e(r["cand_status"])}</td>'
             f'<td style="font-size:12px;color:var(--ink2)">{e(exp)}</td>'
-            f'<td class="num">{fmt_s(r["base_duration_s"])}</td>'
-            f'<td class="num">{fmt_s(r["cand_duration_s"])}</td>'
-            f'<td class="mono" style="color:var(--ink2)">{e(", ".join(r["lf_permissions"]))}</td></tr>')
+            f'<td class="num">{fmt_s(r.get("base_duration_s"))}</td>'
+            f'<td class="num">{fmt_s(r.get("cand_duration_s"))}</td>'
+            f'<td class="mono" style="color:var(--ink2)">{e(", ".join(r.get("lf_permissions") or []))}</td></tr>')
     out.append("</tbody></table></div>")
     return "".join(out)
 
 
 def sec_perf(perf: dict, match: dict, intent: str = "upgrade_regression",
-             scope_suffix: str = "0") -> str:
+             scope_suffix: str = "0", heading: str = "Performance") -> str:
     if not perf:
         return ""
     governance = intent == "governance_overhead"
     a = perf["aggregate"]
-    out = ['<h2 class="sec">Performance</h2>']
+    out = [f'<h2 class="sec">{e(heading)}</h2>']
     if governance:
         out.append('<div class="verdict info"><span class="lvl">overhead, not regression</span><div>'
                    '<h3>This pair measures the price of enabling governance</h3>'
@@ -971,6 +971,18 @@ def sec_env(res: dict) -> str:
     return "".join(out)
 
 
+def num(value, spec: str = ",.0f", suffix: str = "", prefix: str = "") -> str:
+    """Format a number, or an em dash when it is absent.
+
+    A variant can legitimately lack a figure -- no performance workload ran, or no
+    expected-support matrix covers its access mode -- and a dashboard that raises
+    TypeError on None turns a partial result into no report at all.
+    """
+    if value is None:
+        return "—"
+    return f"{prefix}{format(value, spec)}{suffix}"
+
+
 def dashboard(run, results: list[dict]) -> str:
     """Cross-variant dashboard: one row per variant, independent of any pair."""
     pricing = run.manifest["pricing"]
@@ -1017,12 +1029,12 @@ def dashboard(run, results: list[dict]) -> str:
             f'<code style="color:var(--ink3);white-space:nowrap">{e(v["variant_id"])}</code></td>'
             f'<td class="mono" style="white-space:nowrap">{e(release_label(v["release_label"]))}</td>'
             f'<td>{chip(access_label(v["access_mode"]), "info" if v["access_mode"]=="lf_fgac" else "neutral")}</td>'
-            f'<td class="num">{r["pass_rate"]:.1f}%<br><span style="color:var(--ink3);font-size:11.5px">'
+            f'<td class="num">{num(r["pass_rate"], ".1f", "%")}<br><span style="color:var(--ink3);font-size:11.5px">'
             f'{r["passed"]}/{r["expected_ok"]}</span></td>'
             f'<td class="num" style="color:var(--ink3)">{r["unsupported"]}</td>'
-            f'<td class="num">{r["perf_total_s"]:,.0f}s</td>'
+            f'<td class="num">{num(r["perf_total_s"], ",.0f", "s")}</td>'
             f'<td class="num" style="color:{"#d91515" if r["timeouts"] else "var(--ink3)"}">{r["timeouts"]}</td>'
-            f'<td class="num">${r["usd"]:,.2f}</td>'
+            f'<td class="num">{num(r["usd"], ",.2f", "", "$")}</td>'
             f'<td class="num" style="font-weight:650">{fmt_pct(rel)}</td></tr>')
     out.append("</tbody></table></div>")
 
@@ -1210,7 +1222,18 @@ def render_html(run, results: list[dict]) -> str:
         parts.append('<div data-anchor="functional"></div>')
         parts.append(sec_functional(r["functional"], f"ftab-{i}"))
         parts.append('<div data-anchor="performance"></div>')
-        parts.append(sec_perf(r["performance"], r["match"], r["comparison"].get("intent", ""), str(i)))
+        # One section per performance workload, in declaration order, so scales
+        # read 100g -> 1t -> 3t rather than being collapsed into whichever was
+        # declared first.
+        entries = r.get("performances") or (
+            [{"workload_id": "", "label": "", "perf": r["performance"]}] if r["performance"] else [])
+        multi = len(entries) > 1
+        for k, entry in enumerate(entries):
+            head = ("Performance" if not multi
+                    else f'Performance — {entry["label"]}')
+            parts.append(sec_perf(entry["perf"], r["match"],
+                                  r["comparison"].get("intent", ""),
+                                  f"{i}-{k}", head))
         parts.append('<div data-anchor="cost"></div>')
         parts.append(sec_cost(r["cost"], r["baseline"], r["candidate"], m["pricing"]))
         parts.append(sec_env(r))
@@ -1265,6 +1288,13 @@ def render_json(run, results: list[dict]) -> str:
                                for cl in (r["functional"] or {}).get("clusters", [])],
             "correctness_findings": r["correctness"],
             "performance": (r["performance"] or {}).get("aggregate"),
+            # Every scale, in declaration order. A consumer reading only
+            # "performance" above would see the first workload alone.
+            "performance_by_scale": [
+                {"workload_id": pe["workload_id"], "label": pe["label"],
+                 "aggregate": (pe["perf"] or {}).get("aggregate"),
+                 "counts": (pe["perf"] or {}).get("counts", {})}
+                for pe in (r.get("performances") or [])],
             "performance_counts": (r["performance"] or {}).get("counts", {}),
             "performance_units": [
                 {k: u[k] for k in ("name", "verdict", "base_best_s", "cand_best_s", "delta_pct")}

--- a/utilities/emr-test-drive/etd/spec.py
+++ b/utilities/emr-test-drive/etd/spec.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = "0.2"
-VALID_ACCESS_MODES = ("plain", "lf_fta", "lf_fgac")
+VALID_ACCESS_MODES = ("plain", "lf_fta", "lf_fgac", "hms")
 VALID_INTENTS = ("upgrade_regression", "patch_validation", "governance_overhead")
 
 
@@ -73,6 +73,11 @@ class Variant:
     shape: dict = field(default_factory=dict)
     spark_conf: dict = field(default_factory=dict)
     image_uri: str | None = None
+    # {"subnet_ids": [...], "security_group_ids": [...]}. Attaching a VPC is
+    # required to reach an external Hive metastore on RDS. Note that a
+    # VPC-attached application loses default S3 egress, so the subnets must
+    # route to an S3 gateway endpoint or every S3 read hangs.
+    network: dict | None = None
     notes: str = ""
     # populated at provision time
     application_id: str | None = None
@@ -117,6 +122,9 @@ class Variant:
 class Workload:
     workload_id: str
     kind: str
+    # Shown as the section heading when a run carries several performance
+    # workloads, one per data scale.
+    label: str = ""
     iterations: int = 1
     job_repeats: int = 1
     formats: list[str] = field(default_factory=list)
@@ -145,6 +153,9 @@ class RunSpec:
     workloads: list[Workload]
     comparisons: list[dict]
     testbed: dict
+    # name -> s3 uri. Registered as external tables in the run
+    # database at setup so a real dataset can back the workload.
+    external_tables: dict
     thresholds: dict
     safety: dict
     raw: dict
@@ -243,7 +254,8 @@ def load_spec(path: str | Path) -> RunSpec:
             access_mode=mode, baseline=bool(v.get("baseline")),
             shape=dict(v.get("shape") or {}),
             spark_conf={str(k): str(x) for k, x in (v.get("spark_conf") or {}).items()},
-            image_uri=v.get("image_uri"), notes=v.get("notes", ""),
+            image_uri=v.get("image_uri"),
+            network=dict(v.get("network") or {}) or None, notes=v.get("notes", ""),
         ))
     if not variants:
         errs.append("at least one variant is required")
@@ -265,6 +277,7 @@ def load_spec(path: str | Path) -> RunSpec:
             continue
         workloads.append(Workload(
             workload_id=w["id"], kind=w["kind"],
+            label=str(w.get("label") or ""),
             iterations=int(w.get("iterations", 1)),
             job_repeats=int(w.get("job_repeats", 1)),
             formats=list(w.get("formats") or []),
@@ -317,6 +330,7 @@ def load_spec(path: str | Path) -> RunSpec:
         tags=dict(run.get("tags") or {}),
         variants=variants, workloads=workloads, comparisons=comparisons,
         testbed=dict(raw.get("testbed") or {"mode": "generate"}),
+        external_tables=dict(raw.get("external_tables") or {}),
         thresholds={"perf_noise_band_pct": 5.0, "perf_regression_alert_pct": 10.0,
                     "min_iterations_for_perf_verdict": 2, **(raw.get("thresholds") or {})},
         safety={"auto_stop_minutes": 15, "job_timeout_minutes": 30,

--- a/utilities/emr-test-drive/etd/support.py
+++ b/utilities/emr-test-drive/etd/support.py
@@ -31,8 +31,16 @@ ALIASES = {
 }
 
 
+# A catalog choice is not an access-control mode: with an external Hive
+# metastore, Lake Formation is not in the path, so Spark's operation support is
+# the same as with the Glue Data Catalog. Aliasing avoids a duplicate matrix that
+# would drift.
+MATRIX_ALIASES = {"hms": "plain"}
+
+
 @functools.lru_cache(maxsize=8)
 def load_matrix(access_mode: str) -> dict:
+    access_mode = MATRIX_ALIASES.get(access_mode, access_mode)
     p = SUPPORT_DIR / f"{access_mode}.json"
     if not p.exists():
         raise FileNotFoundError(

--- a/utilities/emr-test-drive/examples/offline/fixtures/run_manifest.json
+++ b/utilities/emr-test-drive/examples/offline/fixtures/run_manifest.json
@@ -167,7 +167,18 @@
       "iterations": 3,
       "description": "TPC-DS derived query subset at scale factor 100, Parquet, read via the Glue Data Catalog. Best-of-N per query.",
       "dataset": "s3://etd-example-111122223333/tpcds/sf100/",
-      "method": "spark.sql(q).write.format('noop').mode('overwrite').save(); min across iterations"
+      "method": "spark.sql(q).write.format('noop').mode('overwrite').save(); min across iterations",
+      "label": "TPC-DS 100 GB"
+    },
+    {
+      "workload_id": "perf/tpcds-sf1000",
+      "kind": "performance",
+      "unit_kind": "query",
+      "iterations": 3,
+      "description": "TPC-DS derived query subset at scale factor 100, Parquet, read via the Glue Data Catalog. Best-of-N per query.",
+      "dataset": "s3://etd-example-111122223333/tpcds/sf100/",
+      "method": "spark.sql(q).write.format('noop').mode('overwrite').save(); min across iterations",
+      "label": "TPC-DS 1 TB"
     }
   ],
   "comparisons": [
@@ -223,5 +234,11 @@
     "perf_noise_band_pct": 5.0,
     "perf_regression_alert_pct": 10.0,
     "min_iterations_for_perf_verdict": 2
+  },
+  "lake_formation": {
+    "filter_reader_arn": "arn:aws:iam::111122223333:role/etd-example-filter-reader",
+    "filter_reader_is_lf_admin": false,
+    "filter_enforcement_assertable": true,
+    "job_role_is_lf_admin": true
   }
 }

--- a/utilities/emr-test-drive/examples/offline/fixtures/units/v-711-fgac__func-lf-fgac-core.json
+++ b/utilities/emr-test-drive/examples/offline/fixtures/units/v-711-fgac__func-lf-fgac-core.json
@@ -1636,7 +1636,7 @@
     },
     {
       "name": "ROW_FILTER",
-      "table_format": "iceberg",
+      "table_format": "n/a",
       "table_type": "managed",
       "status": "SUCCESS",
       "error": null,
@@ -1657,11 +1657,11 @@
       "column_filter_enforced": null,
       "filter_over_disclosure": false,
       "expected_state": "S",
-      "expected_reason": "documented support state"
+      "expected_reason": "data cell filter granted to a non-administrator reader principal"
     },
     {
       "name": "COLUMN_FILTER",
-      "table_format": "iceberg",
+      "table_format": "n/a",
       "table_type": "managed",
       "status": "SUCCESS",
       "error": null,
@@ -1685,11 +1685,11 @@
       "column_filter_enforced": true,
       "filter_over_disclosure": false,
       "expected_state": "S",
-      "expected_reason": "documented support state"
+      "expected_reason": "data cell filter granted to a non-administrator reader principal"
     },
     {
       "name": "CELL_FILTER",
-      "table_format": "iceberg",
+      "table_format": "n/a",
       "table_type": "managed",
       "status": "SUCCESS",
       "error": null,
@@ -1711,7 +1711,7 @@
       "column_filter_enforced": true,
       "filter_over_disclosure": false,
       "expected_state": "S",
-      "expected_reason": "documented support state"
+      "expected_reason": "data cell filter granted to a non-administrator reader principal"
     }
   ]
 }

--- a/utilities/emr-test-drive/examples/offline/fixtures/units/v-711-fgac__perf-tpcds-sf1000.json
+++ b/utilities/emr-test-drive/examples/offline/fixtures/units/v-711-fgac__perf-tpcds-sf1000.json
@@ -1,0 +1,259 @@
+{
+  "run_id": "etd-20260813-a41f9c",
+  "variant_id": "v-711-fgac",
+  "workload_id": "perf/tpcds-sf1000",
+  "unit_kind": "query",
+  "iterations": 3,
+  "cost_facts": {
+    "vcpu_hour": 483.447,
+    "memory_gb_hour": 1933.788,
+    "storage_gb_hour": 255.792,
+    "wall_clock_s": 31078.89,
+    "drivers_per_job": 2,
+    "avg_executors": 12,
+    "source": "synthetic fixture \u2014 derived from shape x wall clock"
+  },
+  "data_class": "SAMPLE",
+  "units": [
+    {
+      "name": "q1",
+      "status": "SUCCESS",
+      "iterations": [
+        161.12,
+        160.83,
+        166.85
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00007a31e72f603a"
+    },
+    {
+      "name": "q3",
+      "status": "SUCCESS",
+      "iterations": [
+        84.69,
+        85.73,
+        86.29
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000040a3e20fe5b1"
+    },
+    {
+      "name": "q4",
+      "status": "SUCCESS",
+      "iterations": [
+        1022.16,
+        1030.24,
+        1051.58
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00008b00692dd7c0"
+    },
+    {
+      "name": "q7",
+      "status": "SUCCESS",
+      "iterations": [
+        127.18,
+        132.73,
+        127.56
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000044accb78e0a8"
+    },
+    {
+      "name": "q11",
+      "status": "SUCCESS",
+      "iterations": [
+        797.68,
+        783.58,
+        792.23
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000e9d1c9a027d2"
+    },
+    {
+      "name": "q17",
+      "status": "SUCCESS",
+      "iterations": [
+        292.53,
+        299.01,
+        300.24
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000f3e815284395"
+    },
+    {
+      "name": "q19",
+      "status": "SUCCESS",
+      "iterations": [
+        121.45,
+        124.74,
+        124.17
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000bf78221275b1"
+    },
+    {
+      "name": "q23a",
+      "status": "SUCCESS",
+      "iterations": [
+        894.32,
+        901.74,
+        928.44
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000026815acec364"
+    },
+    {
+      "name": "q25",
+      "status": "SUCCESS",
+      "iterations": [
+        340.56,
+        332.29,
+        344.79
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000672bb7abb01d"
+    },
+    {
+      "name": "q28",
+      "status": "SUCCESS",
+      "iterations": [
+        550.18,
+        527.25,
+        539.37
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000d0bbf3488dc0"
+    },
+    {
+      "name": "q34",
+      "status": "SUCCESS",
+      "iterations": [
+        166.57,
+        171.74,
+        170.61
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00005eeca4f79691"
+    },
+    {
+      "name": "q42",
+      "status": "SUCCESS",
+      "iterations": [
+        65.99,
+        65.33,
+        67.87
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000e108aa04878d"
+    },
+    {
+      "name": "q50",
+      "status": "SUCCESS",
+      "iterations": [
+        395.46,
+        386.15,
+        385.49
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00000532f149f0b4"
+    },
+    {
+      "name": "q59",
+      "status": "SUCCESS",
+      "iterations": [
+        460.98,
+        471.79,
+        455.62
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000b4f8c31b5c3d"
+    },
+    {
+      "name": "q64",
+      "status": "SUCCESS",
+      "iterations": [
+        1153.29,
+        1138.15,
+        1143.13
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00009057be827067"
+    },
+    {
+      "name": "q67",
+      "status": "SUCCESS",
+      "iterations": [
+        1330.38,
+        1317.79,
+        1360.27
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00009b58e6e7137f"
+    },
+    {
+      "name": "q72",
+      "status": "SUCCESS",
+      "iterations": [
+        1668.69,
+        1638.04,
+        1659.48
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000c7fbb28db529"
+    },
+    {
+      "name": "q75",
+      "status": "SUCCESS",
+      "iterations": [
+        611.56,
+        624.35,
+        601.88
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00007f805114a8f6"
+    },
+    {
+      "name": "q78",
+      "status": "SUCCESS",
+      "iterations": [
+        891.03,
+        841.3,
+        848.73
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00001382ec0b5aee"
+    },
+    {
+      "name": "q95",
+      "status": "SUCCESS",
+      "iterations": [
+        707.82,
+        689.77,
+        726.53
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000bae17baa2c42"
+    }
+  ]
+}

--- a/utilities/emr-test-drive/examples/offline/fixtures/units/v-713-fgac-p1__func-lf-fgac-core.json
+++ b/utilities/emr-test-drive/examples/offline/fixtures/units/v-713-fgac-p1__func-lf-fgac-core.json
@@ -1654,7 +1654,7 @@
     },
     {
       "name": "ROW_FILTER",
-      "table_format": "iceberg",
+      "table_format": "n/a",
       "table_type": "managed",
       "status": "FAILED",
       "error": "AssertionError: data filter 'row' not enforced: 10000 rows visible, 1000 permitted",
@@ -1675,11 +1675,11 @@
       "column_filter_enforced": null,
       "filter_over_disclosure": true,
       "expected_state": "S",
-      "expected_reason": "documented support state"
+      "expected_reason": "data cell filter granted to a non-administrator reader principal"
     },
     {
       "name": "COLUMN_FILTER",
-      "table_format": "iceberg",
+      "table_format": "n/a",
       "table_type": "managed",
       "status": "SUCCESS",
       "error": null,
@@ -1703,11 +1703,11 @@
       "column_filter_enforced": true,
       "filter_over_disclosure": false,
       "expected_state": "S",
-      "expected_reason": "documented support state"
+      "expected_reason": "data cell filter granted to a non-administrator reader principal"
     },
     {
       "name": "CELL_FILTER",
-      "table_format": "iceberg",
+      "table_format": "n/a",
       "table_type": "managed",
       "status": "FAILED",
       "error": "AssertionError: data filter 'cell' not enforced: 10000 rows visible, 1000 permitted",
@@ -1729,7 +1729,7 @@
       "column_filter_enforced": true,
       "filter_over_disclosure": true,
       "expected_state": "S",
-      "expected_reason": "documented support state"
+      "expected_reason": "data cell filter granted to a non-administrator reader principal"
     }
   ]
 }

--- a/utilities/emr-test-drive/examples/offline/fixtures/units/v-713-fgac-p1__perf-tpcds-sf1000.json
+++ b/utilities/emr-test-drive/examples/offline/fixtures/units/v-713-fgac-p1__perf-tpcds-sf1000.json
@@ -1,0 +1,254 @@
+{
+  "run_id": "etd-20260813-a41f9c",
+  "variant_id": "v-713-fgac-p1",
+  "workload_id": "perf/tpcds-sf1000",
+  "unit_kind": "query",
+  "iterations": 3,
+  "cost_facts": {
+    "vcpu_hour": 461.712,
+    "memory_gb_hour": 1846.848,
+    "storage_gb_hour": 244.292,
+    "wall_clock_s": 29681.64,
+    "drivers_per_job": 2,
+    "avg_executors": 12,
+    "source": "synthetic fixture \u2014 derived from shape x wall clock"
+  },
+  "data_class": "SAMPLE",
+  "units": [
+    {
+      "name": "q1",
+      "status": "SUCCESS",
+      "iterations": [
+        160.93,
+        156.13,
+        161.87
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00000ee43362016c"
+    },
+    {
+      "name": "q3",
+      "status": "SUCCESS",
+      "iterations": [
+        85.26,
+        82.44,
+        84.98
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000ab6b9388924e"
+    },
+    {
+      "name": "q4",
+      "status": "SUCCESS",
+      "iterations": [
+        809.15,
+        816.01,
+        817.71
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000c730cdd1be52"
+    },
+    {
+      "name": "q7",
+      "status": "SUCCESS",
+      "iterations": [
+        129.72,
+        125.77,
+        124.27
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00007f65de26fa1e"
+    },
+    {
+      "name": "q11",
+      "status": "SUCCESS",
+      "iterations": [
+        776.06,
+        785.18,
+        790.63
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000cc5c3ff02cf5"
+    },
+    {
+      "name": "q17",
+      "status": "SUCCESS",
+      "iterations": [
+        295.54,
+        290.93,
+        290.84
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00009f3901cf15da"
+    },
+    {
+      "name": "q19",
+      "status": "SUCCESS",
+      "iterations": [
+        123.7,
+        118.72,
+        118.25
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000b20660b686e5"
+    },
+    {
+      "name": "q23a",
+      "status": "SUCCESS",
+      "iterations": [
+        1281.78,
+        1279.53,
+        1266.93
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000b57b2ab2ce43"
+    },
+    {
+      "name": "q25",
+      "status": "SUCCESS",
+      "iterations": [
+        325.43,
+        324.96,
+        343.29
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000ff5dd2afde97"
+    },
+    {
+      "name": "q28",
+      "status": "SUCCESS",
+      "iterations": [
+        527.53,
+        545.39,
+        515.5
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000ad24a421ac9b"
+    },
+    {
+      "name": "q34",
+      "status": "SUCCESS",
+      "iterations": [
+        163.37,
+        164.78,
+        164.78
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000de846062420a"
+    },
+    {
+      "name": "q42",
+      "status": "SUCCESS",
+      "iterations": [
+        63.73,
+        65.52,
+        66.36
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00007f6a61c2eea2"
+    },
+    {
+      "name": "q50",
+      "status": "SUCCESS",
+      "iterations": [
+        374.03,
+        369.98,
+        381.26
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00002e76371fd391"
+    },
+    {
+      "name": "q59",
+      "status": "SUCCESS",
+      "iterations": [
+        449.7,
+        456.84,
+        458.91
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00002d2e0c03d8c2"
+    },
+    {
+      "name": "q64",
+      "status": "SUCCESS",
+      "iterations": [
+        968.67,
+        980.51,
+        1021.5
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000cc26b6e38117"
+    },
+    {
+      "name": "q67",
+      "status": "SUCCESS",
+      "iterations": [
+        1300.96,
+        1306.98,
+        1265.8
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000cccccc03134f"
+    },
+    {
+      "name": "q72",
+      "status": "SUCCESS",
+      "iterations": [
+        1968.08,
+        2003.7,
+        2046.94
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000019e6d69f1f08"
+    },
+    {
+      "name": "q75",
+      "status": "SUCCESS",
+      "iterations": [
+        601.41,
+        608.37,
+        582.8
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000089d96886503e"
+    },
+    {
+      "name": "q78",
+      "status": "TIMEOUT",
+      "iterations": [],
+      "error": "Job did not reach a terminal state within 1800s",
+      "job_id": "000082b5d9e68a4b"
+    },
+    {
+      "name": "q95",
+      "status": "SUCCESS",
+      "iterations": [
+        812.63,
+        825.32,
+        809.06
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000042d0457c9cf3"
+    }
+  ]
+}

--- a/utilities/emr-test-drive/examples/offline/fixtures/units/v-713-fgac__func-lf-fgac-core.json
+++ b/utilities/emr-test-drive/examples/offline/fixtures/units/v-713-fgac__func-lf-fgac-core.json
@@ -1655,7 +1655,7 @@
     },
     {
       "name": "ROW_FILTER",
-      "table_format": "iceberg",
+      "table_format": "n/a",
       "table_type": "managed",
       "status": "SUCCESS",
       "error": null,
@@ -1676,11 +1676,11 @@
       "column_filter_enforced": null,
       "filter_over_disclosure": false,
       "expected_state": "S",
-      "expected_reason": "documented support state"
+      "expected_reason": "data cell filter granted to a non-administrator reader principal"
     },
     {
       "name": "COLUMN_FILTER",
-      "table_format": "iceberg",
+      "table_format": "n/a",
       "table_type": "managed",
       "status": "SUCCESS",
       "error": null,
@@ -1704,11 +1704,11 @@
       "column_filter_enforced": true,
       "filter_over_disclosure": false,
       "expected_state": "S",
-      "expected_reason": "documented support state"
+      "expected_reason": "data cell filter granted to a non-administrator reader principal"
     },
     {
       "name": "CELL_FILTER",
-      "table_format": "iceberg",
+      "table_format": "n/a",
       "table_type": "managed",
       "status": "SUCCESS",
       "error": null,
@@ -1730,7 +1730,7 @@
       "column_filter_enforced": true,
       "filter_over_disclosure": false,
       "expected_state": "S",
-      "expected_reason": "documented support state"
+      "expected_reason": "data cell filter granted to a non-administrator reader principal"
     }
   ]
 }

--- a/utilities/emr-test-drive/examples/offline/fixtures/units/v-713-fgac__perf-tpcds-sf1000.json
+++ b/utilities/emr-test-drive/examples/offline/fixtures/units/v-713-fgac__perf-tpcds-sf1000.json
@@ -1,0 +1,254 @@
+{
+  "run_id": "etd-20260813-a41f9c",
+  "variant_id": "v-713-fgac",
+  "workload_id": "perf/tpcds-sf1000",
+  "unit_kind": "query",
+  "iterations": 3,
+  "cost_facts": {
+    "vcpu_hour": 460.184,
+    "memory_gb_hour": 1840.739,
+    "storage_gb_hour": 243.484,
+    "wall_clock_s": 29583.63,
+    "drivers_per_job": 2,
+    "avg_executors": 12,
+    "source": "synthetic fixture \u2014 derived from shape x wall clock"
+  },
+  "data_class": "SAMPLE",
+  "units": [
+    {
+      "name": "q1",
+      "status": "SUCCESS",
+      "iterations": [
+        162.34,
+        155.19,
+        155.85
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000fbb4b8a626fe"
+    },
+    {
+      "name": "q3",
+      "status": "SUCCESS",
+      "iterations": [
+        84.51,
+        81.5,
+        83.19
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00004b632bdf916f"
+    },
+    {
+      "name": "q4",
+      "status": "SUCCESS",
+      "iterations": [
+        798.53,
+        803.79,
+        803.7
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00006ff6b7c39085"
+    },
+    {
+      "name": "q7",
+      "status": "SUCCESS",
+      "iterations": [
+        128.87,
+        127.75,
+        128.22
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000e56f89c977b7"
+    },
+    {
+      "name": "q11",
+      "status": "SUCCESS",
+      "iterations": [
+        779.73,
+        803.79,
+        765.44
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000021a571edff3a"
+    },
+    {
+      "name": "q17",
+      "status": "SUCCESS",
+      "iterations": [
+        297.7,
+        288.02,
+        288.86
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00006757121b1f29"
+    },
+    {
+      "name": "q19",
+      "status": "SUCCESS",
+      "iterations": [
+        119.66,
+        122.2,
+        121.26
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000db5a08f02872"
+    },
+    {
+      "name": "q23a",
+      "status": "SUCCESS",
+      "iterations": [
+        1237.98,
+        1289.21,
+        1259.51
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00008b4b58efcb0f"
+    },
+    {
+      "name": "q25",
+      "status": "SUCCESS",
+      "iterations": [
+        342.16,
+        333.89,
+        325.71
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00006ddf9b688f26"
+    },
+    {
+      "name": "q28",
+      "status": "SUCCESS",
+      "iterations": [
+        545.58,
+        529.78,
+        541.72
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000b82855f11145"
+    },
+    {
+      "name": "q34",
+      "status": "SUCCESS",
+      "iterations": [
+        167.51,
+        164.59,
+        160.83
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000090447f9197b1"
+    },
+    {
+      "name": "q42",
+      "status": "SUCCESS",
+      "iterations": [
+        63.73,
+        64.3,
+        65.89
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000023730b94c291"
+    },
+    {
+      "name": "q50",
+      "status": "SUCCESS",
+      "iterations": [
+        383.99,
+        385.87,
+        387.66
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00009d0dffefb04d"
+    },
+    {
+      "name": "q59",
+      "status": "SUCCESS",
+      "iterations": [
+        460.41,
+        443.96,
+        451.58
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00000869fd8c8062"
+    },
+    {
+      "name": "q64",
+      "status": "SUCCESS",
+      "iterations": [
+        1011.53,
+        971.02,
+        967.92
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00003192c315a179"
+    },
+    {
+      "name": "q67",
+      "status": "SUCCESS",
+      "iterations": [
+        1265.71,
+        1272.1,
+        1296.26
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000feb90075111f"
+    },
+    {
+      "name": "q72",
+      "status": "SUCCESS",
+      "iterations": [
+        2010.47,
+        1958.21,
+        2021.75
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00007e18fa637b47"
+    },
+    {
+      "name": "q75",
+      "status": "SUCCESS",
+      "iterations": [
+        609.03,
+        608.74,
+        613.44
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000a9fdf06c6204"
+    },
+    {
+      "name": "q78",
+      "status": "TIMEOUT",
+      "iterations": [],
+      "error": "Job did not reach a terminal state within 1800s",
+      "job_id": "0000674bac8dc0ee"
+    },
+    {
+      "name": "q95",
+      "status": "SUCCESS",
+      "iterations": [
+        802.38,
+        785.09,
+        793.08
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000b7ea53c531a2"
+    }
+  ]
+}

--- a/utilities/emr-test-drive/examples/offline/fixtures/units/v-713-fta__perf-tpcds-sf1000.json
+++ b/utilities/emr-test-drive/examples/offline/fixtures/units/v-713-fta__perf-tpcds-sf1000.json
@@ -1,0 +1,259 @@
+{
+  "run_id": "etd-20260813-a41f9c",
+  "variant_id": "v-713-fta",
+  "workload_id": "perf/tpcds-sf1000",
+  "unit_kind": "query",
+  "iterations": 3,
+  "cost_facts": {
+    "vcpu_hour": 339.884,
+    "memory_gb_hour": 1359.536,
+    "storage_gb_hour": 193.666,
+    "wall_clock_s": 23530.5,
+    "drivers_per_job": 1,
+    "avg_executors": 12,
+    "source": "synthetic fixture \u2014 derived from shape x wall clock"
+  },
+  "data_class": "SAMPLE",
+  "units": [
+    {
+      "name": "q1",
+      "status": "SUCCESS",
+      "iterations": [
+        123.14,
+        120.41,
+        121.17
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000a94d76580a51"
+    },
+    {
+      "name": "q3",
+      "status": "SUCCESS",
+      "iterations": [
+        63.64,
+        63.07,
+        62.32
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000c5820c95ef7d"
+    },
+    {
+      "name": "q4",
+      "status": "SUCCESS",
+      "iterations": [
+        783.3,
+        762.9,
+        764.6
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000004efba75c510"
+    },
+    {
+      "name": "q7",
+      "status": "SUCCESS",
+      "iterations": [
+        99.26,
+        96.63,
+        98.98
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000f07d72a70474"
+    },
+    {
+      "name": "q11",
+      "status": "SUCCESS",
+      "iterations": [
+        613.82,
+        601.69,
+        596.43
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000946c0039a58b"
+    },
+    {
+      "name": "q17",
+      "status": "SUCCESS",
+      "iterations": [
+        218.08,
+        228.7,
+        227.67
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000f3d962ce8660"
+    },
+    {
+      "name": "q19",
+      "status": "SUCCESS",
+      "iterations": [
+        91.09,
+        91.46,
+        92.31
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000064ea4a8bd1eb"
+    },
+    {
+      "name": "q23a",
+      "status": "SUCCESS",
+      "iterations": [
+        688.36,
+        680.0,
+        669.56
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000ebda5b356182"
+    },
+    {
+      "name": "q25",
+      "status": "SUCCESS",
+      "iterations": [
+        261.79,
+        258.41,
+        255.59
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000092f928002875"
+    },
+    {
+      "name": "q28",
+      "status": "SUCCESS",
+      "iterations": [
+        408.81,
+        403.64,
+        401.66
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000034467a92fe96"
+    },
+    {
+      "name": "q34",
+      "status": "SUCCESS",
+      "iterations": [
+        127.56,
+        124.46,
+        123.23
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000ca105a8c7670"
+    },
+    {
+      "name": "q42",
+      "status": "SUCCESS",
+      "iterations": [
+        50.48,
+        49.35,
+        50.1
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000027c3e9baeab0"
+    },
+    {
+      "name": "q50",
+      "status": "SUCCESS",
+      "iterations": [
+        293.84,
+        290.84,
+        279.74
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00001be63f6e4e55"
+    },
+    {
+      "name": "q59",
+      "status": "SUCCESS",
+      "iterations": [
+        336.33,
+        343.85,
+        343.1
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000793c42f1b8e3"
+    },
+    {
+      "name": "q64",
+      "status": "SUCCESS",
+      "iterations": [
+        863.01,
+        851.83,
+        853.52
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000a239c2a9d24c"
+    },
+    {
+      "name": "q67",
+      "status": "SUCCESS",
+      "iterations": [
+        1020.28,
+        981.74,
+        1018.87
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00008a4f54fb4875"
+    },
+    {
+      "name": "q72",
+      "status": "SUCCESS",
+      "iterations": [
+        1234.88,
+        1251.23,
+        1229.43
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000066b743033030"
+    },
+    {
+      "name": "q75",
+      "status": "SUCCESS",
+      "iterations": [
+        445.09,
+        443.87,
+        442.46
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000f30c0b560835"
+    },
+    {
+      "name": "q78",
+      "status": "SUCCESS",
+      "iterations": [
+        643.34,
+        646.53,
+        659.69
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000746997259617"
+    },
+    {
+      "name": "q95",
+      "status": "SUCCESS",
+      "iterations": [
+        521.14,
+        529.97,
+        514.18
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000013929cad609a"
+    }
+  ]
+}

--- a/utilities/emr-test-drive/examples/offline/fixtures/units/v-713-plain__perf-tpcds-sf1000.json
+++ b/utilities/emr-test-drive/examples/offline/fixtures/units/v-713-plain__perf-tpcds-sf1000.json
@@ -1,0 +1,259 @@
+{
+  "run_id": "etd-20260813-a41f9c",
+  "variant_id": "v-713-plain",
+  "workload_id": "perf/tpcds-sf1000",
+  "unit_kind": "query",
+  "iterations": 3,
+  "cost_facts": {
+    "vcpu_hour": 314.587,
+    "memory_gb_hour": 1258.349,
+    "storage_gb_hour": 179.252,
+    "wall_clock_s": 21779.28,
+    "drivers_per_job": 1,
+    "avg_executors": 12,
+    "source": "synthetic fixture \u2014 derived from shape x wall clock"
+  },
+  "data_class": "SAMPLE",
+  "units": [
+    {
+      "name": "q1",
+      "status": "SUCCESS",
+      "iterations": [
+        109.32,
+        114.68,
+        114.68
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000d9ffa35aac38"
+    },
+    {
+      "name": "q3",
+      "status": "SUCCESS",
+      "iterations": [
+        58.19,
+        58.37,
+        60.07
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00000e2d3d25d206"
+    },
+    {
+      "name": "q4",
+      "status": "SUCCESS",
+      "iterations": [
+        725.4,
+        706.41,
+        700.49
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00003e7af90796c4"
+    },
+    {
+      "name": "q7",
+      "status": "SUCCESS",
+      "iterations": [
+        89.77,
+        91.74,
+        88.27
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00001a24843da408"
+    },
+    {
+      "name": "q11",
+      "status": "SUCCESS",
+      "iterations": [
+        563.15,
+        565.79,
+        570.11
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000727884da0c23"
+    },
+    {
+      "name": "q17",
+      "status": "SUCCESS",
+      "iterations": [
+        208.21,
+        206.52,
+        200.6
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000323f30007f61"
+    },
+    {
+      "name": "q19",
+      "status": "SUCCESS",
+      "iterations": [
+        83.19,
+        87.04,
+        83.75
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000cac9c4412ece"
+    },
+    {
+      "name": "q23a",
+      "status": "SUCCESS",
+      "iterations": [
+        628.01,
+        646.72,
+        642.77
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00007dacd72abe64"
+    },
+    {
+      "name": "q25",
+      "status": "SUCCESS",
+      "iterations": [
+        241.77,
+        242.43,
+        235.47
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00006bc6b21966c8"
+    },
+    {
+      "name": "q28",
+      "status": "SUCCESS",
+      "iterations": [
+        369.61,
+        375.91,
+        380.23
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00001a048b65624c"
+    },
+    {
+      "name": "q34",
+      "status": "SUCCESS",
+      "iterations": [
+        115.34,
+        117.41,
+        112.8
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "000074e63cb756f8"
+    },
+    {
+      "name": "q42",
+      "status": "SUCCESS",
+      "iterations": [
+        45.78,
+        45.68,
+        46.72
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00007fc03c3ef57e"
+    },
+    {
+      "name": "q50",
+      "status": "SUCCESS",
+      "iterations": [
+        259.16,
+        266.21,
+        266.11
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000d8fe182cbb0f"
+    },
+    {
+      "name": "q59",
+      "status": "SUCCESS",
+      "iterations": [
+        312.55,
+        320.26,
+        323.27
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00000a9479ce06af"
+    },
+    {
+      "name": "q64",
+      "status": "SUCCESS",
+      "iterations": [
+        793.83,
+        769.2,
+        773.24
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00001bdc6b684434"
+    },
+    {
+      "name": "q67",
+      "status": "SUCCESS",
+      "iterations": [
+        929.85,
+        923.64,
+        894.97
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000d00c94157266"
+    },
+    {
+      "name": "q72",
+      "status": "SUCCESS",
+      "iterations": [
+        1148.02,
+        1127.91,
+        1133.64
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000c6a513a0607b"
+    },
+    {
+      "name": "q75",
+      "status": "SUCCESS",
+      "iterations": [
+        430.43,
+        407.96,
+        410.69
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000f8257ccbd143"
+    },
+    {
+      "name": "q78",
+      "status": "SUCCESS",
+      "iterations": [
+        593.05,
+        585.9,
+        604.42
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "0000d43fc4a39e75"
+    },
+    {
+      "name": "q95",
+      "status": "SUCCESS",
+      "iterations": [
+        502.99,
+        496.41,
+        500.64
+      ],
+      "row_count": 100,
+      "error": null,
+      "job_id": "00005d175b1ca036"
+    }
+  ]
+}

--- a/utilities/emr-test-drive/examples/offline/make_fixtures.py
+++ b/utilities/emr-test-drive/examples/offline/make_fixtures.py
@@ -323,7 +323,9 @@ def filter_units(variant: dict, matrix: dict, unenforced: bool) -> list:
         bad = unenforced and kind in ("row", "cell")
         rows_visible = 10000 if bad else vis
         rec = {
-            "name": op, "table_format": "iceberg", "table_type": "managed",
+            # Filters are defined on the fact table, so the check is not
+            # format-specific and is no longer labelled per format.
+            "name": op, "table_format": "n/a", "table_type": "managed",
             "status": "FAILED" if bad else "SUCCESS",
             "error": (f"AssertionError: data filter '{kind}' not enforced: "
                       f"{rows_visible} rows visible, {permitted} permitted"
@@ -343,10 +345,9 @@ def filter_units(variant: dict, matrix: dict, unenforced: bool) -> list:
         # Resolved from the same matrix as every other unit, so a filter op is
         # judged against documented support rather than against a hardcoded
         # assumption.
-        entry = (matrix.get("formats", {}).get("iceberg", {}) or {}).get(op) or {}
-        state, why = expected_state("iceberg", op, entry, variant)
-        rec["expected_state"] = state
-        rec["expected_reason"] = why
+        rec["expected_state"] = "S"
+        rec["expected_reason"] = ("data cell filter granted to a non-administrator "
+                                  "reader principal")
         out.append(rec)
     return out
 

--- a/utilities/emr-test-drive/scripts/scan_identifiers.py
+++ b/utilities/emr-test-drive/scripts/scan_identifiers.py
@@ -15,6 +15,7 @@ decimal point, and generated output is skipped.
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -43,7 +44,25 @@ CHECKS = [
 ]
 
 
+def ignored(root: Path, paths: list[Path]) -> set[Path]:
+    """Paths git ignores. Anything gitignored cannot leak through the repository,
+    and a local file such as a real-account config would otherwise fail the scan
+    on a developer machine while passing in CI."""
+    if not (root / ".git").exists() or not paths:
+        return set()
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), "check-ignore", "--stdin"],
+            input="\n".join(str(p) for p in paths), text=True,
+            capture_output=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    return {Path(line) for line in proc.stdout.splitlines() if line}
+
+
 def files(root: Path):
+    candidates: list[Path] = []
+    skip: set[Path] = set()
     for p in sorted(root.rglob("*")):
         if not p.is_file():
             continue
@@ -53,7 +72,11 @@ def files(root: Path):
             continue
         if p.resolve() == Path(__file__).resolve():
             continue
-        yield p
+        candidates.append(p)
+    skip = ignored(root, candidates)
+    for p in candidates:
+        if p not in skip:
+            yield p
 
 
 def main() -> int:

--- a/utilities/emr-test-drive/tests/test_ops_sync.py
+++ b/utilities/emr-test-drive/tests/test_ops_sync.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""The default operation list exists in two places and must agree.
+
+etd/assets/etd_job.py runs on the cluster and imports pyspark at module scope, so
+the orchestrator cannot import it: doing so raised ModuleNotFoundError and killed
+the one variant whose dispatch path needed it. The list is duplicated instead,
+which is only safe if drift is detected.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def literal(path: pathlib.Path, name: str):
+    tree = ast.parse(path.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name) and t.id == name:
+                    return ast.literal_eval(node.value)
+    raise AssertionError(f"{name} not found in {path}")
+
+
+def main() -> int:
+    asset = literal(ROOT / "etd/assets/etd_job.py", "DEFAULT_OPERATIONS")
+    live = literal(ROOT / "etd/live.py", "DEFAULT_OPERATIONS")
+    if asset == live:
+        print(f"  ok   DEFAULT_OPERATIONS agree ({len(asset)} operations)")
+        return 0
+    print("  FAIL DEFAULT_OPERATIONS differ")
+    print(f"       only in asset: {[o for o in asset if o not in live]}")
+    print(f"       only in live : {[o for o in live if o not in asset]}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utilities/emr-test-drive/tests/test_security.py
+++ b/utilities/emr-test-drive/tests/test_security.py
@@ -135,6 +135,48 @@ def main() -> int:
         check("a run with a disclosure does not say PROCEED",
               blocked and all(v != "PROCEED" for v in blocked), f"verdicts={blocked}")
 
+    # The filter check must be attributed to a principal filters apply to, and
+    # must not be duplicated per table format.
+    if rj.exists():
+        doc = json.loads(rj.read_text())
+        man = json.loads((Path(__file__).resolve().parents[1]
+                          / "examples/offline/fixtures/run_manifest.json").read_text())
+        lf = man.get("lake_formation") or {}
+        check("a reader principal is recorded", bool(lf.get("filter_reader_arn")))
+        check("the reader is not an LF administrator", lf.get("filter_reader_is_lf_admin") is False)
+        check("enforcement is marked assertable", lf.get("filter_enforcement_assertable") is True)
+        # Not-assertable path: clearing the flag must downgrade, not hide.
+        import copy
+        from etd.compare import compare_correctness
+        units = [{"name": "ROW_FILTER", "table_format": "n/a", "status": "FAILED",
+                  "filter_kind": "row", "rows_visible": 100, "rows_permitted": 10,
+                  "columns_visible": ["a"], "columns_permitted": None,
+                  "filter_over_disclosure": True, "expected_state": "S"}]
+        def payload(assertable):
+            return {"units": copy.deepcopy(units),
+                    "run": {"lake_formation": {"filter_enforcement_assertable": assertable}}}
+        hard = compare_correctness(payload(True), payload(True))
+        soft = compare_correctness(payload(False), payload(False))
+        cats_hard = {f["category"] for f in hard}
+        cats_soft = {f["category"] for f in soft}
+        check("assertable -> critical FILTER_NOT_ENFORCED",
+              "FILTER_NOT_ENFORCED" in cats_hard
+              and all(f["severity"] == "critical" for f in hard))
+        check("not assertable -> informational, not hidden",
+              "FILTER_ENFORCEMENT_NOT_ASSERTABLE" in cats_soft
+              and all(f["severity"] == "info" for f in soft) and len(soft) == len(hard))
+
+    # Filter units must not be duplicated per table format
+    import glob as _g2
+    dupes = []
+    for path in _g2.glob(str(Path(__file__).resolve().parents[1]
+                             / "examples/offline/fixtures/units/*func*")):
+        d = json.loads(Path(path).read_text())
+        fmts = {u.get("table_format") for u in d["units"] if u.get("filter_kind")}
+        if fmts - {"n/a"}:
+            dupes.append((d["variant_id"], sorted(f for f in fmts if f)))
+    check("filter checks are not labelled per table format", not dupes, str(dupes))
+
     # Filters are only asserted under FGAC: with plain Glue or full table access
     # every row is legitimately visible, so asserting otherwise would invent a
     # finding. Verified against the generated fixtures.


### PR DESCRIPTION
## What this adds

Follow-up to #203, from validating the utility against a live account: TPC-DS at
100 GB, 1 TB and 3 TB across four access modes (plain Glue, Lake Formation full
table access, Lake Formation FGAC, external Hive metastore on RDS). 42 jobs, no
failures. That run is what surfaced the two fixes below.

### Several data scales in one report

A run can now carry a performance workload per data scale. The report renders each
one in declaration order with the scale in the heading, and the cost section
itemises every workload, so cost and query time line up scale by scale in a single
report instead of one report per scale.

The comparison layer previously took the first performance workload and ignored
the rest. A three-scale run would have silently discarded two scales while the
report still looked complete. Verdicts now merge across scales, so a regression at
only the largest scale still counts, while per-scale aggregates stay separate
(a geometric mean across data scales is not a meaningful number).

### Filter enforcement is tested with a principal that filters apply to

The Lake Formation filter check ran as the job role. In the account it was
validated against, that role is a data lake administrator — and administrators
bypass data cell filters. So a read returned all 20,000,000 rows of a table whose
filter permits 2,500,000, and the tool reported a critical disclosure for what was
correct service behaviour. A table-wide `SELECT` grant, which the job role also
holds, has the same effect: the wider grant supersedes the filter.

The check now runs as its own principal, created at setup: holding exactly one
Lake Formation grant (SELECT on the data cell filter) plus database DESCRIBE, and
deliberately not an administrator. It is given no S3 read on the table data
either, because under FGAC the record server reads on the caller's behalf, so a
direct S3 path would mask a filter that is not being applied. EMR Serverless
accepts an execution role per job run, so only the filter job uses it.

Where no such principal is available the finding is still reported, as
informational, stating that enforcement was not tested. Removing it would let a
report read as "FGAC verified" when nothing about enforcement had been checked.

The check was also dispatched once per table format, though the filters are
defined on a single table — so `parquet.`, `iceberg.` and `delta.CELL_FILTER` ran
the identical query three times under labels implying a format-specific test that
does not exist. It is now one job mode, once per FGAC variant.

### Also

- External table registration recovers partitions, which the partitioned 3 TB
  TPC-DS set requires; without it every query silently read zero rows.
- Workloads take a display label, carried into the manifest and the report.
- `report.json` carries per-scale performance, not just the first scale.
- The identifier scanner respects `.gitignore`.
- The orchestrator no longer imports the cluster-side asset. That asset imports
  pyspark at module scope, so the import raised `ModuleNotFoundError` in the
  orchestrator and silently killed an entire variant.

## Testing

`make test` — 37 security and correctness assertions, config validation, offline
report generation from fixtures, and the identifier scan. Runs without AWS
credentials.

Live: 42 EMR Serverless jobs across 4 variants and 3 data scales, all succeeded.
Filter enforcement itself has still not been observed succeeding against a live
account — the reader role is new, and this run is what proved the previous
approach could not test it.
