### PR TITLE
feat(config-advisor): Fine Tuner Balanced DRA (cost-mode gated) + val…

### DIFF
--- a/utilities/EMR-Serverless-Config-Advisor/README.md
+++ b/utilities/EMR-Serverless-Config-Advisor/README.md
@@ -124,7 +124,7 @@ python3 python_extractor.py --input s3://your-bucket/event-logs/app_id/ --output
 python3 emr_s_fine_tuner.py --input-path /tmp/extracted/
 ```
 
-The Fine Tuner analyzes actual task metrics, shuffle volumes, spill, and memory utilization to produce configs that are typically 25–35% cheaper than the T-shirt sizer's configuration on the same workload — and substantially cheaper than untuned platform defaults (−61% on our full TPC-DS 3 TB evaluation) — while maintaining the same or better performance.
+The Fine Tuner analyzes actual task metrics, shuffle volumes, spill, and memory utilization to produce configs that are typically 25–35% cheaper than the T-shirt sizer's configuration on the same workload — and substantially cheaper than untuned platform defaults (−75% on our full TPC-DS 3 TB evaluation) — while maintaining the same or better performance.
 
 ### Choosing Your Size
 
@@ -298,20 +298,19 @@ Worker type (cores/memory) is fixed by size + sub-category. `partitions` and `di
 
 ## Benchmark Results
 
-Evaluated on the full TPC-DS suite at 3 TB scale, 95 queries, three iterations per configuration, EMR Serverless release emr-7.13.0. Each query ran as its own job; cost is computed from `billedResourceUtilization` at list rates.
+Evaluated on the full TPC-DS suite at 3 TB scale, 95 queries, three iterations per configuration, EMR Serverless release emr-7.13.0, on a clean application with no pre-initialized capacity. Each query ran as its own job; cost is computed from `billedResourceUtilization` at list rates. Comparisons are against **true platform defaults** (unbounded dynamic allocation, default worker/disk).
 
-The workflow delivers escalating savings as you give the tools more information:
+The workflow delivers large cost savings at neutral runtime:
 
 | Configuration | Input needed | Runtime | Cost | Cost vs defaults | Regressions |
 |--------------|-------------|---------|------|-----------------:|:-----------:|
-| Platform defaults | Nothing | 775 min | $38.65 | — | — |
-| T-shirt General (`--size L`) | Data size | 393 min | $22.58 | −42% | 9/95 |
-| T-shirt Optimized (`--shuffle-write-gb`) | + Shuffle volume | 356 min | $20.18 | −48% | 9/95 |
-| Fine Tuner (cost-optimized) | One event log | 318 min | $14.89 | −61% | 0/95 |
+| Platform defaults | Nothing | 228 min | $41.97 | — | — |
+| T-shirt General (`--size L`, Balanced DRA) | Data size | 236 min | $14.61 | −65% | 2/95 |
+| Fine Tuner (cost-optimized) | One event log | 238 min | $10.36 | −75% | 0/95 |
 
-The Fine Tuner produced zero cost regressions across all 95 queries. Cost variance (run-to-run predictability) also improves at each step: median coefficient of variation falls from 27% (defaults) → 21% (General) → 7% (Optimized) → 6% (Fine Tuner).
+The Fine Tuner produced zero cost regressions across all 95 queries. Runtime stays flat — the savings come from eliminating over-provisioned, idle executor time, not from running slower. Cost variance (run-to-run predictability) also improves sharply: the median coefficient of variation across queries falls from 36% (true defaults) to 9% with the Balanced DRA T-shirt configuration — roughly 4× more predictable billing.
 
-A separate performance-optimized run of the full suite achieved −72.7% runtime / −18.3% cost with zero regressions — the right profile for latency-sensitive jobs.
+A separate performance-optimized run of the full suite, generated from the same event logs, ran **9% faster than platform defaults while still cutting cost 62%** — the right profile for latency-sensitive jobs. Cost-optimized minimizes spend at neutral runtime; performance-optimized minimizes wall-clock time.
 
 ---
 

--- a/utilities/EMR-Serverless-Config-Advisor/emr_s_fine_tuner.py
+++ b/utilities/EMR-Serverless-Config-Advisor/emr_s_fine_tuner.py
@@ -1227,7 +1227,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
                         return True
             return False
 
-        def build_spark_cfg(max_exec, min_exec, sp, executor_disk, vcpu_override=None, mem_override=None):
+        def build_spark_cfg(max_exec, min_exec, sp, executor_disk, vcpu_override=None, mem_override=None, cfg_mode="cost"):
             d_cores, d_mem = _driver_sizing(sp, max_exec, s_in_gb + s_out_gb)
             driver_disk = _driver_disk_sizing(total_tasks)
             vcpu = vcpu_override or worker_cfg["vcpu"]
@@ -1330,23 +1330,15 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
                     cfg.pop("spark.emr-serverless.executor.disk", None)
                     cfg.pop("spark.emr-serverless.executor.disk.type", None)
 
-            # Balanced DRA rate controls for ramp-wasteful queries (applied last, so it
-            # sees the final maxExecutors after any spill-driven bump).
-            # A static maxExecutors ceiling makes short queries ramp hard to the cap and
-            # bill idle executor-hours before the query finishes. When the event log shows
-            # a short query that is NOT sustained-shuffle and NOT spill-bound, throttle the
-            # ramp with rate controls instead — the Balanced DRA lesson validated in the
-            # T-shirt sizer (−46% cost on short TPC-DS queries; zero change on the Expedia
-            # sustained-shuffle workloads, so no regression).
-            # Guards (keep the hard cap when any hold):
-            #   - sustained shuffle (shuffle/input > 0.5 AND CPU > 80%): cap is correct
-            #   - significant spill (spill_ratio > 0.05): needs the executor floor
+            # Balanced DRA rate controls for ramp-wasteful queries (COST mode only).
+            # Performance-optimized mode intentionally keeps an aggressive ramp (its goal
+            # is minimum wall-clock), so throttling would be counterproductive there.
             _dur_min = duration * 60 if duration else 0
             _sh_ratio = (s_out_gb / i_in_gb) if i_in_gb > 0 else 0
             _sustained_shuffle = _sh_ratio > 0.5 and cpu_pct > 80
             _spill_bound = (spill_gb / max(s_in_gb + s_out_gb, 1)) > 0.05
             _ramp_wasteful = ((0 < _dur_min <= 10) or (idle_pct > 60)) and not _sustained_shuffle and not _spill_bound
-            if _ramp_wasteful:
+            if cfg_mode == "cost" and _ramp_wasteful:
                 cfg["spark.dynamicAllocation.executorAllocationRatio"] = "0.5"
                 cfg["spark.dynamicAllocation.sustainedSchedulerBacklogTimeout"] = "15s"
                 # Rate controls replace the hard ceiling (the validated Balanced DRA shape).
@@ -1400,7 +1392,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
                 "total_vcpu_capacity": max_exec_perf * worker_cfg["vcpu"],
                 "total_memory_capacity": max_exec_perf * worker_cfg["memory"],
             },
-            "spark_configs": build_spark_cfg(max_exec_perf, min_exec_perf, sp_perf, executor_disk_perf),
+            "spark_configs": build_spark_cfg(max_exec_perf, min_exec_perf, sp_perf, executor_disk_perf, cfg_mode="performance"),
             "shuffle_tuned": {
                 "partitions": sp_perf,
                 "target_partition_size_mib": target_mib_perf,
@@ -1588,7 +1580,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
                     }
                     perf_recs[-1]["spark_configs"] = build_spark_cfg(
                         bexec, bmin, sp_perf, executor_disk_perf,
-                        vcpu_override=br["vcpu"], mem_override=bmem)
+                        vcpu_override=br["vcpu"], mem_override=bmem, cfg_mode="performance")
                 else:
                     # Fallback: inflate original workers to match disk count
                     max_exec_perf = io_max
@@ -1597,7 +1589,7 @@ def generate_dual_recommendations(input_path: str, limit: int = 100,
                     perf_recs[-1]["worker"]["min_executors"] = min_exec_perf
                     perf_recs[-1]["worker"]["total_vcpu_capacity"] = max_exec_perf * worker_cfg["vcpu"]
                     perf_recs[-1]["worker"]["total_memory_capacity"] = max_exec_perf * worker_cfg["memory"]
-                    perf_recs[-1]["spark_configs"] = build_spark_cfg(max_exec_perf, min_exec_perf, sp_perf, executor_disk_perf)
+                    perf_recs[-1]["spark_configs"] = build_spark_cfg(max_exec_perf, min_exec_perf, sp_perf, executor_disk_perf, cfg_mode="performance")
         # No IO rec for non-IO-bound jobs or already-Small workers
     
     # Process applications with no input data - recommend minimal config

--- a/utilities/EMR-Serverless-Config-Advisor/tests/golden_baseline.json
+++ b/utilities/EMR-Serverless-Config-Advisor/tests/golden_baseline.json
@@ -101,6 +101,16 @@
     "ec2_migration/eventlog_v2_00g6bunn7pe8do0b [performance] spark_configs.spark.emr-serverless.executor.disk: golden='2000G' current='1000G'"
    ],
    "reason": "tier-aware disk sizing: A/B-validated 2026-07-25 on replicated production workloads \u2014 16c 2000G->1000G won on both test jobs (-13.3% wall/-18% cost and -8.6%/-13.9%); 8c IOPS floor + FetchFailed IOPS-ladder escalation keep serving-bound fleets on 1000G+"
+  },
+  {
+   "changed_lines": 4,
+   "changes": [
+    "b12/eventlog_v2_00g5r6925j39qg0b [cost] spark_configs.spark.dynamicAllocation.maxExecutors: golden='35' current=None",
+    "field_reports/collect_heavy_omp_00g6tp1n6gqmio0b [cost] spark_configs.spark.dynamicAllocation.maxExecutors: golden='11' current=None",
+    "serverless_overprovisioned/applications [cost] spark_configs.spark.dynamicAllocation.maxExecutors: golden='79' current=None",
+    "serverless_overprovisioned/synthetic_neil_454exec [cost] spark_configs.spark.dynamicAllocation.maxExecutors: golden='116' current=None"
+   ],
+   "reason": "Balanced DRA rate controls in Fine Tuner are now gated to COST mode only. Performance-optimized configs keep an aggressive ramp (no rate controls, static maxExecutors retained) since perf mode optimizes for runtime. Cost-mode short/ramp-wasteful queries drop the static cap for rate controls as before."
   }
  ],
  "snapshot": {
@@ -187,7 +197,6 @@
    },
    "eventlog_v2_00g5r6925j39qg0b": {
     "cost": {
-     "spark_configs.spark.dynamicAllocation.maxExecutors": "35",
      "spark_configs.spark.dynamicAllocation.minExecutors": "11",
      "spark_configs.spark.emr-serverless.executor.disk": "1000G",
      "spark_configs.spark.emr-serverless.executor.disk.type": "shuffle_optimized",
@@ -588,7 +597,6 @@
   "field_reports": {
    "collect_heavy_omp_00g6tp1n6gqmio0b": {
     "cost": {
-     "spark_configs.spark.dynamicAllocation.maxExecutors": "11",
      "spark_configs.spark.dynamicAllocation.minExecutors": "3",
      "spark_configs.spark.sql.shuffle.partitions": "1000",
      "worker.max_executors": 11,
@@ -638,7 +646,6 @@
   "serverless_overprovisioned": {
    "applications": {
     "cost": {
-     "spark_configs.spark.dynamicAllocation.maxExecutors": "79",
      "spark_configs.spark.dynamicAllocation.minExecutors": "26",
      "spark_configs.spark.sql.shuffle.partitions": "1000",
      "worker.max_executors": 79,
@@ -660,7 +667,6 @@
    },
    "synthetic_neil_454exec": {
     "cost": {
-     "spark_configs.spark.dynamicAllocation.maxExecutors": "116",
      "spark_configs.spark.dynamicAllocation.minExecutors": "38",
      "spark_configs.spark.sql.shuffle.partitions": "1000",
      "worker.max_executors": 116,

--- a/utilities/EMR-Serverless-Config-Advisor/tests/test_finetuner_dra_fix.py
+++ b/utilities/EMR-Serverless-Config-Advisor/tests/test_finetuner_dra_fix.py
@@ -19,6 +19,15 @@ MAXEXEC = "spark.dynamicAllocation.maxExecutors"
 
 def cost_configs(fixture_dir):
     """Run recommender on a fixture dir, return list of cost spark_configs dicts."""
+    return _configs(fixture_dir, "cost")
+
+
+def perf_configs(fixture_dir):
+    """Run recommender on a fixture dir, return list of PERFORMANCE spark_configs dicts."""
+    return _configs(fixture_dir, "perf")
+
+
+def _configs(fixture_dir, which):
     with tempfile.TemporaryDirectory() as td:
         cost_out = os.path.join(td, "cost.json")
         perf_out = os.path.join(td, "perf.json")
@@ -27,11 +36,23 @@ def cost_configs(fixture_dir):
              "--output-cost", cost_out, "--output-perf", perf_out],
             capture_output=True, text=True, cwd=td)
         assert proc.returncode == 0, f"recommender failed:\n{proc.stderr[-2000:]}"
-        with open(cost_out) as f:
+        with open(cost_out if which == "cost" else perf_out) as f:
             recs = json.load(f)
     if isinstance(recs, dict):
         recs = [recs]
     return [r.get("spark_configs", {}) for r in recs]
+
+
+def test_perf_mode_never_throttles():
+    """Performance-optimized mode must NOT apply DRA rate controls (it optimizes for
+    runtime, so throttling the ramp would be counterproductive). Even on the short-query
+    fixture that triggers the cost-mode fix, perf configs keep an aggressive ramp."""
+    for name in ("serverless_overprovisioned", "field_reports", "b12"):
+        d = os.path.join(FIX, name)
+        if not os.path.isdir(d):
+            continue
+        for c in perf_configs(d):
+            assert c.get(RATIO) != "0.5", f"{name}: perf config must not carry DRA rate controls"
 
 
 def test_short_query_gets_dra_rate_controls():


### PR DESCRIPTION
…idated benchmark numbers

Builds on the T-shirt Balanced DRA and app-consolidator changes already on main.

Fine Tuner:
- Adopt Balanced DRA rate controls (executorAllocationRatio=0.5, sustainedSchedulerBacklogTimeout=15s, drop static maxExecutors) for short/ ramp-wasteful, non-shuffle-heavy, non-spill-bound queries in COST mode.
- Performance-optimized mode is explicitly excluded (it optimizes for wall-clock, so throttling the ramp is counterproductive) — keeps aggressive ramp + cap.
- Guards keep the hard cap for sustained shuffle (shuffle/input>0.5 & CPU>80%) and spill-bound (spill_ratio>0.05) queries.

Validated on TPC-DS 3TB (clean app, no pre-init capacity, 95q x 3 iters):
- Fine Tuner cost-optimized: -75% cost vs true defaults, runtime-neutral, 0/95 regressions
- Fine Tuner performance-optimized: -9% runtime / -62% cost
- T-shirt Balanced DRA: -65% cost, runtime-neutral, cost CV 36% -> 9% Config-diff regression check on 6 production workloads (search-health, vrbo, lodging-sort-be, clickstream, sup-trvlr, ump-email): identical configs, no regression.

README benchmark section updated to these clean-baseline numbers. Golden baseline regenerated (perf configs unchanged; cost-mode short-query configs adopt rate controls). Adds tests: cost-mode rate controls, perf mode never throttled, sustained-shuffle keeps cap.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
