### PR TITLE
feat(emr-spark-connect-client): unified Spark Connect client for EMR Serverless, EC2, and EKS

### DIFF
--- a/utilities/emr-spark-connect-client/.gitignore
+++ b/utilities/emr-spark-connect-client/.gitignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+dist/
+build/
+.eggs/
+*.egg
+.venv*/
+venv/
+.env
+.pytest_cache/
+.ipynb_checkpoints/
+.DS_Store
+.vscode/

--- a/utilities/emr-spark-connect-client/README.md
+++ b/utilities/emr-spark-connect-client/README.md
@@ -1,0 +1,170 @@
+# emr-spark-connect
+
+Unified PySpark Spark Connect client for **EMR Serverless**, **EMR on EC2**, and **EMR on EKS** with automatic auth token refresh.
+
+## What It Does
+
+- **One interface for all EMR backends** — `EMRSparkSession.create(resource_id=...)` auto-detects EMR Serverless, EC2, or EKS from the resource ID
+- **Manages the remote lifecycle** — starts a session (Serverless/EC2) or reuses/creates the `SPARK_CONNECT` managed endpoint (EKS, which has no session API), waits for ready, connects, releases on stop
+- **Automatic token refresh** — gRPC interceptor transparently refreshes the 1-hour auth token before expiry; sessions survive up to 24 hours
+- **Standard SparkSession** — `session.sql()`, `session.read`, `session.createDataFrame()` all work normally
+- **Context manager** — `with EMRSparkSession.create(...) as session:` auto-cleans up
+
+## Install
+
+```bash
+pip install .
+```
+
+Requires: Python 3.9+, `pyspark[connect]` matching your EMR release, `boto3>=1.43.72`.
+
+## Quick Start
+
+```python
+from emr_spark_connect import EMRSparkSession
+
+# EMR Serverless (16-char app ID starting with "00")
+session = EMRSparkSession.create(
+    resource_id="00abcdef01234567",
+    execution_role_arn="arn:aws:iam::123456789012:role/MyRole",
+    region="us-east-1",
+)
+
+# EMR on EC2 (cluster ID starting with "j-")
+session = EMRSparkSession.create(
+    resource_id="j-1K48XXXXXXHCB",
+    region="us-east-1",
+)
+
+# EMR on EKS (20-25 char virtual cluster ID)
+session = EMRSparkSession.create(
+    resource_id="uds4tzurhrvs1mdia8h1qr647",
+    execution_role_arn="arn:aws:iam::123456789012:role/EMRonEKSExecutionRole",
+    region="us-east-1",
+    idle_timeout_minutes=60,
+    spark_conf={"spark.dynamicAllocation.enabled": "true"},
+)
+
+session.sql("SELECT 1 + 1 AS result").show()
+session.stop()
+```
+
+## EMR on EKS: two layers, two timeouts
+
+EMR Serverless and EMR on EC2 are **session-based**: `StartSession` creates a
+session, and `GetSessionEndpoint` returns both its URL and a fresh token. There is
+no endpoint resource with a lifetime of its own — only the token expires, so
+refreshing means minting a new one against the existing session. Nothing else to
+check, and the host never changes.
+
+EMR on EKS has **no session API at all**. `emr-containers` exposes no
+`StartSession`, `GetSession`, or `TerminateSession` — the only session-shaped
+operation is `GetManagedEndpointSessionCredentials`, and it hands back a token that
+is *already active*. So there is nothing to start and no session state to poll: the
+`SPARK_CONNECT` managed endpoint is the whole remote resource, and the managed
+endpoint ID is what `session.session_id` reports.
+
+What EKS does have is **two independently-timed layers**:
+
+| Layer | Lifetime | Renewed by |
+|---|---|---|
+| **Managed endpoint** — the ALB-fronted Spark Connect server, and the only resource | `sessionIdleTimeoutInMinutes` on `CreateManagedEndpoint` | Creating a *new* endpoint |
+| **Session token** — `x-aws-proxy-auth`, minted against that endpoint | `durationInSeconds` on `GetManagedEndpointSessionCredentials` (default 15 min, max 12 h) | `GetManagedEndpointSessionCredentials` |
+
+They're nested, not parallel: a token is only valid against the endpoint it was
+minted for, so it can never outlive its endpoint. Which layer expired decides what
+gets rebuilt:
+
+| What expired | What the client does |
+|---|---|
+| **Token only** (endpoint `ACTIVE`) | Mints a new token against the same endpoint. Host unchanged, channel keeps working — identical to Serverless/EC2. |
+| **Endpoint too** | Creates a new endpoint, then mints a token against it. Routine, not an error. |
+
+Endpoint reuse is checked before every token mint, so a live endpoint is never
+replaced and no redundant ALB gets provisioned. Replacement applies whether the
+endpoint was created by the client or handed in via `managed_endpoint_id` — once
+expired, there's nothing left to reuse.
+
+The one thing that can't be automated is the **gRPC channel**. A replacement
+endpoint listens on a different `authProxyUrl`, and an interceptor can only rewrite
+a header, not redirect an open channel. So when the endpoint layer expires
+mid-session, the client creates the replacement and then raises
+`EndpointExpiredError` to tell you the channel needs rebuilding. `reconnect()`
+attaches to the endpoint that is already up:
+
+```python
+from emr_spark_connect import EMRSparkSession, EndpointExpiredError
+
+try:
+    session.sql("SELECT 1").show()
+except EndpointExpiredError:
+    session.reconnect()          # attach to the replacement endpoint
+    session.sql("SELECT 1").show()
+
+session.is_endpoint_active()     # False once the endpoint has been torn down
+```
+
+If the endpoint was replaced, `reconnect()` gives you a fresh Spark driver, so temp
+views and cached DataFrames from the previous endpoint are gone — re-register them
+afterwards. Calling `reconnect()` while the endpoint is still `ACTIVE` reuses it
+rather than provisioning another ALB.
+
+EMR on EKS-specific `create()` arguments:
+
+| Argument | Purpose |
+|---|---|
+| `managed_endpoint_id` | Reuse an existing `SPARK_CONNECT` endpoint instead of creating one (skips the multi-minute ALB provisioning). Not deleted on `stop()`. |
+| `release_label` | EMR release for the endpoint (default `emr-7.14.0-latest`). |
+| `token_duration_seconds` | Session token TTL (default 12h, the documented max). |
+| `application_configuration` | Full `applicationConfiguration` list — for classifications and nested configs a flat `spark_conf` can't express. |
+| `monitoring_configuration` | `monitoringConfiguration` dict (CloudWatch/S3 logging, persistent app UI). |
+
+`spark_conf` and `application_configuration` can be combined; `spark_conf` merges
+into a `spark-defaults` block, and explicitly-listed properties win on conflicts.
+
+## API
+
+```python
+EMRSparkSession.create(
+    resource_id,                # Required: app ID, cluster ID, or virtual cluster ID
+    execution_role_arn=None,    # Required for Serverless/EKS, optional for EC2
+    region=None,                # Defaults to boto3 session region
+    backend=None,               # Force: 'serverless', 'ec2', 'eks' (auto-detected if None)
+    session_name="emr-spark-connect",
+    idle_timeout_minutes=60,
+    max_wait_seconds=900,
+    spark_conf=None,            # Dict of Spark config overrides
+    endpoint_url=None,          # Custom AWS endpoint
+    boto3_session=None,         # Pre-configured boto3.Session
+)
+```
+
+## How Token Refresh Works
+
+EMR auth tokens are short-lived. This client installs a gRPC interceptor on the Spark Connect channel that:
+
+1. Checks token expiry before every outgoing gRPC call (with a 5-minute buffer)
+2. Mints a fresh token when needed — `GetSessionEndpoint` on Serverless/EC2, `GetManagedEndpointSessionCredentials` on EKS
+3. Injects the new token as the `x-aws-proxy-auth` header
+
+The user's code never sees token expiry — queries just work across token boundaries.
+
+This covers EMR Serverless and EMR on EC2 completely: they have only a token to
+refresh, against a session whose endpoint host never moves. On EMR on EKS the minted
+token is already active, so it fully covers the token layer within the life of one
+managed endpoint; when the *endpoint* layer expires the interceptor raises
+`EndpointExpiredError`, because the replacement endpoint has a new host and a header
+swap cannot reach it. See
+[EMR on EKS: two layers, two timeouts](#emr-on-eks-two-layers-two-timeouts).
+
+## Prerequisites
+
+| Backend | Release | Key requirement |
+|---------|---------|-----------------|
+| EMR Serverless | emr-7.13.0+ | `sessionEnabled: true` on the application |
+| EMR on EC2 | emr-spark-8.0.0+ | `--session-enabled` at cluster creation |
+| EMR on EKS | emr-7.14.0+ | Virtual cluster in `RUNNING`; AWS Load Balancer Controller on the EKS cluster (the endpoint is fronted by an ALB) and network reachability to it |
+
+## License
+
+MIT-0

--- a/utilities/emr-spark-connect-client/README.md
+++ b/utilities/emr-spark-connect-client/README.md
@@ -136,6 +136,12 @@ EMRSparkSession.create(
     spark_conf=None,            # Dict of Spark config overrides
     endpoint_url=None,          # Custom AWS endpoint
     boto3_session=None,         # Pre-configured boto3.Session
+    **kwargs: #Additional backend-specific arguments. For EMR on EKS:
+        - managed_endpoint_id: # reuse an existing SPARK_CONNECT managed endpoint instead of creating one.
+        - release_label: # EMR release for the endpoint(default 'emr-7.14.0-latest').
+        - token_duration_seconds: # session token TTL (default 12h, the max).
+        - application_configuration: # full `applicationConfiguration` list, for classifications and nested configs `spark_conf` can't express.
+        - monitoring_configuration: # monitoringConfiguratio
 )
 ```
 

--- a/utilities/emr-spark-connect-client/TESTING.md
+++ b/utilities/emr-spark-connect-client/TESTING.md
@@ -1,0 +1,314 @@
+# emr-spark-connect: Testing Summary
+
+## What Was Built
+
+A unified Python package (`emr-spark-connect`) that provides a single interface to connect to EMR Serverless, EMR on EC2, and EMR on EKS via Spark Connect — with automatic auth token refresh so sessions survive past the 1-hour token TTL.
+
+### User Experience
+
+```python
+from emr_spark_connect import EMRSparkSession
+
+# EMR Serverless
+session = EMRSparkSession.create(
+    resource_id="00abcdef01234567",
+    execution_role_arn="arn:aws:iam::123456789012:role/EMRServerlessS3RuntimeRole",
+    region="us-east-1",
+)
+
+# EMR on EC2
+session = EMRSparkSession.create(
+    resource_id="j-1K48XXXXXXHCB",
+    region="us-east-1",
+)
+
+# Then use it like a normal SparkSession
+session.sql("SELECT 1 + 1 AS result").show()
+session.stop()
+```
+
+The `resource_id` format is auto-detected — no need to specify which backend to use.
+
+---
+
+## What Was Tested
+
+### EMR Serverless (emr-7.13.0, Spark 3.5.6-amzn-2)
+
+| Item | Details |
+|------|---------|
+| Application ID | `00abcdef01234567` |
+| Execution Role | `arn:aws:iam::123456789012:role/EMRServerlessS3RuntimeRole` |
+| Region | us-east-1 |
+| Session ID | `00abcdef01234568` |
+| Session startup time | ~77 seconds (SUBMITTED → STARTING → STARTED) |
+| Spark version | 3.5.6-amzn-2 |
+
+**Tests run:**
+1. ✅ `SELECT 1 + 1 AS result` — returned `2`
+2. ✅ `session.range(10).selectExpr("id", "id * id AS squared")` — 10 rows with correct squares
+3. ✅ `SELECT current_timestamp() AS now, current_date() AS today` — returned valid timestamps
+
+**Token refresh:** Interceptor installed, next refresh scheduled ~55 minutes ahead (5-minute buffer before the 1-hour TTL).
+
+---
+
+### EMR on EC2 (emr-spark-8.0.0, Spark 4.0.2-amzn-0)
+
+| Item | Details |
+|------|---------|
+| Cluster ID | `j-1K48XXXXXXHCB` |
+| Cluster config | 1× m5.xlarge master + 2× m5.xlarge core |
+| Execution Role | Not required (no runtime role) |
+| Region | us-east-1 |
+| Session ID | `is-ABCDEFGHIJKL` |
+| Session startup time | ~38 seconds (SUBMITTED → STARTING → STARTED) |
+| Spark version | 4.0.2-amzn-0 |
+
+**Tests run:**
+1. ✅ `SELECT 1 + 1 AS result` — returned `2`
+2. ✅ `session.range(10).selectExpr("id", "id * id AS squared")` — 10 rows with correct squares
+3. ✅ `SELECT current_timestamp() AS now, current_date() AS today` — returned valid timestamps
+
+**Token refresh:** Interceptor installed, next refresh scheduled ~56 minutes ahead.
+
+---
+
+## Key Observations
+
+1. **EMR on EC2 does NOT require an execution role** for basic sessions (unlike EMR Serverless which always requires one).
+
+2. **Session startup is faster on EC2** (~38s vs ~77s for Serverless) because the cluster is already running — Serverless needs to provision compute from cold.
+
+3. **The auto-start feature on EMR Serverless works** — the application was in STOPPED state but auto-started when a session was requested.
+
+4. **EMR on EC2 requires `emr-spark-8.0.0`** (released August 2026) with the `--session-enabled` flag at cluster creation. The older `emr-7.13.0` does not support Spark Connect sessions on EC2.
+
+5. **Resource ID auto-detection works reliably:**
+   - `00abcdef01234567` (16 chars, starts with `00`) → EMR Serverless
+   - `j-1K48XXXXXXHCB` (starts with `j-`) → EMR on EC2
+   - 20-25 lowercase alphanumeric chars → EMR on EKS
+
+6. **The same token refresh interceptor works for both backends** — the abstraction of `refresh_fn: Callable[[], Tuple[str, datetime]]` cleanly separates token refresh logic from the gRPC machinery.
+
+---
+
+## How Token Refresh and Endpoints Work
+
+### The Problem
+
+EMR Spark Connect uses a `sc://` URL to connect your local PySpark client to a remote Spark driver over gRPC. Each connection is authenticated with an `x-aws-proxy-auth` token embedded in the URL. This token **expires after 1 hour**. Once expired, every gRPC call fails with `StatusCode.UNKNOWN / "Stream removed"` — killing your session mid-work.
+
+The remote session itself can live up to **24 hours**. It's only the auth token that's short-lived.
+
+### The Solution: gRPC Interceptor
+
+The package installs a `TokenRefreshInterceptor` that sits between PySpark's Spark Connect client and the gRPC channel. On **every outgoing gRPC call**, the interceptor:
+
+1. Checks if the cached token is within 5 minutes of expiry
+2. If yes, calls `GetSessionEndpoint` (Serverless) or `GetSessionEndpoint` (EC2) to get a fresh token
+3. Injects the fresh token as the `x-aws-proxy-auth` metadata header on the gRPC call
+4. Passes the call through to the server
+
+```
+Local PySpark Client
+        │
+        ▼
+┌─────────────────────────────┐
+│  TokenRefreshInterceptor    │
+│                             │
+│  • Every gRPC call passes   │
+│    through here             │
+│  • Checks: is token expiring│
+│    within 5 minutes?        │
+│  • If yes: calls AWS API    │
+│    to get fresh token       │
+│  • Injects x-aws-proxy-auth │
+│    header with valid token  │
+└─────────────────────────────┘
+        │
+        ▼ (gRPC over TLS, port 443)
+┌─────────────────────────────┐
+│  EMR Spark Connect Endpoint │
+│  sc://host:443/;use_ssl=true│
+└─────────────────────────────┘
+```
+
+### Endpoint URLs
+
+When a session starts, the `GetSessionEndpoint` API returns:
+- **Endpoint URL** — an `https://` URL unique to the session
+- **Auth token** — a time-limited bearer token (1-hour TTL)
+- **Token expiry time** — when the token becomes invalid
+
+The client converts the `https://` endpoint to a `sc://` URL:
+
+| Backend | Endpoint format | sc:// URL |
+|---------|----------------|-----------|
+| EMR Serverless | `https://<session-id>.s.emr-serverless-services.<region>.amazonaws.com` | `sc://<session-id>.s.emr-serverless-services.<region>.amazonaws.com:443/;use_ssl=true;x-aws-proxy-auth=<token>` |
+| EMR on EC2 | `https://<session-id>.elasticmapreduce-services.<region>.amazonaws.com` | `sc://<session-id>.elasticmapreduce-services.<region>.amazonaws.com:443/;use_ssl=true;x-aws-proxy-auth=<token>;authorization=<session-id>` |
+
+Note: EMR on EC2 requires an additional `authorization=<session-id>` parameter in the URL.
+
+### Timeouts
+
+| Timeout | Default | Description |
+|---------|---------|-------------|
+| Token TTL | 1 hour (not configurable) | Auth token lifetime. Interceptor refreshes 5 min before expiry. |
+| Session idle timeout | 60 min (configurable via `idle_timeout_minutes`) | Session auto-terminates after this period of inactivity. |
+| Session max lifetime | 24 hours | Hard limit — session terminates even if actively running. |
+| `max_wait_seconds` | 900 (15 min) | How long `create()` waits for session to become ready. |
+| Application auto-stop (Serverless) | 15 min | Application stops if no active sessions/jobs. Re-starts on next request if auto-start is enabled. |
+
+### What Happens During a Long-Running Session
+
+```
+t=0 min    Session starts, initial token obtained (expires at t=60)
+t=0-55     All gRPC calls use cached token — no refresh needed
+t=55       Next gRPC call triggers refresh (within 5-min buffer)
+           → calls GetSessionEndpoint → gets new token (expires t=120)
+t=55-115   Uses new token
+t=115      Another refresh
+...        Continues indefinitely up to 24-hour session limit
+```
+
+The user's code doesn't need to know about any of this. Queries, DataFrame operations, and writes all just work across token boundaries.
+
+### How It's Wired Together
+
+```python
+# EMRChannelBuilder extends PySpark's ChannelBuilder
+class EMRChannelBuilder(ChannelBuilder):
+    def __init__(self, url, refresh_fn):
+        # refresh_fn = manager.refresh_token (returns token + expiry)
+        ...
+
+    def toChannel(self):
+        channel = super().toChannel()  # normal gRPC channel with TLS
+        interceptor = TokenRefreshInterceptor(self._refresh_fn)
+        return grpc.intercept_channel(channel, interceptor)
+
+# The SparkSession uses this channel builder
+spark = SparkSession.builder.channelBuilder(channel_builder).getOrCreate()
+```
+
+The `refresh_fn` is backend-agnostic — it's just a callable that returns `(token, expiry_datetime)`. Each backend (Serverless, EC2, EKS) implements its own version that calls the appropriate AWS API.
+
+---
+
+## Package Structure
+
+```
+src/emr_spark_connect/
+├── __init__.py          # Public API: EMRSparkSession
+├── session.py           # EMRSparkSession — unified facade
+├── backends.py          # Backend managers (Serverless, EC2, EKS)
+└── interceptors.py      # gRPC token refresh interceptor + EMRChannelBuilder
+```
+
+## EMR on EKS
+
+Implemented in `EKSSessionManager` and exercised by `test_emreks.py`. The flow is:
+
+1. `create_managed_endpoint(type="SPARK_CONNECT", releaseLabel="emr-7.14.0-latest", sessionIdleTimeoutInMinutes=...)`
+2. `describe_managed_endpoint` → poll to `ACTIVE`, read **`endpoint.authProxyUrl`**
+3. `get_managed_endpoint_session_credentials(credentialType="TOKEN", durationInSeconds=43200)` → `credentials.token`
+4. `sc://{authProxyUrl}:443/;use_ssl=true;x-aws-proxy-auth={token}`
+
+Four details differ from the other backends and are easy to get wrong:
+
+| Detail | Correct value |
+|---|---|
+| Endpoint host | `endpoint.authProxyUrl` — **not** `serverUrl` |
+| Token API cluster param | `virtualClusterIdentifier` — **not** `virtualClusterId` (that name is a `ParamValidationError`) |
+| Endpoint lifetime | Ephemeral. Expires after `sessionIdleTimeoutInMinutes` |
+| Session API | There isn't one. `emr-containers` has no `StartSession`/`GetSession`/`TerminateSession` |
+
+### No session API — the managed endpoint is the resource
+
+`emr-containers` exposes no `StartSession`, `GetSession`, or `TerminateSession`
+(verified against the botocore service model; the only session-shaped operation is
+`GetManagedEndpointSessionCredentials`, which returns an *already-active* token).
+So on EKS there is nothing to start and no session state to poll: the managed
+endpoint is the entire remote resource. That is why the abstract method is
+`provision()` rather than `start_session()` — Serverless/EC2 implement it with the
+real `StartSession`, and EKS implements it as reuse-or-create of the endpoint.
+Verified: `EKSSessionManager.provision()` touches only `CreateManagedEndpoint`, and
+a full connect/refresh/stop cycle calls exactly `CreateManagedEndpoint`,
+`DescribeManagedEndpoint`, `GetManagedEndpointSessionCredentials`, and
+`DeleteManagedEndpoint`.
+
+### Two layers, two independent timeouts
+
+Serverless and EC2 are **session-based**: `StartSession` creates a session and
+`GetSessionEndpoint` returns both URL and token, so there is no endpoint resource
+that expires separately. Only the token expires, and the interceptor refreshes it
+against the same session — which is why `ensure_endpoint()` is a no-op on those
+backends (verified: zero API calls).
+
+EMR on EKS has two layers, nested rather than parallel — a token is only valid
+against the endpoint it was minted for, so it cannot outlive its endpoint:
+
+| Layer | Lifetime | Renewed by |
+|---|---|---|
+| Managed endpoint (the only resource) | `sessionIdleTimeoutInMinutes` (`CreateManagedEndpoint`) | Creating a new endpoint |
+| Session token (minted against it, active on return) | `durationInSeconds` (`GetManagedEndpointSessionCredentials`, default 15 min / max 12 h) | Minting a new token |
+
+Which layer expired decides what is rebuilt:
+
+- **Token only, endpoint `ACTIVE`** → mint a new token against the same endpoint.
+  Host unchanged, channel survives. Same shape as Serverless/EC2.
+- **Endpoint expired** → create a new endpoint, *then* mint a token against it.
+  Routine, not an error. Applies equally to an endpoint passed in as
+  `managed_endpoint_id`.
+
+`EKSSessionManager.ensure_endpoint()` is the single place that reuse-or-replace
+decision is made, and `provision()`, `get_endpoint_and_token()`, and
+`reconnect()` all route through it, so a token is never minted against a dead
+endpoint. The residual manual step is the gRPC channel: a replacement endpoint has a
+new `authProxyUrl`, and an interceptor can only rewrite a header, so `refresh_token()`
+creates the replacement and then raises `EndpointExpiredError` to tell the caller to
+`reconnect()`.
+
+Verification status: the API contract (parameter names, config shape, URL construction,
+and the absence of any session operation on `emr-containers`) is verified against the
+botocore service model and via mocked clients, covering both layers — token-only
+refresh reusing a live endpoint (1 create across 3 mints), endpoint expiry creating
+the replacement before signalling, expired and live caller-supplied endpoints,
+`CREATING` reuse, one `DescribeManagedEndpoint` per mint, and endpoint-ownership
+delete semantics. Serverless/EC2 were re-checked to confirm they still call the real
+`StartSession`, skip the endpoint layer entirely, and only mint tokens against the
+existing session. A live end-to-end run against a virtual cluster with an ALB-fronted
+endpoint has **not** been done — `test_emreks.py` is the script for it.
+
+## Not Yet Tested
+- **Token refresh past the 1-hour mark** — verified the interceptor installs and schedules correctly; a long-running session test (>60 min) would confirm end-to-end refresh.
+- **Spark configuration overrides** — the `spark_conf` parameter is wired through to the APIs but not explicitly tested.
+- **Context manager** (`with EMRSparkSession.create(...) as session:`) — code path exists but not explicitly tested in isolation.
+
+---
+
+## Prerequisites for Reproduction
+
+### EMR Serverless
+- Application with `sessionEnabled: true` on `emr-7.13.0+`
+- Execution role trusted by `emr-serverless.amazonaws.com`
+- IAM permissions: `emr-serverless:StartSession`, `GetSession`, `GetSessionEndpoint`, `TerminateSession`
+
+### EMR on EC2
+- Cluster on `emr-spark-8.0.0+` created with `--session-enabled`
+- Cluster in `WAITING` or `RUNNING` state
+- VPC/subnet tagged `for-use-with-amazon-emr-managed-policies=true` (for private subnet clusters)
+- IAM permissions: `elasticmapreduce:StartSession`, `GetSession`, `GetSessionEndpoint`, `TerminateSession`
+- **boto3 >= 1.43.72** (earlier versions don't have the EMR session APIs)
+
+### EMR on EKS
+- Virtual cluster in `RUNNING` state on a release supporting `SPARK_CONNECT` managed endpoints
+- Job execution role trusted by EMR on EKS
+- AWS Load Balancer Controller on the EKS cluster (the endpoint is ALB-fronted), and network reachability from the client to that ALB
+- IAM permissions: `emr-containers:CreateManagedEndpoint`, `DescribeManagedEndpoint`, `DeleteManagedEndpoint`, `GetManagedEndpointSessionCredentials` — note there is no session permission to grant, because there is no session API
+
+### Local Environment
+- Python 3.9+
+- `pip install emr-spark-connect` (or `pip install -e .` from source)
+- AWS credentials configured

--- a/utilities/emr-spark-connect-client/examples/basic_usage.py
+++ b/utilities/emr-spark-connect-client/examples/basic_usage.py
@@ -1,0 +1,50 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: MIT-0
+"""Basic example: Connect to EMR Serverless and run SQL queries.
+
+Prerequisites:
+    pip install emr-spark-connect
+
+    An EMR Serverless application with sessionEnabled=true (emr-7.13.0+):
+    aws emr-serverless create-application \
+        --type SPARK \
+        --name my-spark-connect-app \
+        --release-label emr-7.13.0 \
+        --interactive-configuration '{"sessionEnabled": true}'
+"""
+
+from emr_spark_connect import EMRSparkSession
+
+# Replace with your values
+APPLICATION_ID = "00abcdef01234567"
+EXECUTION_ROLE = "arn:aws:iam::123456789012:role/EMRServerlessRole"
+REGION = "us-east-1"
+
+# Create a session — auto-detects EMR Serverless from the application ID format
+session = EMRSparkSession.create(
+    resource_id=APPLICATION_ID,
+    execution_role_arn=EXECUTION_ROLE,
+    region=REGION,
+)
+
+try:
+    # Run SQL
+    print("Spark version:", session.spark.version)
+    session.sql("SELECT 1 + 1 AS result").show()
+
+    # DataFrame operations
+    from pyspark.sql.functions import col
+
+    df = session.createDataFrame(
+        [(1, "Alice"), (2, "Bob"), (3, "Charlie")],
+        ["id", "name"],
+    )
+    df.filter(col("id") > 1).show()
+
+    # Read from S3
+    # df = session.read.parquet("s3://my-bucket/my-data/")
+    # df.groupBy("category").count().show()
+
+finally:
+    session.stop()
+    print("Session terminated.")

--- a/utilities/emr-spark-connect-client/examples/context_manager.py
+++ b/utilities/emr-spark-connect-client/examples/context_manager.py
@@ -1,0 +1,43 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: MIT-0
+"""Example: Using EMRSparkSession as a context manager.
+
+The context manager automatically stops the SparkSession and terminates
+the EMR session on exit — even if an exception occurs.
+"""
+
+from emr_spark_connect import EMRSparkSession
+from pyspark.sql import functions as F
+
+APPLICATION_ID = "00abcdef01234567"
+EXECUTION_ROLE = "arn:aws:iam::123456789012:role/EMRServerlessRole"
+
+with EMRSparkSession.create(
+    resource_id=APPLICATION_ID,
+    execution_role_arn=EXECUTION_ROLE,
+    region="us-east-1",
+    spark_conf={
+        "spark.executor.memory": "4g",
+        "spark.executor.cores": "2",
+        "spark.dynamicAllocation.enabled": "true",
+    },
+) as session:
+    # All standard PySpark operations work
+    df = session.read.parquet("s3://my-bucket/events/")
+
+    # Filter, aggregate, write
+    result = (
+        df.filter(F.col("event_date") >= "2024-01-01")
+        .groupBy("event_type")
+        .agg(
+            F.count("*").alias("event_count"),
+            F.countDistinct("user_id").alias("unique_users"),
+        )
+        .orderBy(F.desc("event_count"))
+    )
+
+    result.show(20)
+    result.write.mode("overwrite").parquet("s3://my-bucket/reports/event_summary/")
+
+# Session is automatically cleaned up here
+print("Done! Session terminated.")

--- a/utilities/emr-spark-connect-client/examples/emr_ec2_example.py
+++ b/utilities/emr-spark-connect-client/examples/emr_ec2_example.py
@@ -1,0 +1,43 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: MIT-0
+"""Example: Connect to an EMR on EC2 cluster with Spark Connect.
+
+Prerequisites:
+    pip install emr-spark-connect
+
+    An EMR cluster with sessions enabled (emr-spark-8.0.0+):
+    aws emr create-cluster \
+        --release-label emr-spark-8.0.0 \
+        --applications Name=Spark \
+        --session-enabled \
+        --instance-groups '[
+          {"InstanceCount":1,"InstanceGroupType":"MASTER","InstanceType":"m5.xlarge"},
+          {"InstanceCount":2,"InstanceGroupType":"CORE","InstanceType":"m5.xlarge"}
+        ]' \
+        --service-role EMR_DefaultRole \
+        --ec2-attributes InstanceProfile=EMR_EC2_DefaultRole
+"""
+
+from emr_spark_connect import EMRSparkSession
+
+CLUSTER_ID = "j-3HXXXXXX8RG0E"
+REGION = "us-west-2"
+
+# EMR on EC2 — execution_role_arn is optional (for runtime role sessions)
+session = EMRSparkSession.create(
+    resource_id=CLUSTER_ID,
+    region=REGION,
+    session_name="my-analytics-session",
+    idle_timeout_minutes=120,
+)
+
+try:
+    session.sql("SHOW DATABASES").show()
+    session.sql("SELECT current_timestamp() AS now").show()
+
+    # DataFrame operations
+    df = session.range(1000)
+    df.selectExpr("id", "id * id as squared").show(5)
+
+finally:
+    session.stop()

--- a/utilities/emr-spark-connect-client/examples/emr_eks_example.py
+++ b/utilities/emr-spark-connect-client/examples/emr_eks_example.py
@@ -1,0 +1,83 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: MIT-0
+"""Example: Connect to EMR on EKS and handle managed endpoint expiry.
+
+EMR on EKS has no session API — emr-containers exposes no StartSession, and
+GetManagedEndpointSessionCredentials returns an already-active token. The
+SPARK_CONNECT managed endpoint is the entire remote resource, so session.session_id
+here is a managed endpoint ID.
+
+Prerequisites:
+    An EMR on EKS virtual cluster in RUNNING state, a job execution role, and
+    the AWS Load Balancer Controller on the EKS cluster — the SPARK_CONNECT
+    managed endpoint is fronted by an ALB, which this machine must be able to
+    reach.
+
+The equivalent manual setup via the AWS CLI would be:
+
+    aws emr-containers create-managed-endpoint \
+        --type SPARK_CONNECT \
+        --virtual-cluster-id <VC_ID> \
+        --name spark-connect-demo \
+        --execution-role-arn arn:aws:iam::123456789012:role/EMRonEKSExecutionRole \
+        --release-label emr-7.14.0-latest \
+        --session-idle-timeout-in-minutes 60
+
+    aws emr-containers get-managed-endpoint-session-credentials \
+        --virtual-cluster-identifier <VC_ID> \
+        --endpoint-identifier <ENDPOINT_ID> \
+        --execution-role-arn arn:aws:iam::123456789012:role/EMRonEKSExecutionRole \
+        --credential-type TOKEN \
+        --duration-in-seconds 43200
+
+EMRSparkSession.create() does all of that, plus polling the endpoint to ACTIVE
+and building the sc://{authProxyUrl}:443 connection.
+"""
+
+from emr_spark_connect import EMRSparkSession, EndpointExpiredError
+
+# Replace with your values
+VIRTUAL_CLUSTER_ID = "YOUR_VIRTUAL_CLUSTER_ID"
+EXECUTION_ROLE = "arn:aws:iam::123456789012:role/EMRonEKSExecutionRole"
+
+# One call does three steps:
+#   1. create the endpoint (CreateManagedEndpoint) or reuse a live one
+#   2. mint a token (GetManagedEndpointSessionCredentials)
+#   3. connect to Spark Connect at sc://{authProxyUrl}:443
+session = EMRSparkSession.create(
+    resource_id=VIRTUAL_CLUSTER_ID,
+    execution_role_arn=EXECUTION_ROLE,
+    idle_timeout_minutes=10,
+    token_duration_seconds=900,
+    spark_conf={
+        "spark.dynamicAllocation.minExecutors": "0",
+        "spark.dynamicAllocation.enabled": "true",
+        "spark.kubernetes.node.selector.topology.kubernetes.io/zone": "us-west-2a"
+    },
+    # Reuse an existing ACTIVE endpoint (skips the multi-minute ALB creation):
+    # managed_endpoint_id="YOUR_ENDPOINT_ID",
+)
+
+try:
+    print("Managed endpoint:", session.session_id)
+    print("Spark version:", session.spark.version)
+
+    session.sql("SELECT 1 + 1 AS result").show()
+
+    # The endpoint and its tokens expire on separate timers. While the endpoint is
+    # ACTIVE, token expiry is handled in place — a new token is minted against the
+    # same endpoint and comes back ready to use, so you never see it. When the
+    # endpoint itself times out, the client creates a replacement automatically —
+    # but that replacement has a brand new Spark driver, so the open channel has to be rebuilt.
+    try:
+        session.sql("SELECT current_timestamp() AS now").show()
+    except EndpointExpiredError:
+        print("Endpoint expired — replacement created, reattaching")
+        session.reconnect()
+        # The replacement is a new Spark driver: temp views and cached
+        # DataFrames from before are all gone
+        session.sql("SELECT current_timestamp() AS now").show()
+
+finally:
+    # Stop the Spark session, keep the endpoint alive until idle timeout
+    session.stop(terminate=False)

--- a/utilities/emr-spark-connect-client/examples/long_running_session.py
+++ b/utilities/emr-spark-connect-client/examples/long_running_session.py
@@ -1,0 +1,34 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: MIT-0
+"""Example: Long-running session demonstrating automatic token refresh.
+
+This example runs queries over a period longer than the 1-hour token TTL.
+The token refresh interceptor handles this transparently — no code changes needed.
+"""
+
+import logging
+import time
+
+from emr_spark_connect import EMRSparkSession
+
+# Enable logging to observe token refreshes
+logging.basicConfig(level=logging.INFO)
+logging.getLogger("emr_spark_connect").setLevel(logging.DEBUG)
+
+APPLICATION_ID = "00abcdef01234567"
+EXECUTION_ROLE = "arn:aws:iam::123456789012:role/EMRServerlessRole"
+REGION = "us-east-1"
+
+with EMRSparkSession.create(
+    resource_id=APPLICATION_ID,
+    execution_role_arn=EXECUTION_ROLE,
+    region=REGION,
+    idle_timeout_minutes=180,  # 3 hours
+) as session:
+    # Run queries periodically for > 1 hour
+    # The token auto-refreshes transparently
+    for i in range(90):  # Run for ~90 minutes
+        result = session.sql(f"SELECT {i} AS iteration, current_timestamp() AS ts")
+        result.show()
+        print(f"Iteration {i} complete at minute ~{i}")
+        time.sleep(60)  # Wait 1 minute between queries

--- a/utilities/emr-spark-connect-client/examples/simple_demo.ipynb
+++ b/utilities/emr-spark-connect-client/examples/simple_demo.ipynb
@@ -1,0 +1,364 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# EMR Spark Connect Client Wrapper — supports all deployment models\n",
+    "\n",
+    "`EMRSparkSession` connects a local PySpark process to a remote Spark driver over\n",
+    "[Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html) on\n",
+    "`EMR Serverless, EMR on EC2, and EMR on EKS`. The three flavors expose\n",
+    "quite different APIs; this wrapper hides that behind a single `create()` call and\n",
+    "keeps the connection's auth token fresh for as long as the notebook lives.\n",
+    "\n",
+    "| | EMR Serverless | EMR on EC2 | EMR on EKS |\n",
+    "|---|---|---|---|\n",
+    "| `resource_id` | application ID<br>`00abcdef01234567` | cluster ID<br>`j-XXXXXXXXXXXXX` | virtual cluster ID<br>`m123456789abcdefg` |\n",
+    "| boto3 client | emr-serverless | emr | emr-containers |\n",
+    "| Remote resource | session | session | **managed endpoint** |\n",
+    "| Provisioned by | `StartSession` | `StartSession` | `CreateManagedEndpoint` |\n",
+    "| `execution_role_arn` | required | optional | required |\n",
+    "| `session.session_id` | session ID | session ID | managed endpoint ID |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c257a645",
+   "metadata": {},
+   "source": [
+    "### ⚠️ The PySpark version must match EMR Spark's major version\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b7379d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the followings via terminal from the REPO ROOT (one level up from examples/)\n",
+    "# to create two kernels. The kernels are registered globally with absolute paths,\n",
+    "# so this notebook works from examples/ (or anywhere) once they exist.\n",
+    "#\n",
+    "# Kernel A — EMR Serverless + EMR on EKS (Spark 3.5.x)\n",
+    "# python -m venv .venv-spark35\n",
+    "# ./.venv-spark35/bin/python -m pip install -e . \"pyspark[connect]>=3.5.6,<4\" \"boto3>=1.43.72\" ipykernel\n",
+    "# ./.venv-spark35/bin/python -m ipykernel install --user --name spark35 --display-name \"EMR (Spark 3.5)\"\n",
+    "#\n",
+    "# Kernel B — EMR on EC2 (Spark 4.0.2)\n",
+    "# python -m venv .venv-spark40\n",
+    "# ./.venv-spark40/bin/python -m pip install -e . \"pyspark[connect]==4.0.2\" \"boto3>=1.43.72\" ipykernel\n",
+    "# ./.venv-spark40/bin/python -m ipykernel install --user --name spark40 --display-name \"EMR (Spark 4.0)\"\n",
+    "\n",
+    "#  ./.venv-spark35/bin/python -m jupyter kernelspec list\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ff18c40",
+   "metadata": {},
+   "source": [
+    "## 1. EMR on EC2 test on kernel EMR(Spark4.0)\n",
+    "Prerequisites:\n",
+    "- `a Spark-only cluster` with sessions enabled (emr-spark-8.0.0+, Spark 4.0.2)\n",
+    "- `execution_role_arn\" is OPTIONAL` — supply it only for runtime-role sessions.\n",
+    "- The Spark Connect URL carries an extra `authorization={session_id}` parameter, which the wrapper adds for you."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42853180",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os;os.environ[\"AWS_PROFILE\"] = \"default\"\n",
+    "from emr_spark_connect import EMRSparkSession\n",
+    "session = EMRSparkSession.create(\n",
+    "        resource_id=\"j-1K48XXXXXXHCB\",\n",
+    "        execution_role_arn=\"arn:aws:iam::123456789012:role/EMR_RuntimeRole_001\",\n",
+    "        idle_timeout_minutes=1\n",
+    "    )\n",
+    "# validate the remote connection\n",
+    "session.range(5).selectExpr(\"id\", \"id * id AS squared\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e83343f3",
+   "metadata": {},
+   "source": [
+    "### Test the idle timeout with EMR-EC2\n",
+    "- the remote session is gone — recreate() starts a new one.\n",
+    "- A new session is a new Spark driver: temp views and cached DataFrames are gone."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f52e3e96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not session.is_active():\n",
+    "    old = session.session_id\n",
+    "    print(f\"session {old} is {session.session_state()}\")\n",
+    "    session.recreate()       # same settings, brand-new session\n",
+    "    print(f\"recreated {old} -> {session.session_id}\")\n",
+    "\n",
+    "print(f\"spark version  {session.spark.version}\")\n",
+    "session.range(5).selectExpr(\"id\", \"id * id AS squared\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f6e3031",
+   "metadata": {},
+   "source": [
+    "## 2. EMR Serverless test on another kernel - EMR(Spark 3.5)\n",
+    "\n",
+    "Prerequisites:\n",
+    "- an application has interactive sessions enabled (EMR 7.13.0+, Spark 3.5.6+)\n",
+    "- a job execution role"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98888acd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os;os.environ[\"AWS_PROFILE\"] = \"default\"\n",
+    "from emr_spark_connect import EMRSparkSession\n",
+    "\n",
+    "serverless_session = EMRSparkSession.create(\n",
+    "    resource_id=\"00abcdef01234567\",\n",
+    "    execution_role_arn=\"arn:aws:iam::123456789012:role/EMRServerlessS3RuntimeRole\",\n",
+    "    idle_timeout_minutes=1\n",
+    ")\n",
+    "# validate the remote connection\n",
+    "serverless_session.range(5).selectExpr(\"id\", \"id * id AS squared\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0af09a4a",
+   "metadata": {},
+   "source": [
+    "### Test the idle timeout with EMR Serverless\n",
+    "- the remote session is gone — recreate() starts a new one.\n",
+    "- A new session is a new Spark driver: temp views and cached DataFrames are gone."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9450219f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not serverless_session.is_active():\n",
+    "    old = serverless_session.session_id\n",
+    "    print(f\"session {old} is {serverless_session.session_state()}\")\n",
+    "    serverless_session.recreate()       # same settings, brand-new session\n",
+    "    print(f\"recreated {old} -> {serverless_session.session_id}\")\n",
+    "    \n",
+    "print(f\"spark version  {serverless_session.spark.version}\")\n",
+    "serverless_session.range(5).selectExpr(\"id\", \"id * id AS squared\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5dd3e3e",
+   "metadata": {},
+   "source": [
+    "## 3. EMR on EKS\n",
+    "Prerequisites: \n",
+    "- 1/ a Virtual Cluster (EMR 7.14.0+, Spark 3.5.8+) with session enabled\n",
+    "- 2/ a security configuration is attached to VC\n",
+    "- 3/ a job execution role\n",
+    "- 4/ an AWS Load Balancer Controller installed on the EKS cluster\n",
+    "\n",
+    "EMR on EKS specific parameters: \n",
+    "- managed_endpoint_id/release_label, token_duration_seconds, application_configuration, monitoring_configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e35e67e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os;os.environ[\"AWS_PROFILE\"] = \"default\"\n",
+    "from emr_spark_connect import EMRSparkSession\n",
+    "\n",
+    "eks_session = EMRSparkSession.create(\n",
+    "    resource_id=\"m123456789abcdefghijk\",\n",
+    "    execution_role_arn=\"arn:aws:iam::123456789012:role/emr-on-eks-execution-role\",\n",
+    "    idle_timeout_minutes=1,\n",
+    "    spark_conf={\n",
+    "        # avoid cross-AZ data traffic\n",
+    "        \"spark.kubernetes.node.selector.topology.kubernetes.io/zone\": \"us-west-2a\"\n",
+    "    },\n",
+    "    # Optional control-plane override (e.g. a beta endpoint):\n",
+    "    # endpoint_url=\"https://emr-containers-beta...\",\n",
+    ")\n",
+    "\n",
+    "# validate the remote connection\n",
+    "print(f\"session id  {eks_session.session_id}\")\n",
+    "print(f\"spark version  {eks_session.spark.version}\")\n",
+    "eks_session.range(5).selectExpr(\"id\", \"id * id AS squared\").show()\n",
+    "old_endpoint = eks_session.session_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2dc81d09",
+   "metadata": {},
+   "source": [
+    "### Which timer ran out: token or endpoint?\n",
+    "\n",
+    "EMR on EKS is the only backend where \"it stopped working\" is ambiguous, because two things expire on **independent clocks**:\n",
+    "\n",
+    "| Layer | `create()` argument | API name | Lifetime | Renewed by |\n",
+    "|---|---|---|---|---|\n",
+    "| Managed endpoint | `idle_timeout_minutes` | `sessionIdleTimeoutInMinutes` | max 24h | `CreateManagedEndpoint` — a *new* endpoint, on a *new* host |\n",
+    "| Session token | `token_duration_seconds` | `durationInSeconds` | max 12h | `GetManagedEndpointSessionCredentials` against the *same* endpoint |\n",
+    "\n",
+    "Two calls tell them apart:\n",
+    "\n",
+    "| Check | Cost | Meaning when True |\n",
+    "|---|---|---|\n",
+    "| `is_token_expired()` | local — compares the recorded `expiresAt` | token lapsed. **Nothing to do** — the gRPC interceptor remints on the next call, same endpoint, same Spark driver |\n",
+    "| `not is_endpoint_active()` | one `DescribeManagedEndpoint` call | endpoint hit its idle timeout — call `reconnect()` to attach to a replacement |\n",
+    "\n",
+    "Note: with `token_duration_seconds` below 300 the token is always inside the interceptor's five-minute early-refresh window, so it is reminted on every single gRPC call — which is why a lapsed token is hard to observe in practice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21411c67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from emr_spark_connect import EndpointExpiredError\n",
+    "\n",
+    "if not eks_session.is_endpoint_active():\n",
+    "     print(\"Managed endpoint idled out, reconnecting to a replacement ...\")                                              \n",
+    "     eks_session.reconnect()\n",
+    "     print(f\"endpoint replaced {old_endpoint} -> {eks_session.session_id}\")\n",
+    "if eks_session.is_token_expired():\n",
+    "     print(f\"token     duration = {eks_session.token_duration_seconds}s  \"\n",
+    "       f\"remaining = {eks_session.token_seconds_remaining():.0f}s  \"\n",
+    "       f\"expired = {eks_session.is_token_expired()}\")\n",
+    "     print(\"\\nToken lapsed, the interceptor remints it on the next call ...\")\n",
+    "try:\n",
+    "    eks_session.range(5).selectExpr(\"id\", \"id * id AS squared\").show()\n",
+    "except (EndpointExpiredError) as e:\n",
+    "    print(\"\\nManaged endpoint idled out, reconnecting to a replacement ...\")\n",
+    "    eks_session.reconnect()\n",
+    "    print(f\"endpoint replaced {old_endpoint} -> {eks_session.session_id}\")\n",
+    "    # A new Spark driver\n",
+    "    eks_session.range(5).selectExpr(\"id\", \"id * id AS squared\").show()\n",
+    "\n",
+    "# stop Spark session, keep the endpoint alive until idle timeout\n",
+    "active_endpoint = eks_session.session_id\n",
+    "# eks_session.stop(terminate=False)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48479f3d",
+   "metadata": {},
+   "source": [
+    "### Reconnect with a managed endpoint id\n",
+    "\n",
+    "| Scenario | Action |\n",
+    "|---|---|\n",
+    "| Pass in an `ACTIVE` endpoint (`managed_endpoint_id` set) | reuse |\n",
+    "| Pass in an invalid endpoint (`EXPIRED` or `TERMINATED`) | create a new |\n",
+    "| `managed_endpoint_id` = None (default) | create a new |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88676c7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from emr_spark_connect import EMRSparkSession\n",
+    "reuse_session = EMRSparkSession.create(\n",
+    "    resource_id=\"m123456789abcdefghijk\",\n",
+    "    execution_role_arn=\"arn:aws:iam::123456789012:role/emr-on-eks-execution-role\",\n",
+    "    # Active EP\n",
+    "    managed_endpoint_id=active_endpoint,\n",
+    ")\n",
+    "# validate the remote connection\n",
+    "print(f\"session_id     {reuse_session.session_id}\")\n",
+    "reuse_session.range(5).selectExpr(\"id\", \"id * id AS squared\").show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "926c0e96",
+   "metadata": {},
+   "source": [
+    "### Endpoint expired: pass in an expired endpoint id\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "201be032",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expired_session = EMRSparkSession.create(\n",
+    "    resource_id=\"m123456789abcdefghijk\",\n",
+    "    execution_role_arn=\"arn:aws:iam::123456789012:role/emr-on-eks-execution-role\",\n",
+    "    idle_timeout_minutes=1,\n",
+    "    spark_conf={\n",
+    "        \"spark.dynamicAllocation.minExecutors\": \"0\",\n",
+    "        \"spark.dynamicAllocation.enabled\": \"true\"\n",
+    "    },\n",
+    "    # expired endpoint, create a new\n",
+    "    managed_endpoint_id=\"xxxxxxxxxxxxx\",\n",
+    ")\n",
+    "print(f\"session_id     {expired_session.session_id}\")\n",
+    "print(f\"spark version  {expired_session.spark.version}\")\n",
+    "expired_session.range(5).selectExpr(\"id\", \"id * id AS squared\").show()\n",
+    "\n",
+    "# stop Spark session\n",
+    "# terminate the managed endpoint before its idle timeout\n",
+    "expired_session.stop(terminate=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "EMR (Spark 3.5)",
+   "language": "python",
+   "name": "spark35"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/utilities/emr-spark-connect-client/pyproject.toml
+++ b/utilities/emr-spark-connect-client/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "emr-spark-connect"
+version = "0.1.0"
+description = "Unified SparkConnect client for EMR Serverless, EMR on EKS, and EMR on EC2 with automatic token refresh"
+readme = "README.md"
+license = "MIT-0"
+requires-python = ">=3.9"
+authors = [
+    { name = "Amazon Web Services" },
+]
+keywords = ["emr", "spark", "spark-connect", "aws", "pyspark"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "boto3>=1.43.72",
+    "grpcio>=1.43.0",
+    "pyspark[connect]>=3.5.6",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "moto>=4.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/aws-samples/aws-emr-utilities/tree/main/utilities/emr-spark-connect-client"
+Documentation = "https://github.com/aws-samples/aws-emr-utilities/tree/main/utilities/emr-spark-connect-client#readme"
+Issues = "https://github.com/aws-samples/aws-emr-utilities/issues"

--- a/utilities/emr-spark-connect-client/src/emr_spark_connect/__init__.py
+++ b/utilities/emr-spark-connect-client/src/emr_spark_connect/__init__.py
@@ -1,0 +1,9 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: MIT-0
+"""EMR Spark Connect — unified client for EMR Serverless, EMR on EKS, and EMR on EC2."""
+
+from .backends import EndpointExpiredError
+from .session import EMRSparkSession
+
+__all__ = ["EMRSparkSession", "EndpointExpiredError"]
+__version__ = "0.1.0"

--- a/utilities/emr-spark-connect-client/src/emr_spark_connect/backends.py
+++ b/utilities/emr-spark-connect-client/src/emr_spark_connect/backends.py
@@ -1,0 +1,1076 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: MIT-0
+"""Backend-specific session managers for EMR Serverless, EMR on EKS, and EMR on EC2.
+
+Each backend handles:
+- Resource lifecycle (provision, wait, get endpoint, release)
+- Token refresh (returns token + expiry for the interceptor)
+- Resource ID detection (which backend to use based on ID format)
+
+Note that "session" is a Serverless/EC2 concept. Those services have a session
+API (``StartSession`` / ``GetSession`` / ``GetSessionEndpoint`` /
+``TerminateSession``). ``emr-containers`` does not: EMR on EKS has only the
+``SPARK_CONNECT`` managed endpoint, and ``GetManagedEndpointSessionCredentials``
+returns an already-active token against it, so there is no session to start or
+poll. `BaseSessionManager.provision` covers both shapes.
+"""
+
+from __future__ import annotations
+
+import abc
+import datetime
+import logging
+import re
+import threading
+import time
+import warnings
+from typing import Any, Dict, List, Optional, Tuple
+
+import boto3
+
+logger = logging.getLogger("emr_spark_connect.backends")
+
+
+# ---------------------------------------------------------------------------
+# Resource ID patterns for auto-detection
+# ---------------------------------------------------------------------------
+# EMR Serverless application IDs: 16 alphanumeric chars starting with "00"
+# e.g., 00abcdef01234567
+_EMRS_APP_ID_RE = re.compile(r"^00[a-z0-9]{14}$")
+# EMR on EC2 cluster IDs: start with j- followed by alphanumeric chars
+# e.g., j-3HABCDEF8RG0E, j-08396852YQHF5PD3YGSX
+_EMR_EC2_CLUSTER_ID_RE = re.compile(r"^j-[A-Z0-9]{10,20}$")
+# EMR on EKS virtual cluster IDs: 20-25 lowercase alphanumeric chars (not starting with "00")
+_EMR_EKS_VC_ID_RE = re.compile(r"^[a-z0-9]{20,25}$")
+
+
+def detect_backend(resource_id: str) -> str:
+    """Detect the EMR backend type from the resource ID format.
+
+    Returns:
+        One of 'serverless', 'ec2', or 'eks'.
+
+    Raises:
+        ValueError: If the resource ID format is not recognized.
+    """
+    if _EMR_EC2_CLUSTER_ID_RE.match(resource_id):
+        return "ec2"
+    if _EMRS_APP_ID_RE.match(resource_id):
+        return "serverless"
+    if _EMR_EKS_VC_ID_RE.match(resource_id):
+        return "eks"
+    raise ValueError(
+        f"Cannot detect EMR backend from resource_id '{resource_id}'. "
+        "Expected EMR Serverless application ID (16 chars starting with '00'), "
+        "EMR on EC2 cluster ID (j-XXXXXXXXXXXX), or "
+        "EMR on EKS virtual cluster ID (20-25 alphanumeric chars)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Abstract base class
+# ---------------------------------------------------------------------------
+class BaseSessionManager(abc.ABC):
+    """Abstract manager for the remote resource backing a Spark Connect session.
+
+    The two backend families are shaped differently, and the abstraction here is
+    deliberately neutral about which one you get.
+
+    **EMR Serverless and EMR on EC2 are session-based.** ``StartSession`` creates
+    a session resource, ``GetSessionEndpoint`` returns both its URL and a fresh
+    auth token, and ``TerminateSession`` ends it. There is no endpoint resource
+    with a lifetime of its own — the endpoint host is a property of the session —
+    so the only thing that expires is the token, and refreshing means minting a
+    new one against the same session.
+
+    **EMR on EKS has no session API at all.** ``emr-containers`` exposes no
+    ``StartSession``/``GetSession``/``TerminateSession``; the only resource is the
+    ``SPARK_CONNECT`` *managed endpoint*, and ``GetManagedEndpointSessionCredentials``
+    hands back an already-active token against it. Nothing needs to be started
+    and no session state needs polling — see `EKSSessionManager`.
+
+    So `provision` means "make the remote resource exist and be usable", which is
+    ``StartSession`` for the session-based backends and endpoint reuse-or-create
+    for EKS. `session_id` is correspondingly the session ID or the managed
+    endpoint ID.
+    """
+
+    def __init__(
+        self,
+        resource_id: str,
+        region: str,
+        execution_role_arn: Optional[str] = None,
+        session_name: str = "emr-spark-connect",
+        idle_timeout_minutes: int = 60,
+        max_wait_seconds: int = 900,
+        spark_conf: Optional[Dict[str, str]] = None,
+        endpoint_url: Optional[str] = None,
+        boto3_session: Optional[boto3.Session] = None,
+    ):
+        self.resource_id = resource_id
+        self.region = region
+        self.execution_role_arn = execution_role_arn
+        self.session_name = session_name
+        self.idle_timeout_minutes = idle_timeout_minutes
+        self.max_wait_seconds = max_wait_seconds
+        self.spark_conf = spark_conf or {}
+        self.endpoint_url = endpoint_url
+        self._boto3_session = boto3_session or boto3.Session()
+        self._session_id: Optional[str] = None
+        self._client: Any = None
+        # Expiry of the token currently on the wire, recorded by
+        # get_endpoint_and_token. None until the first token is minted.
+        self._token_expires_at: Optional[datetime.datetime] = None
+
+    @property
+    def session_id(self) -> Optional[str]:
+        """Session ID (Serverless/EC2) or managed endpoint ID (EKS)."""
+        return self._session_id
+
+    @abc.abstractmethod
+    def _create_client(self) -> Any:
+        """Create the boto3 client for this backend."""
+
+    @abc.abstractmethod
+    def provision(self) -> str:
+        """Make the remote resource exist and be usable. Returns its ID.
+
+        ``StartSession`` for the session-based backends; reuse-or-create of the
+        managed endpoint for EMR on EKS, which has no session API.
+        """
+
+    @abc.abstractmethod
+    def wait_for_ready(self) -> None:
+        """Wait until the remote resource can accept connections."""
+
+    @abc.abstractmethod
+    def get_endpoint_and_token(self) -> Tuple[str, str, datetime.datetime]:
+        """Get endpoint URL, auth token, and token expiry time."""
+
+    @abc.abstractmethod
+    def terminate_session(self) -> None:
+        """Release the remote resource."""
+
+    # States in which a session-based backend can still accept work. Shared by
+    # Serverless and EC2, which use the same vocabulary.
+    _SESSION_READY_STATES: Tuple[str, ...] = ("READY", "IDLE", "STARTED", "RUNNING", "BUSY")
+
+    def ensure_endpoint(self, wait: bool = True) -> bool:
+        """Guarantee a usable *endpoint* exists, creating one if it expired.
+
+        No-op for EMR Serverless and EMR on EC2: their endpoint is a property of
+        the session rather than a resource of its own, so it cannot expire
+        separately and there is nothing to ensure — a token is simply minted
+        against the existing session. `EKSSessionManager` overrides this.
+
+        Returns:
+            True if a new endpoint was created, False if an existing one is
+            being reused (always False for the session-based backends).
+        """
+        return False
+
+    def is_endpoint_active(self) -> bool:
+        """Whether the endpoint is live.
+
+        Always True for the session-based backends — their endpoint lives exactly
+        as long as the session, so it never expires out from under them.
+        """
+        return True
+
+    # -- token liveness -----------------------------------------------------
+    # Separate from endpoint/session liveness on purpose. On EMR on EKS the two
+    # run on independent timers, so "it stopped working" has two distinct causes
+    # and only these methods can tell them apart. See `EKSSessionManager`.
+
+    @property
+    def token_expires_at(self) -> Optional[datetime.datetime]:
+        """When the token currently on the wire expires, or None if none yet.
+
+        Recorded by `get_endpoint_and_token` each time a token is minted, so it
+        tracks the token the interceptor is actually sending — not the token this
+        session started with.
+        """
+        return self._token_expires_at
+
+    @property
+    def token_duration_seconds(self) -> Optional[int]:
+        """Requested token lifetime, or None if the backend does not accept one.
+
+        Only EMR on EKS does: ``durationInSeconds`` on
+        ``GetManagedEndpointSessionCredentials``. Serverless and EC2 mint tokens
+        with a service-chosen lifetime that the client cannot influence.
+        """
+        return None
+
+    def token_seconds_remaining(self) -> Optional[float]:
+        """Seconds until the current token expires; negative once it has.
+
+        None if no token has been minted yet.
+        """
+        if self._token_expires_at is None:
+            return None
+        now = datetime.datetime.now(datetime.timezone.utc)
+        return (self._token_expires_at - now).total_seconds()
+
+    def is_token_expired(self) -> bool:
+        """Whether the token currently on the wire has lapsed.
+
+        This is a *local* check against the recorded ``expiresAt`` — it makes no
+        API call, so it cannot say anything about the endpoint behind the token.
+        A True here on its own is rarely a problem: the interceptor remints
+        before every call whose cached token is within five minutes of expiry.
+        Its use is diagnostic — pairing it with `is_endpoint_active` separates a
+        token that lapsed from an endpoint that timed out.
+        """
+        remaining = self.token_seconds_remaining()
+        return remaining is not None and remaining <= 0
+
+    # -- session liveness (session-based backends) --------------------------
+    # These sit on the base class because the *question* is universal, but only
+    # Serverless and EC2 have a session to ask about. EKS overrides them to
+    # defer to the managed endpoint, which is its only resource.
+
+    def session_state(self) -> str:
+        """Current state of the remote session, or ``NOT_FOUND`` if it is gone.
+
+        Subclasses implement this against their own ``GetSession`` shape. The
+        returned value is the service's own state string, uppercased.
+        """
+        raise NotImplementedError
+
+    def is_session_active(self) -> bool:
+        """Whether the remote session can still accept work.
+
+        False means the session has hit ``idleTimeoutMinutes``, failed, or been
+        terminated. Unlike an expired EMR on EKS managed endpoint, a dead
+        session-based session cannot be revived or reattached to — its ID is
+        permanently spent — so the only recovery is to start a new one. That is
+        what ``EMRSparkSession.recreate()`` does.
+        """
+        try:
+            return self.session_state() in self._SESSION_READY_STATES
+        except NotImplementedError:
+            raise
+        except Exception as e:
+            # An API error here means we cannot confirm liveness. Report not-live
+            # rather than raising: callers use this to decide whether to recreate,
+            # and a failed probe should steer them to recreate, not crash.
+            logger.debug(f"Could not determine session state: {e}")
+            return False
+
+    def refresh_token(self) -> Tuple[str, datetime.datetime]:
+        """Refresh the auth token. Used by the interceptor.
+
+        For Serverless and EC2 this is the whole story: mint a new token against
+        the existing session and hand it back for the interceptor to inject. The
+        endpoint host never changes, so the open gRPC channel stays valid.
+
+        Returns:
+            Tuple of (auth_token, expiry_datetime)
+        """
+        _, token, expires_at = self.get_endpoint_and_token()
+        return token, expires_at
+
+    @property
+    def client(self) -> Any:
+        if self._client is None:
+            self._client = self._create_client()
+        return self._client
+
+    def build_spark_connect_url(self, endpoint: str, token: str) -> str:
+        """Build the sc:// URL from the endpoint and token."""
+        host = endpoint
+        for scheme in ("sc://", "https://", "http://"):
+            if host.startswith(scheme):
+                host = host[len(scheme) :]
+                break
+        # Remove trailing slash if present
+        host = host.rstrip("/")
+        return f"sc://{host}:443/;use_ssl=true;x-aws-proxy-auth={token}"
+
+
+# ---------------------------------------------------------------------------
+# EMR Serverless backend
+# ---------------------------------------------------------------------------
+class ServerlessSessionManager(BaseSessionManager):
+    """Session manager for EMR Serverless (application IDs like 00abcdef01234567).
+
+    Session-based: ``StartSession`` creates the session and ``GetSessionEndpoint``
+    returns its endpoint plus a fresh token.
+    """
+
+    def _create_client(self) -> Any:
+        kwargs: Dict[str, Any] = {"region_name": self.region}
+        if self.endpoint_url:
+            kwargs["endpoint_url"] = self.endpoint_url
+        return self._boto3_session.client("emr-serverless", **kwargs)
+
+    def provision(self) -> str:
+        start_kwargs: Dict[str, Any] = {
+            "applicationId": self.resource_id,
+            "executionRoleArn": self.execution_role_arn,
+            "name": self.session_name,
+            "idleTimeoutMinutes": self.idle_timeout_minutes,
+        }
+        if self.spark_conf:
+            start_kwargs["configurationOverrides"] = {
+                "runtimeConfiguration": [
+                    {
+                        "classification": "spark-defaults",
+                        "properties": self.spark_conf,
+                    }
+                ]
+            }
+        resp = self.client.start_session(**start_kwargs)
+        self._session_id = resp["sessionId"]
+        logger.info(f"Started EMR Serverless session: {self._session_id}")
+        return self._session_id
+
+    def wait_for_ready(self) -> None:
+        _poll_resource_state(
+            poll_fn=lambda: self.client.get_session(
+                applicationId=self.resource_id, sessionId=self._session_id
+            )["session"]["state"],
+            ready_states=("READY", "IDLE", "STARTED"),
+            terminal_states=("FAILED", "TERMINATED", "STOPPED"),
+            resource_id=self._session_id,
+            max_wait=self.max_wait_seconds,
+        )
+
+    def get_endpoint_and_token(self) -> Tuple[str, str, datetime.datetime]:
+        resp = self.client.get_session_endpoint(
+            applicationId=self.resource_id, sessionId=self._session_id
+        )
+        endpoint = resp["endpoint"]
+        token = resp["authToken"]
+        expires_at = resp["authTokenExpiresAt"]
+        if isinstance(expires_at, str):
+            expires_at = datetime.datetime.fromisoformat(expires_at)
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
+        self._token_expires_at = expires_at
+        return endpoint, token, expires_at
+
+    def session_state(self) -> str:
+        """State of the interactive session, or ``NOT_FOUND`` if it is gone."""
+        if not self._session_id:
+            return "NOT_FOUND"
+        try:
+            resp = self.client.get_session(
+                applicationId=self.resource_id, sessionId=self._session_id
+            )
+        except self.client.exceptions.ResourceNotFoundException:
+            return "NOT_FOUND"
+        return str(resp["session"]["state"]).upper()
+
+    def terminate_session(self) -> None:
+        if self._session_id:
+            try:
+                self.client.terminate_session(
+                    applicationId=self.resource_id, sessionId=self._session_id
+                )
+                logger.info(f"Terminated EMR Serverless session: {self._session_id}")
+            except Exception as e:
+                logger.error(f"Failed to terminate session {self._session_id}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# EMR on EC2 backend
+# ---------------------------------------------------------------------------
+class EC2SessionManager(BaseSessionManager):
+    """Session manager for EMR on EC2 (cluster IDs like j-XXXXXXXXXXXXX).
+
+    Session-based: ``StartSession`` creates the session and ``GetSessionEndpoint``
+    returns its endpoint plus a fresh token.
+    """
+
+    def _create_client(self) -> Any:
+        kwargs: Dict[str, Any] = {"region_name": self.region}
+        if self.endpoint_url:
+            kwargs["endpoint_url"] = self.endpoint_url
+        return self._boto3_session.client("emr", **kwargs)
+
+    def provision(self) -> str:
+        start_kwargs: Dict[str, Any] = {
+            "ClusterId": self.resource_id,
+            "Name": self.session_name,
+        }
+        if self.execution_role_arn:
+            start_kwargs["ExecutionRoleArn"] = self.execution_role_arn
+        if self.idle_timeout_minutes:
+            start_kwargs["SessionIdleTimeoutInMinutes"] = self.idle_timeout_minutes
+        if self.spark_conf:
+            start_kwargs["EngineConfigurations"] = [
+                {
+                    "Classification": "spark-defaults",
+                    "Properties": self.spark_conf,
+                }
+            ]
+        resp = self.client.start_session(**start_kwargs)
+        self._session_id = resp["Id"]
+        logger.info(f"Started EMR on EC2 session: {self._session_id}")
+        return self._session_id
+
+    def wait_for_ready(self) -> None:
+        _poll_resource_state(
+            poll_fn=lambda: self.client.get_session(
+                ClusterId=self.resource_id, SessionId=self._session_id
+            )["Session"]["State"],
+            ready_states=("IDLE", "STARTED", "READY"),
+            terminal_states=("FAILED", "TERMINATED"),
+            resource_id=self._session_id,
+            max_wait=self.max_wait_seconds,
+        )
+
+    def get_endpoint_and_token(self) -> Tuple[str, str, datetime.datetime]:
+        resp = self.client.get_session_endpoint(
+            ClusterId=self.resource_id, SessionId=self._session_id
+        )
+        endpoint = resp["Endpoint"]
+        token = resp["AuthToken"]
+        expires_at = resp.get("AuthTokenExpirationTime") or resp.get("AuthTokenExpiresAt")
+        if isinstance(expires_at, str):
+            expires_at = datetime.datetime.fromisoformat(expires_at)
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
+        self._token_expires_at = expires_at
+        return endpoint, token, expires_at
+
+    def build_spark_connect_url(self, endpoint: str, token: str) -> str:
+        """EMR on EC2 also requires the session ID in the authorization parameter."""
+        host = endpoint.replace("https://", "").replace("http://", "").rstrip("/")
+        return (
+            f"sc://{host}:443/;use_ssl=true;"
+            f"x-aws-proxy-auth={token};"
+            f"authorization={self._session_id}"
+        )
+
+    def session_state(self) -> str:
+        """State of the interactive session, or ``NOT_FOUND`` if it is gone."""
+        if not self._session_id:
+            return "NOT_FOUND"
+        try:
+            resp = self.client.get_session(
+                ClusterId=self.resource_id, SessionId=self._session_id
+            )
+        except self.client.exceptions.InvalidRequestException:
+            # emr has no ResourceNotFoundException for sessions; a spent or
+            # unknown session ID comes back as InvalidRequestException.
+            return "NOT_FOUND"
+        return str(resp["Session"]["State"]).upper()
+
+    def terminate_session(self) -> None:
+        if self._session_id:
+            try:
+                self.client.terminate_session(
+                    ClusterId=self.resource_id, SessionId=self._session_id
+                )
+                logger.info(f"Terminated EMR on EC2 session: {self._session_id}")
+            except Exception as e:
+                logger.error(f"Failed to terminate session {self._session_id}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# EMR on EKS backend
+# ---------------------------------------------------------------------------
+class EndpointExpiredError(RuntimeError):
+    """Raised when an expired managed endpoint could **not** be replaced.
+
+    Expiry itself is not an error: the managed endpoint backing Spark Connect
+    on EMR on EKS is torn down once ``sessionIdleTimeoutInMinutes`` elapses,
+    and the client simply creates another one. This is raised only when that
+    automatic replacement fails, so the caller is genuinely stuck.
+    """
+
+
+class EKSSessionManager(BaseSessionManager):
+    """Session manager for EMR on EKS (virtual cluster IDs).
+
+    There is no session to start
+    ----------------------------
+    ``emr-containers`` has no session API. The only resource is the
+    ``SPARK_CONNECT`` *managed endpoint* on a virtual cluster, and
+    ``GetManagedEndpointSessionCredentials`` returns an already-active session
+    token against it. So there is nothing to start and no session state to poll:
+    the endpoint is the whole resource, and provisioning it is the whole job.
+
+    That leaves two things with independent lifetimes:
+
+    ===============  =============================================  =========================================
+    Thing            Lifetime                                       Renewed by
+    ===============  =============================================  =========================================
+    Managed          ``sessionIdleTimeoutInMinutes`` on              ``CreateManagedEndpoint`` — i.e. a new
+    endpoint         ``CreateManagedEndpoint``                       endpoint; it cannot be extended
+    Session token    ``durationInSeconds`` on                       ``GetManagedEndpointSessionCredentials``
+                     ``GetManagedEndpointSessionCredentials``
+                     (default 15 min, max 12 h)
+    ===============  =============================================  =========================================
+
+    A token is only valid against the endpoint it was minted for, so it cannot
+    outlive its endpoint. Which one expired decides what has to be rebuilt:
+
+    * **Token expired, endpoint still ACTIVE** — the common case, and the cheap
+      one. Mint a new token against the same endpoint; the host is unchanged so
+      the gRPC channel keeps working. Same shape as the other backends.
+    * **Endpoint expired** — the token is moot. Create a new endpoint (routine,
+      not an error), then mint a token against it. The replacement has a new
+      ``authProxyUrl``, so the channel must also be rebuilt.
+
+    `ensure_endpoint` is the single place that reuse-or-replace decision is made,
+    and `provision`, `get_endpoint_and_token` and `EMRSparkSession.reconnect()`
+    all route through it, so a token is never minted against a dead endpoint.
+    `refresh_token` handles the token and, when it finds the endpoint was replaced
+    underneath it, signals that the caller must reconnect.
+    """
+
+    #: EMR on EKS release used when creating a Spark Connect managed endpoint.
+    DEFAULT_RELEASE_LABEL = "emr-7.14.0-latest"
+    #: Token lifetime requested from GetManagedEndpointSessionCredentials.
+    #: API default is 15 minutes; 12 hours (43200s) is the documented maximum.
+    DEFAULT_TOKEN_DURATION_SECONDS = 12 * 60 * 60
+    #: Documented maximum for durationInSeconds; larger values are rejected.
+    MAX_TOKEN_DURATION_SECONDS = 12 * 60 * 60
+    #: Below this, tokens routinely expire in transit: the 30-60s budget has to
+    #: cover the mint round trip, connection setup, and retry backoff before
+    #: the auth proxy validates the token — losing that race means the RPC is
+    #: rejected at the proxy and never reaches the Spark driver. 300s is the
+    #: floor at which a token reliably outlives one dispatch.
+    MIN_SANE_TOKEN_DURATION_SECONDS = 300
+    #: An endpoint with a tiny idle timeout deletes itself between demo cells:
+    #: retried-but-failing RPCs don't count as activity, so the whole driver
+    #: deployment is reaped mid-session and every temp view with it.
+    MIN_SANE_IDLE_TIMEOUT_MINUTES = 5
+
+    # describe_managed_endpoint states
+    _READY_STATES = ("ACTIVE",)
+    _DEAD_STATES = ("TERMINATED", "TERMINATED_WITH_ERRORS", "TERMINATING")
+
+    def __init__(
+        self,
+        *args,
+        managed_endpoint_id: Optional[str] = None,
+        release_label: Optional[str] = None,
+        token_duration_seconds: Optional[int] = None,
+        application_configuration: Optional[List[Dict[str, Any]]] = None,
+        monitoring_configuration: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        # Endpoint id supplied by the caller. We reuse it and never delete it —
+        # deleting a caller-owned endpoint would be a surprising side effect.
+        self._managed_endpoint_id = managed_endpoint_id
+        self._owns_endpoint = False
+        self._release_label = release_label or self.DEFAULT_RELEASE_LABEL
+        if token_duration_seconds is not None:
+            if token_duration_seconds > self.MAX_TOKEN_DURATION_SECONDS:
+                raise ValueError(
+                    f"token_duration_seconds={token_duration_seconds} exceeds the "
+                    f"GetManagedEndpointSessionCredentials maximum of "
+                    f"{self.MAX_TOKEN_DURATION_SECONDS} (12 hours)."
+                )
+            if token_duration_seconds < self.MIN_SANE_TOKEN_DURATION_SECONDS:
+                warnings.warn(
+                    f"token_duration_seconds={token_duration_seconds} is below "
+                    f"{self.MIN_SANE_TOKEN_DURATION_SECONDS}s. Such tokens can "
+                    "expire in transit — the auth proxy then rejects RPCs before "
+                    "they reach the Spark driver — and every gRPC call will mint "
+                    "a fresh token (an extra AWS API round trip per call). The "
+                    "API default is 900s.",
+                    stacklevel=3,
+                )
+        self._token_duration_seconds = (
+            token_duration_seconds
+            if token_duration_seconds is not None
+            else self.DEFAULT_TOKEN_DURATION_SECONDS
+        )
+        if self.idle_timeout_minutes and (
+            self.idle_timeout_minutes < self.MIN_SANE_IDLE_TIMEOUT_MINUTES
+        ):
+            warnings.warn(
+                f"idle_timeout_minutes={self.idle_timeout_minutes} is below "
+                f"{self.MIN_SANE_IDLE_TIMEOUT_MINUTES}. On EMR on EKS this is the "
+                "managed endpoint's sessionIdleTimeoutInMinutes: the endpoint "
+                "deletes its own driver deployment after that many idle minutes, "
+                "and the replacement comes up on a new host with none of the old "
+                "driver state.",
+                stacklevel=3,
+            )
+        # Serializes token minting and endpoint replacement. Without this, the
+        # interceptor's refresh and PySpark's background ReleaseExecute threads
+        # can race ensure_endpoint into creating two replacement endpoints.
+        self._refresh_lock = threading.RLock()
+        self._application_configuration = application_configuration
+        self._monitoring_configuration = monitoring_configuration
+        # authProxyUrl of the endpoint currently in use. Tracked so we can tell
+        # a token refresh (same host) from an endpoint swap (new host).
+        self._endpoint_host: Optional[str] = None
+        # Most recent DescribeManagedEndpoint result, set by describe_endpoint().
+        self._last_endpoint: Optional[Dict[str, Any]] = None
+
+    def _create_client(self) -> Any:
+        kwargs: Dict[str, Any] = {"region_name": self.region}
+        if self.endpoint_url:
+            kwargs["endpoint_url"] = self.endpoint_url
+        return self._boto3_session.client("emr-containers", **kwargs)
+
+    # -- the managed endpoint (the only resource; no session to start) ------
+    def provision(self) -> str:
+        """Reuse a live managed endpoint if there is one, else create one.
+
+        This is the entire provisioning step for EMR on EKS — there is no
+        ``StartSession`` to call afterwards. ``wait_for_ready`` is invoked
+        separately by the caller, matching the other backends, so this does not
+        block on a newly created endpoint.
+        """
+        self.ensure_endpoint(wait=False)
+        return self._session_id
+
+    def ensure_endpoint(self, wait: bool = True) -> bool:
+        """Guarantee a usable managed endpoint exists, creating one if needed.
+
+        This concerns only the endpoint — it says nothing about the session token,
+        which `get_endpoint_and_token` mints against it afterwards. It is the one
+        place the reuse-or-replace decision is made:
+
+        * An endpoint that is ``ACTIVE`` (or still ``CREATING``) is **reused**
+          as-is — no new endpoint, no redundant ALB provisioning.
+        * An endpoint that has expired, is terminating, or no longer exists is
+          **replaced** with a new one. Expiry after
+          ``sessionIdleTimeoutInMinutes`` is the normal end of an endpoint's
+          life, so it is handled routinely rather than raised as an error.
+
+        Replacement applies equally to an endpoint passed in as
+        ``managed_endpoint_id``: once it has expired there is nothing to reuse,
+        so the client stops referring to that id and manages its own from then
+        on (otherwise it would keep describing the same dead id forever).
+
+        Args:
+            wait: Poll a newly created (or still-``CREATING``) endpoint until it
+                reaches ``ACTIVE``.
+
+        Returns:
+            True if a new endpoint was created, False if an existing one is
+            being reused. Callers use this to tell whether the ``authProxyUrl``
+            may have changed under them.
+        """
+        # Serialized so two concurrent callers (e.g. the interceptor's refresh
+        # and reconnect()) can't both see a dead endpoint and create two
+        # replacements. RLock: get_endpoint_and_token calls this while holding it.
+        with self._refresh_lock:
+            endpoint_id = self._session_id or self._managed_endpoint_id
+            if endpoint_id:
+                self._session_id = endpoint_id
+                state = self.endpoint_state()
+                if state in self._READY_STATES or state == "CREATING":
+                    logger.info(
+                        f"Reusing EMR on EKS managed endpoint {endpoint_id} "
+                        f"(state {state})"
+                    )
+                    if wait and state not in self._READY_STATES:
+                        self.wait_for_ready()
+                    return False
+                logger.info(
+                    f"EMR on EKS managed endpoint {endpoint_id} is no longer usable "
+                    f"(state {state}) — creating a replacement"
+                )
+                # The caller's endpoint is gone; from here on we manage our own.
+                self._managed_endpoint_id = None
+
+            self._create_endpoint()
+            if wait:
+                self.wait_for_ready()
+            if endpoint_id:
+                logger.info(
+                    f"Replaced EMR on EKS managed endpoint: "
+                    f"{endpoint_id} -> {self._session_id}"
+                )
+            return True
+
+    def _build_configuration_overrides(self) -> Dict[str, Any]:
+        """Assemble ``configurationOverrides`` for CreateManagedEndpoint.
+
+        Customer Spark configuration reaches the endpoint two ways, and both are
+        honoured:
+
+        * ``spark_conf={"spark.executor.memory": "4g"}`` — the common case, a
+          flat dict promoted to a ``spark-defaults`` classification.
+        * ``application_configuration=[{...}]`` — the full API shape, for
+          anything a flat dict cannot express: other classifications
+          (``spark-env``, ``spark-hive-site``, ``jeg-config``, ...) and nested
+          ``configurations``.
+
+        When both are given, ``spark_conf`` is merged into the caller's
+        ``spark-defaults`` block if there is one (caller's explicit properties
+        win on key conflicts) and appended as a new block otherwise. That keeps
+        both from silently overwriting each other.
+        """
+        app_config: List[Dict[str, Any]] = [
+            dict(block) for block in (self._application_configuration or [])
+        ]
+
+        if self.spark_conf:
+            existing = next(
+                (
+                    b
+                    for b in app_config
+                    if b.get("classification") == "spark-defaults"
+                ),
+                None,
+            )
+            if existing is None:
+                app_config.append(
+                    {
+                        "classification": "spark-defaults",
+                        "properties": dict(self.spark_conf),
+                    }
+                )
+            else:
+                # Caller's explicitly-listed properties take precedence.
+                merged = dict(self.spark_conf)
+                merged.update(existing.get("properties") or {})
+                existing["properties"] = merged
+
+        overrides: Dict[str, Any] = {}
+        if app_config:
+            overrides["applicationConfiguration"] = app_config
+        if self._monitoring_configuration:
+            overrides["monitoringConfiguration"] = self._monitoring_configuration
+        return overrides
+
+    def _create_endpoint(self) -> str:
+        create_kwargs: Dict[str, Any] = {
+            "name": self.session_name,
+            "virtualClusterId": self.resource_id,
+            "type": "SPARK_CONNECT",
+            "releaseLabel": self._release_label,
+            "executionRoleArn": self.execution_role_arn,
+        }
+        # The endpoint is torn down this many idle minutes after creation.
+        if self.idle_timeout_minutes:
+            create_kwargs["sessionIdleTimeoutInMinutes"] = self.idle_timeout_minutes
+        overrides = self._build_configuration_overrides()
+        if overrides:
+            create_kwargs["configurationOverrides"] = overrides
+        # clientToken carries the idempotencyToken trait, so boto3 generates it.
+        resp = self.client.create_managed_endpoint(**create_kwargs)
+        self._session_id = resp["id"]
+        self._owns_endpoint = True
+        self._endpoint_host = None
+        # Both describe the endpoint we just replaced — drop them.
+        self._last_endpoint = None
+        logger.info(
+            f"Created EMR on EKS managed endpoint {self._session_id} "
+            f"({self._release_label}, idle timeout "
+            f"{self.idle_timeout_minutes} min)"
+        )
+        return self._session_id
+
+    def describe_endpoint(self) -> Dict[str, Any]:
+        """Return the ``endpoint`` struct from DescribeManagedEndpoint."""
+        endpoint = self.client.describe_managed_endpoint(
+            virtualClusterId=self.resource_id, id=self._session_id
+        )["endpoint"]
+        # Cached so the reuse path doesn't describe twice per token mint.
+        self._last_endpoint = endpoint
+        return endpoint
+
+    def session_state(self) -> str:
+        """The managed endpoint's state — EMR on EKS has no session resource.
+
+        ``emr-containers`` exposes no ``GetSession``, so "is the session alive"
+        can only mean "is the managed endpoint alive" here.
+        """
+        return self.endpoint_state()
+
+    def is_session_active(self) -> bool:
+        """Whether the managed endpoint is live.
+
+        Deliberately identical to ``is_endpoint_active``. On EMR on EKS an
+        expired endpoint is *replaced in place* by ``ensure_endpoint``, so
+        ``EMRSparkSession.reconnect()`` remains the recovery path — recreating
+        the whole session is neither needed nor correct.
+        """
+        return self.is_endpoint_active()
+
+    def endpoint_state(self) -> str:
+        """Current endpoint state, or ``NOT_FOUND`` if it no longer exists."""
+        try:
+            return self.describe_endpoint()["state"]
+        except self.client.exceptions.ResourceNotFoundException:
+            self._last_endpoint = None
+            return "NOT_FOUND"
+
+    def is_endpoint_active(self) -> bool:
+        """Whether the managed endpoint is currently live.
+
+        False means it has hit ``sessionIdleTimeoutInMinutes``; the next call
+        needing it will create a replacement.
+        """
+        return self.endpoint_state() in self._READY_STATES
+
+    @property
+    def token_duration_seconds(self) -> Optional[int]:
+        """The ``durationInSeconds`` requested for each token.
+
+        Independent of ``sessionIdleTimeoutInMinutes``, so a token can easily
+        outlive its endpoint or lapse long before it.
+        """
+        return self._token_duration_seconds
+
+    def wait_for_ready(self) -> None:
+        """Poll the endpoint to ACTIVE. There is no session state to wait on."""
+        # Endpoint creation provisions a load balancer, so this is minutes, not
+        # seconds. CREATING is the normal pre-ACTIVE state.
+        _poll_resource_state(
+            poll_fn=self.endpoint_state,
+            ready_states=self._READY_STATES,
+            terminal_states=self._DEAD_STATES + ("NOT_FOUND",),
+            resource_id=self._session_id,
+            max_wait=self.max_wait_seconds,
+            resource_kind="Managed endpoint",
+        )
+
+    # -- the session token --------------------------------------------------
+    def get_endpoint_and_token(self) -> Tuple[str, str, datetime.datetime]:
+        """Return ``(authProxyUrl, token, expires_at)`` for a live endpoint.
+
+        The endpoint is settled first via `ensure_endpoint` — reused if ``ACTIVE``,
+        replaced if it hit ``sessionIdleTimeoutInMinutes`` — because a token is
+        only valid against the endpoint it was minted for and must never be minted
+        against a dead one. ``GetManagedEndpointSessionCredentials`` then returns an
+        already-active token with its own independent ``durationInSeconds``; no
+        session is started, and the token is usable immediately.
+
+        ``DescribeManagedEndpoint`` can keep reporting ``ACTIVE`` for a window
+        after the endpoint has actually hit its idle timeout, so the reuse
+        decision above can be wrong. The credentials API validates against the
+        endpoint's real state and rejects such an endpoint with
+        ``ValidationException: Endpoint is in invalid state``. That rejection is
+        treated exactly like an observed expiry: the endpoint is replaced and
+        the mint retried once against the replacement.
+
+        Because the credentials API does that validation anyway, an endpoint
+        this manager has already connected to is minted against directly,
+        without a preceding ``DescribeManagedEndpoint`` — halving the AWS calls
+        on the common refresh path. The describe-first path runs on the first
+        connection and whenever a direct mint is rejected.
+        """
+        with self._refresh_lock:
+            # Optimistic path: the endpoint served us before, so mint straight
+            # against it and let the credentials API be the liveness check.
+            if self._endpoint_host and self._session_id:
+                try:
+                    return self._mint_token(self._endpoint_host)
+                except self.client.exceptions.ValidationException as e:
+                    if "state" not in str(e).lower():
+                        raise
+                    logger.info(
+                        f"Managed endpoint {self._session_id} rejected a token "
+                        f"mint ({e}) — falling back to describe-and-replace"
+                    )
+                    # Stale by definition now; force the full path to re-look.
+                    self._last_endpoint = None
+
+            # Reuses the current endpoint when it is still ACTIVE; creates a
+            # replacement when it has timed out. Either way, describe_endpoint()
+            # has run and cached the result, so no second describe is needed.
+            self.ensure_endpoint(wait=True)
+
+            host = self._resolve_endpoint_host()
+            try:
+                return self._mint_token(host)
+            except self.client.exceptions.ValidationException as e:
+                # Only a state complaint means "the endpoint is dead behind an
+                # ACTIVE describe". Anything else (bad duration, bad role, ...)
+                # would fail identically against a replacement, so re-raise.
+                if "state" not in str(e).lower():
+                    raise
+                logger.info(
+                    f"Managed endpoint {self._session_id} rejected a token mint "
+                    f"({e}) — it expired behind an ACTIVE describe; creating a "
+                    "replacement"
+                )
+                # Same handover as ensure_endpoint: the caller's endpoint is
+                # gone, so from here on we manage our own.
+                self._managed_endpoint_id = None
+                self._create_endpoint()
+                self.wait_for_ready()
+                return self._mint_token(self._resolve_endpoint_host())
+
+    def _resolve_endpoint_host(self) -> str:
+        """Return the Spark Connect host of the current endpoint, recording it."""
+        endpoint = self._last_endpoint or self.describe_endpoint()
+        state = endpoint.get("state")
+        if state not in self._READY_STATES:
+            # ensure_endpoint just brought an endpoint to ACTIVE, so this means
+            # the replacement itself is unusable — a real failure.
+            raise EndpointExpiredError(
+                f"Managed endpoint {self._session_id} is in state {state}, "
+                "not ACTIVE, immediately after being ensured."
+            )
+        # authProxyUrl is the Spark Connect host; serverUrl is not.
+        host = endpoint.get("authProxyUrl") or endpoint.get("serverUrl")
+        if not host:
+            raise EndpointExpiredError(
+                f"Managed endpoint {self._session_id} exposed no authProxyUrl."
+            )
+        self._endpoint_host = host
+        return host
+
+    def _mint_token(self, host: str) -> Tuple[str, str, datetime.datetime]:
+        """Mint a session token against the current endpoint."""
+        resp = self.client.get_managed_endpoint_session_credentials(
+            virtualClusterIdentifier=self.resource_id,
+            endpointIdentifier=self._session_id,
+            executionRoleArn=self.execution_role_arn,
+            credentialType="TOKEN",
+            durationInSeconds=self._token_duration_seconds,
+        )
+        # `credentials` and `endpointCredentials` are equivalent unions; the
+        # docs' example reads credentials.token.
+        creds = resp.get("credentials") or resp.get("endpointCredentials") or {}
+        token = creds.get("token")
+        if not token:
+            raise RuntimeError(
+                "GetManagedEndpointSessionCredentials returned no token for "
+                f"endpoint {self._session_id}"
+            )
+
+        expires_at = resp.get("expiresAt")
+        if expires_at is None:
+            expires_at = datetime.datetime.now(
+                datetime.timezone.utc
+            ) + datetime.timedelta(seconds=self._token_duration_seconds)
+        elif isinstance(expires_at, str):
+            expires_at = datetime.datetime.fromisoformat(expires_at)
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
+        self._token_expires_at = expires_at
+        return host, token, expires_at
+
+    def refresh_token(self) -> Tuple[str, datetime.datetime]:
+        """Mint a fresh token for the endpoint the open channel points at.
+
+        The gRPC interceptor calls this when the *token* is near expiry. Which of
+        the two actually expired decides the outcome:
+
+        * **Only the token expired** (endpoint still ``ACTIVE``) — the common
+          case. A new token is minted against the same endpoint and returned for
+          the interceptor to inject. The host is unchanged, so the open channel
+          keeps working. Indistinguishable from Serverless/EC2 behaviour.
+        * **The endpoint expired too** — `get_endpoint_and_token` has already
+          created the replacement, which is not an error and needs no caller
+          involvement. But an interceptor can only rewrite a header, and the
+          replacement listens on a *different* ``authProxyUrl``, so the open
+          channel points at a host that no longer answers. That is the one case
+          raised as `EndpointExpiredError` — the new endpoint is already up, and
+          `EMRSparkSession.reconnect()` simply attaches to it.
+        """
+        previous_host = self._endpoint_host
+        host, token, expires_at = self.get_endpoint_and_token()
+        if previous_host and host != previous_host:
+            raise EndpointExpiredError(
+                f"Managed endpoint expired and was replaced with "
+                f"{self._session_id} at a new host ({previous_host} -> {host}). "
+                "The open Spark Connect channel cannot be redirected — call "
+                "EMRSparkSession.reconnect() to attach to the new endpoint."
+            )
+        return token, expires_at
+
+    def build_spark_connect_url(self, endpoint: str, token: str) -> str:
+        """Build the ``sc://`` URL from ``authProxyUrl`` and a session token."""
+        host = endpoint
+        for scheme in ("sc://", "https://", "http://"):
+            if host.startswith(scheme):
+                host = host[len(scheme) :]
+                break
+        host = host.rstrip("/")
+        if ":" not in host:
+            host = f"{host}:443"
+        return f"sc://{host}/;use_ssl=true;x-aws-proxy-auth={token}"
+
+    def terminate_session(self) -> None:
+        """Delete the managed endpoint. There is no session to terminate."""
+        # Only delete endpoints we created; a caller-supplied endpoint is theirs.
+        if not self._session_id or not self._owns_endpoint:
+            return
+        try:
+            self.client.delete_managed_endpoint(
+                virtualClusterId=self.resource_id, id=self._session_id
+            )
+            logger.info(f"Deleted EMR on EKS managed endpoint: {self._session_id}")
+        except Exception as e:
+            logger.error(
+                f"Failed to delete managed endpoint {self._session_id}: {e}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Shared utilities
+# ---------------------------------------------------------------------------
+def _poll_resource_state(
+    poll_fn,
+    ready_states: Tuple[str, ...],
+    terminal_states: Tuple[str, ...],
+    resource_id: str,
+    max_wait: int,
+    poll_interval: float = 3.0,
+    resource_kind: str = "Session",
+) -> None:
+    """Poll until the remote resource reaches a ready or terminal state.
+
+    Args:
+        resource_kind: What is being polled, for log/error text — a session on
+            Serverless/EC2, a managed endpoint on EMR on EKS (which has no
+            session resource to poll).
+    """
+    start = time.time()
+    last_state = None
+    while True:
+        elapsed = time.time() - start
+        if elapsed >= max_wait:
+            raise TimeoutError(
+                f"{resource_kind} {resource_id} not ready after {max_wait}s "
+                f"(last state: {last_state})"
+            )
+        state = poll_fn()
+        if state != last_state:
+            logger.info(f"{resource_kind} {resource_id}: {state}")
+            last_state = state
+        if state in ready_states:
+            return
+        if state in terminal_states:
+            raise RuntimeError(
+                f"{resource_kind} {resource_id} reached terminal state: {state}"
+            )
+        time.sleep(poll_interval)
+
+
+def create_session_manager(
+    resource_id: str,
+    backend: Optional[str] = None,
+    **kwargs,
+) -> BaseSessionManager:
+    """Factory to create the appropriate session manager.
+
+    Args:
+        resource_id: EMR resource ID (app ID, cluster ID, or virtual cluster ID)
+        backend: Explicit backend ('serverless', 'ec2', 'eks') or None for auto-detect
+        **kwargs: Passed to the session manager constructor
+
+    Returns:
+        An initialized (but not yet started) session manager
+    """
+    if backend is None:
+        backend = detect_backend(resource_id)
+
+    managers = {
+        "serverless": ServerlessSessionManager,
+        "ec2": EC2SessionManager,
+        "eks": EKSSessionManager,
+    }
+    if backend not in managers:
+        raise ValueError(
+            f"Unknown backend '{backend}'. Must be one of: {list(managers.keys())}"
+        )
+    return managers[backend](resource_id=resource_id, **kwargs)

--- a/utilities/emr-spark-connect-client/src/emr_spark_connect/interceptors.py
+++ b/utilities/emr-spark-connect-client/src/emr_spark_connect/interceptors.py
@@ -1,0 +1,171 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: MIT-0
+"""gRPC interceptor for automatic EMR auth token refresh.
+
+Intercepts every outgoing gRPC call, checks token expiry, refreshes via
+the backend-specific token refresh callable, and injects the fresh token
+as x-aws-proxy-auth metadata.
+"""
+
+import datetime
+import logging
+import threading
+import time
+from collections import namedtuple
+from typing import Callable, Optional, Tuple
+
+import grpc
+
+# The URL-parsing builder. In PySpark 4.x ChannelBuilder became an abstract base
+# whose __init__ takes channelOptions, and the sc:// parsing moved to
+# DefaultChannelBuilder (exported from .core, not the client package). On 3.x
+# ChannelBuilder itself is the concrete URL-parsing class.
+try:
+    from pyspark.sql.connect.client.core import DefaultChannelBuilder as _ChannelBuilder
+except ImportError:  # pyspark < 4
+    from pyspark.sql.connect.client import ChannelBuilder as _ChannelBuilder
+
+logger = logging.getLogger("emr_spark_connect.interceptors")
+
+# namedtuple to create new ClientCallDetails with updated metadata
+_ClientCallDetails = namedtuple(
+    "_ClientCallDetails",
+    ("method", "timeout", "metadata", "credentials", "wait_for_ready", "compression"),
+)
+
+
+class _ClientCallDetails(_ClientCallDetails, grpc.ClientCallDetails):
+    pass
+
+
+class TokenRefreshInterceptor(
+    grpc.UnaryUnaryClientInterceptor,
+    grpc.UnaryStreamClientInterceptor,
+    grpc.StreamUnaryClientInterceptor,
+    grpc.StreamStreamClientInterceptor,
+):
+    """Intercepts gRPC calls to inject a fresh EMR auth token.
+
+    Works with any EMR backend (Serverless, on EKS, on EC2) — the caller
+    provides a `refresh_fn` that returns (token, expires_at).
+    """
+
+    # Refresh this many seconds before actual expiry — shrunk adaptively for
+    # tokens whose whole lifetime is shorter than this (see _refresh_token).
+    MAX_EARLY_REFRESH_SECONDS = 5 * 60
+    # Never shrink the early-refresh margin below this: the token must survive
+    # proxy-side validation after transit, so a few seconds of slack is required.
+    MIN_EARLY_REFRESH_SECONDS = 5.0
+    # Revalidate through refresh_fn at least this often, even while the token
+    # is still valid. The refresh path is the only place a dead EMR on EKS
+    # endpoint is detected (the credentials API rejects it and the manager
+    # raises EndpointExpiredError); with a long-lived token and no cap, the
+    # first call after an endpoint idles out instead hits a dead host and
+    # grinds through gRPC's UNAVAILABLE retry policy — 15 attempts with
+    # backoff capped at 60s, i.e. ~11 minutes — before failing.
+    REVALIDATE_INTERVAL_SECONDS = 60.0
+
+    def __init__(self, refresh_fn: Callable[[], Tuple[str, datetime.datetime]]):
+        """
+        Args:
+            refresh_fn: Callable that returns (auth_token, expiry_datetime).
+                        The expiry_datetime must be timezone-aware (UTC).
+        """
+        self._refresh_fn = refresh_fn
+        self._cached_token: Optional[str] = None
+        self._cache_expiration_time = datetime.datetime.min.replace(
+            tzinfo=datetime.timezone.utc
+        )
+        # Monotonic timestamp of the last successful refresh, for the
+        # revalidation cap. -inf so the very first call always refreshes.
+        self._last_refresh_monotonic = float("-inf")
+        # PySpark's reattachable execute releases results from a background
+        # thread pool, so several RPCs — hence several interceptions — can be
+        # in flight at once. The lock keeps them from each minting a token
+        # (and, worse, racing the manager into replacing endpoints twice).
+        self._lock = threading.Lock()
+
+    def _refresh_token(self) -> str:
+        """Mint a fresh token and return it. Caller must hold the lock."""
+        token, expires_at = self._refresh_fn()
+        self._cached_token = token
+        if isinstance(expires_at, str):
+            expires_at = datetime.datetime.fromisoformat(expires_at)
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
+        # A fixed 5-minute margin would put any token shorter than 300s
+        # permanently inside the refresh window, degrading to a mint per RPC
+        # (two AWS calls each). Scale the margin to the observed lifetime so
+        # short-lived tokens still get reused for most of their life.
+        now = datetime.datetime.now(datetime.timezone.utc)
+        lifetime = (expires_at - now).total_seconds()
+        early = min(self.MAX_EARLY_REFRESH_SECONDS,
+                    max(self.MIN_EARLY_REFRESH_SECONDS, lifetime / 3))
+        self._cache_expiration_time = expires_at - datetime.timedelta(seconds=early)
+        self._last_refresh_monotonic = time.monotonic()
+        logger.debug(f"Token refreshed. Next refresh at {self._cache_expiration_time}")
+        return token
+
+    def _cache_is_fresh(self) -> bool:
+        if time.monotonic() - self._last_refresh_monotonic > self.REVALIDATE_INTERVAL_SECONDS:
+            return False
+        return self._cache_expiration_time >= datetime.datetime.now(datetime.timezone.utc)
+
+    def _current_token(self) -> Optional[str]:
+        if self._cache_is_fresh():
+            return self._cached_token
+        with self._lock:
+            # Re-check: another thread may have refreshed while we waited.
+            if self._cache_is_fresh():
+                return self._cached_token
+            return self._refresh_token()
+
+    def _with_metadata(self, client_call_details):
+        metadata = dict(client_call_details.metadata or {})
+        metadata["x-aws-proxy-auth"] = self._current_token()
+        return _ClientCallDetails(
+            method=client_call_details.method,
+            timeout=client_call_details.timeout,
+            metadata=list(metadata.items()),
+            credentials=client_call_details.credentials,
+            wait_for_ready=client_call_details.wait_for_ready,
+            compression=client_call_details.compression,
+        )
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        return continuation(self._with_metadata(client_call_details), request)
+
+    def intercept_unary_stream(self, continuation, client_call_details, request):
+        return continuation(self._with_metadata(client_call_details), request)
+
+    def intercept_stream_unary(
+        self, continuation, client_call_details, request_iterator
+    ):
+        return continuation(
+            self._with_metadata(client_call_details), request_iterator
+        )
+
+    def intercept_stream_stream(
+        self, continuation, client_call_details, request_iterator
+    ):
+        return continuation(
+            self._with_metadata(client_call_details), request_iterator
+        )
+
+
+class EMRChannelBuilder(_ChannelBuilder):
+    """Extends PySpark's URL-parsing ChannelBuilder to add the token-refresh interceptor."""
+
+    def __init__(self, url: str, refresh_fn: Callable[[], Tuple[str, datetime.datetime]]):
+        """
+        Args:
+            url: Spark Connect URL (sc://host:443/;use_ssl=true;...)
+            refresh_fn: Callable that returns (auth_token, expiry_datetime)
+        """
+        super().__init__(url)
+        self._refresh_fn = refresh_fn
+
+    def toChannel(self) -> grpc.Channel:
+        channel = super().toChannel()
+        interceptor = TokenRefreshInterceptor(self._refresh_fn)
+        return grpc.intercept_channel(channel, interceptor)

--- a/utilities/emr-spark-connect-client/src/emr_spark_connect/session.py
+++ b/utilities/emr-spark-connect-client/src/emr_spark_connect/session.py
@@ -1,0 +1,444 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: MIT-0
+"""Unified EMRSparkSession — the main entry point for the package.
+
+Usage:
+    from emr_spark_connect import EMRSparkSession
+
+    session = EMRSparkSession.create(
+        resource_id="00abcdef01234567",  # EMR Serverless app ID
+        execution_role_arn="arn:aws:iam::123456789012:role/MyRole",
+    )
+    session.sql("SELECT 1 + 1 AS result").show()
+    session.stop()
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional
+
+import boto3
+from pyspark.sql import SparkSession
+from pyspark.sql.connect.session import SparkSession as ConnectSparkSession
+
+from .backends import BaseSessionManager, EndpointExpiredError, create_session_manager
+from .interceptors import EMRChannelBuilder
+
+logger = logging.getLogger("emr_spark_connect")
+
+
+def _discard_channel(spark: Optional[SparkSession], remote_gone: bool) -> None:
+    """Close a stale Spark Connect channel without waiting on a dead host.
+
+    ``stop()`` on PySpark 4.x first sends a ``ReleaseSession`` RPC to the remote
+    driver. When that driver is gone — an idled-out session, an expired managed
+    endpoint — the RPC gets ``UNAVAILABLE``, which the default retry policy
+    treats as retryable: 15 attempts with exponential backoff capped at 60s,
+    so ``stop()`` blocks for over ten minutes before giving up. That looks
+    exactly like a hang in :meth:`EMRSparkSession.recreate`.
+
+    PySpark 3.5's ``stop()`` has no such RPC, which is why this only bites the
+    4.x line (EMR on EC2). ``release_session_on_close`` is likewise 4.x-only,
+    so it is set defensively rather than assumed to exist.
+
+    Args:
+        spark: The SparkSession to close. None is a no-op.
+        remote_gone: True if the remote driver is known to be unreachable, in
+            which case the release RPC is skipped as pointless. When False the
+            RPC is left in place so a live remote session is released cleanly.
+    """
+    if spark is None:
+        return
+    if remote_gone:
+        try:
+            spark.release_session_on_close = False
+        except Exception as e:  # pragma: no cover - attribute is 4.x-only
+            logger.debug(f"Could not disable ReleaseSession on close: {e}")
+    try:
+        spark.stop()
+    except Exception as e:
+        logger.debug(f"Ignoring error stopping stale SparkSession: {e}")
+
+
+def _connect(manager: BaseSessionManager) -> SparkSession:
+    """Build a SparkSession against a ready endpoint, with token auto-refresh.
+
+    Assumes the manager's session/endpoint is already in a ready state.
+    """
+    endpoint, token, _expires_at = manager.get_endpoint_and_token()
+    spark_connect_url = manager.build_spark_connect_url(endpoint, token)
+    logger.info(f"Connecting to Spark Connect at {endpoint}")
+
+    channel_builder = EMRChannelBuilder(
+        url=spark_connect_url,
+        refresh_fn=manager.refresh_token,
+    )
+    # create() rather than getOrCreate(): getOrCreate would hand back the
+    # cached session bound to a previous (now stale) channel on reconnect.
+    spark = ConnectSparkSession.builder.channelBuilder(channel_builder).create()
+    logger.info("SparkSession created with automatic token refresh")
+    return spark
+
+
+class EMRSparkSession:
+    """Unified Spark Connect session for EMR Serverless, EMR on EKS, and EMR on EC2.
+
+    Manages the full lifecycle:
+    - Detects backend from resource_id format (or use explicit backend= param)
+    - Starts an interactive session
+    - Waits for session readiness
+    - Creates a PySpark SparkSession with automatic token refresh
+    - Provides session termination on stop()
+
+    The returned object delegates attribute access to the underlying SparkSession,
+    so you can use it exactly like a regular SparkSession:
+        session.sql("...").show()
+        session.read.parquet("s3://...")
+        session.createDataFrame(...)
+    """
+
+    def __init__(
+        self,
+        spark: SparkSession,
+        manager: BaseSessionManager,
+    ):
+        self._spark = spark
+        self._manager = manager
+
+    @classmethod
+    def create(
+        cls,
+        resource_id: str,
+        execution_role_arn: Optional[str] = None,
+        region: Optional[str] = None,
+        backend: Optional[str] = None,
+        session_name: str = "emr-spark-connect",
+        idle_timeout_minutes: int = 60,
+        max_wait_seconds: int = 900,
+        spark_conf: Optional[Dict[str, str]] = None,
+        endpoint_url: Optional[str] = None,
+        boto3_session: Optional[boto3.Session] = None,
+        **kwargs,
+    ) -> "EMRSparkSession":
+        """Create a SparkSession connected to an EMR backend with automatic token refresh.
+
+        Args:
+            resource_id: The EMR resource to connect to:
+                - EMR Serverless application ID (16 chars starting with '00',
+                  e.g. '00abcdef01234567')
+                - EMR on EC2 cluster ID (e.g. 'j-XXXXXXXXXXXXX')
+                - EMR on EKS virtual cluster ID (20-25 alphanumeric chars)
+            execution_role_arn: IAM role ARN for the session. Required for EMR Serverless
+                and EMR on EKS. Optional for EMR on EC2 (runtime role sessions).
+            region: AWS region. If None, uses the default from boto3 session/environment.
+            backend: Explicit backend type ('serverless', 'ec2', 'eks'). If None,
+                auto-detected from resource_id format.
+            session_name: Human-readable session name.
+            idle_timeout_minutes: Auto-terminate session after this many idle minutes.
+            max_wait_seconds: Maximum time to wait for session to become ready.
+            spark_conf: Optional Spark configuration overrides (dict of key→value),
+                applied as a `spark-defaults` classification.
+            endpoint_url: Custom AWS service endpoint URL (for testing/beta).
+            boto3_session: Optional pre-configured boto3.Session to use.
+            **kwargs: Additional backend-specific arguments. For EMR on EKS:
+                - managed_endpoint_id: reuse an existing SPARK_CONNECT managed
+                  endpoint instead of creating one.
+                - release_label: EMR release for the endpoint
+                  (default 'emr-7.14.0-latest').
+                - token_duration_seconds: session token TTL (default 12h, the max).
+                - application_configuration: full `applicationConfiguration` list,
+                  for classifications and nested configs `spark_conf` can't express.
+                - monitoring_configuration: `monitoringConfiguration` dict
+                  (CloudWatch/S3 logging, persistent app UI).
+
+        Returns:
+            EMRSparkSession wrapping a fully-connected PySpark SparkSession.
+
+        Raises:
+            ValueError: If resource_id format is unrecognized and backend is not specified.
+            TimeoutError: If session does not become ready within max_wait_seconds.
+            RuntimeError: If session reaches a terminal/failed state.
+
+        Example:
+            >>> from emr_spark_connect import EMRSparkSession
+            >>> session = EMRSparkSession.create(
+            ...     resource_id="00abcdef01234567",
+            ...     execution_role_arn="arn:aws:iam::123456789012:role/SparkRole",
+            ...     region="us-east-1",
+            ... )
+            >>> session.sql("SELECT 1 + 1 AS result").show()
+            +------+
+            |result|
+            +------+
+            |     2|
+            +------+
+            >>> session.stop()
+        """
+        # Resolve region
+        if region is None:
+            sess = boto3_session or boto3.Session()
+            region = sess.region_name or "us-east-1"
+
+        # Create the appropriate backend session manager
+        manager = create_session_manager(
+            resource_id=resource_id,
+            backend=backend,
+            region=region,
+            execution_role_arn=execution_role_arn,
+            session_name=session_name,
+            idle_timeout_minutes=idle_timeout_minutes,
+            max_wait_seconds=max_wait_seconds,
+            spark_conf=spark_conf,
+            endpoint_url=endpoint_url,
+            boto3_session=boto3_session,
+            **kwargs,
+        )
+
+        # Provision the remote resource and wait for it to be ready. That is
+        # StartSession on Serverless/EC2; on EMR on EKS there is no session API,
+        # so it reuses or creates the SPARK_CONNECT managed endpoint instead.
+        manager.provision()
+        manager.wait_for_ready()
+
+        spark = _connect(manager)
+        return cls(spark=spark, manager=manager)
+
+    @property
+    def spark(self) -> SparkSession:
+        """Access the underlying PySpark SparkSession directly."""
+        return self._spark
+
+    @property
+    def session_id(self) -> Optional[str]:
+        """The EMR session ID, or on EMR on EKS the managed endpoint ID.
+
+        EMR on EKS has no session resource — ``emr-containers`` exposes no
+        ``StartSession`` — so the managed endpoint is the identity of the remote
+        Spark driver there.
+        """
+        return self._manager.session_id
+
+    @property
+    def resource_id(self) -> str:
+        """The EMR resource ID (application ID, cluster ID, or virtual cluster ID)."""
+        return self._manager.resource_id
+
+    def reconnect(self) -> "EMRSparkSession":
+        """Rebuild the Spark Connect channel, replacing the endpoint if expired.
+
+        This exists for EMR on EKS, the one backend whose endpoint is a resource
+        in its own right with its own timer. The endpoint side is handled
+        routinely — a still-``ACTIVE`` endpoint is reused, and one that hit
+        ``sessionIdleTimeoutInMinutes`` is replaced automatically.
+
+        What cannot be automated away is the channel: a replacement endpoint
+        listens on a new ``authProxyUrl``, so the open gRPC channel points at a
+        dead host and a token refresh cannot redirect it. This method drops that
+        channel and builds a new SparkSession against whichever endpoint is live.
+
+        If the endpoint was replaced, the new one is a new Spark driver — temp
+        views and cached DataFrames from before are gone and need re-registering.
+
+        Returns:
+            self, so you can chain: ``session.reconnect().sql("SELECT 1").show()``
+        """
+        # Drop the stale channel first; its target host may no longer answer.
+        # An expired endpoint's ALB is gone, so skip the release RPC there.
+        _discard_channel(self._spark, remote_gone=not self._manager.is_endpoint_active())
+        self._spark = None
+
+        # EKS: reuse the endpoint if live, create one if expired.
+        # Serverless/EC2: no separate endpoint resource, so this is a no-op and
+        # the existing session is reused as-is.
+        self._manager.ensure_endpoint(wait=True)
+
+        self._spark = _connect(self._manager)
+        return self
+
+    def is_endpoint_active(self) -> bool:
+        """Whether the remote endpoint is currently live.
+
+        Meaningful only on EMR on EKS, where False means the managed endpoint
+        has expired and the next call that needs it will create a replacement.
+        On Serverless and EC2 the endpoint belongs to the session and cannot
+        expire separately, so they always report True.
+        """
+        return self._manager.is_endpoint_active()
+
+    @property
+    def token_expires_at(self):
+        """When the auth token currently on the wire expires (UTC), or None.
+
+        None before the first token is minted. This tracks the token the gRPC
+        interceptor is actually sending, so it moves forward on every refresh.
+        """
+        return self._manager.token_expires_at
+
+    @property
+    def token_duration_seconds(self) -> Optional[int]:
+        """The token lifetime this session requests, or None if not settable.
+
+        Only EMR on EKS accepts one — ``token_duration_seconds`` on
+        :meth:`create`, passed through as ``durationInSeconds`` to
+        ``GetManagedEndpointSessionCredentials``. The service honours it exactly,
+        up to the documented 12 h maximum (43200s); larger values are rejected.
+        Serverless and EC2 report None: their token lifetime is service-chosen.
+        """
+        return self._manager.token_duration_seconds
+
+    def token_seconds_remaining(self) -> Optional[float]:
+        """Seconds until the current token expires; negative once it has."""
+        return self._manager.token_seconds_remaining()
+
+    def is_token_expired(self) -> bool:
+        """Whether the token currently on the wire has lapsed.
+
+        A local check against the recorded ``expiresAt`` — no API call, and it
+        says nothing about the endpoint behind the token. True on its own is
+        usually benign: the interceptor remints before any call whose token is
+        within five minutes of expiry.
+
+        On EMR on EKS the endpoint and the token expire on independent clocks,
+        so pair this with :meth:`is_endpoint_active` to tell the two apart. A
+        token is only ever valid against the endpoint it was minted for, so
+        check the endpoint first — once it has expired, the token is moot.
+        """
+        return self._manager.is_token_expired()
+
+    def session_state(self) -> str:
+        """The remote session's state as the service reports it.
+
+        ``NOT_FOUND`` if the session no longer exists. On EMR on EKS, which has
+        no session resource, this reports the managed endpoint's state.
+        """
+        return self._manager.session_state()
+
+    def is_active(self) -> bool:
+        """Whether the remote session can still accept work.
+
+        Use this before reusing a session that has been idle — a session that
+        hit ``idle_timeout_minutes`` is gone, and the next query against it
+        fails with a gRPC or botocore error rather than anything catchable as
+        ``EndpointExpiredError``.
+
+        Recovery differs by backend, because the underlying resource differs:
+
+        * **EMR Serverless / EMR on EC2** — the session *is* the endpoint. A
+          spent session ID cannot be revived, so call :meth:`recreate`.
+        * **EMR on EKS** — the managed endpoint is replaceable underneath a
+          live client, so call :meth:`reconnect`. This method is a synonym for
+          :meth:`is_endpoint_active` there.
+
+        Note this reports on the *remote* session only. It stays True after a
+        local ``stop()`` with ``terminate=False``, since the remote session is
+        indeed still alive; use :attr:`spark` being None to test the local side.
+        """
+        return self._manager.is_session_active()
+
+    def recreate(self) -> "EMRSparkSession":
+        """Start a fresh remote session and reattach, reusing the original settings.
+
+        For EMR Serverless and EMR on EC2, where an idled-out session cannot be
+        revived. The new session inherits every argument the original was
+        created with, so a caller does not have to restate them.
+
+        The result is a **new remote session with a new ID**. Temp views, cached
+        DataFrames and any other driver-side state from the old session are gone.
+        On EMR on EC2 the session ID is embedded in the Spark Connect URL, so the
+        channel is necessarily rebuilt too.
+
+        Mutates and returns ``self``, so an existing variable stays valid:
+
+            if not session.is_active():
+                session.recreate()
+
+        Raises:
+            NotImplementedError: On EMR on EKS. Its managed endpoint is replaced
+                in place by ``reconnect()``; recreating the session is neither
+                needed nor correct.
+        """
+        from .backends import EKSSessionManager
+
+        if isinstance(self._manager, EKSSessionManager):
+            raise NotImplementedError(
+                "recreate() does not apply to EMR on EKS: an expired managed "
+                "endpoint is replaced in place — call reconnect() instead."
+            )
+
+        old_session_id = self.session_id
+
+        # Drop the local channel first; its session is spent and the host may
+        # not answer. Deliberately not terminate_session() — the remote session
+        # is already gone, and calling it on a live one would be destructive.
+        # remote_gone is decided by asking the service, not assumed: recreate()
+        # on a still-live session should release it cleanly rather than leak it.
+        _discard_channel(self._spark, remote_gone=not self._manager.is_session_active())
+        self._spark = None
+
+        # Re-provision through the same manager, which still holds every
+        # create() argument; provision() overwrites _session_id with the new one.
+        self._manager.provision()
+        try:
+            self._manager.wait_for_ready()
+            self._spark = _connect(self._manager)
+        except BaseException:
+            # The replacement was started but never became usable. It is billing
+            # and idle-timing out on its own, so say which ID to chase — silently
+            # dropping the reference is how clusters fill up with orphans.
+            logger.error(
+                f"Recreate failed after starting session {self.session_id}; it is "
+                "still running remotely. Call stop() to terminate it, or reuse it "
+                "once the cluster has capacity."
+            )
+            raise
+
+        logger.info(f"Recreated session: {old_session_id} -> {self.session_id}")
+        return self
+
+    def stop(self, terminate: bool = True) -> None:
+        """Stop the SparkSession and optionally release the remote resource.
+
+        Args:
+            terminate: If True (default), releases the remote resource —
+                ``TerminateSession`` on Serverless/EC2, or deleting the managed
+                endpoint on EMR on EKS (only if this client created it; an
+                endpoint passed in as ``managed_endpoint_id`` is left alone).
+                Set to False to leave it running for reuse.
+        """
+        if self._spark is not None:
+            # A session that already idled out cannot answer the release RPC;
+            # without this, stop() blocks on retries for over ten minutes.
+            _discard_channel(
+                self._spark, remote_gone=not self._manager.is_session_active()
+            )
+            self._spark = None
+
+        if terminate:
+            self._manager.terminate_session()
+
+    def __enter__(self) -> "EMRSparkSession":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.stop()
+
+    def __getattr__(self, name):
+        """Delegate attribute access to the underlying SparkSession.
+
+        This allows using EMRSparkSession exactly like a regular SparkSession:
+            session.sql("...")
+            session.read.parquet("...")
+            session.createDataFrame(...)
+        """
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return getattr(self._spark, name)
+
+    def __repr__(self) -> str:
+        backend = type(self._manager).__name__.replace("SessionManager", "")
+        return (
+            f"EMRSparkSession(backend={backend}, "
+            f"resource_id={self.resource_id}, "
+            f"session_id={self.session_id})"
+        )

--- a/utilities/emr-spark-connect-client/test_ec2.py
+++ b/utilities/emr-spark-connect-client/test_ec2.py
@@ -1,0 +1,49 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: MIT-0
+"""End-to-end test of EMRSparkSession with EMR on EC2."""
+
+import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+logging.getLogger("emr_spark_connect").setLevel(logging.DEBUG)
+
+from emr_spark_connect import EMRSparkSession
+
+CLUSTER_ID = "j-1K48XXXXXXHCB"
+REGION = "us-east-1"
+
+print(f"Connecting to EMR on EC2 cluster: {CLUSTER_ID}")
+print(f"Region: {REGION}")
+print()
+
+session = EMRSparkSession.create(
+    resource_id=CLUSTER_ID,
+    region=REGION,
+    session_name="spark-connect-client-test",
+    idle_timeout_minutes=15,
+)
+
+try:
+    print(f"\n{'='*60}")
+    print(f"Connected! Session ID: {session.session_id}")
+    print(f"Spark version: {session.spark.version}")
+    print(f"{'='*60}\n")
+
+    # Test 1: Simple SQL
+    print("Test 1: Simple SQL")
+    session.sql("SELECT 1 + 1 AS result").show()
+
+    # Test 2: DataFrame operations
+    print("Test 2: DataFrame operations")
+    df = session.range(10)
+    df.selectExpr("id", "id * id AS squared").show()
+
+    # Test 3: Current timestamp
+    print("Test 3: Current timestamp")
+    session.sql("SELECT current_timestamp() AS now, current_date() AS today").show(truncate=False)
+
+    print("\n✅ All tests passed!")
+
+finally:
+    session.stop()
+    print("Session terminated.")

--- a/utilities/emr-spark-connect-client/test_emreks.py
+++ b/utilities/emr-spark-connect-client/test_emreks.py
@@ -1,0 +1,154 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: MIT-0
+"""End-to-end test of EMRSparkSession with EMR on EKS.
+
+Follows the three steps of the EMR on EKS Spark Connect setup, but driven
+through the client instead of the AWS CLI:
+
+  Step 1  Create a SPARK_CONNECT managed endpoint on the virtual cluster
+          (CreateManagedEndpoint), then wait for state ACTIVE and read
+          endpoint.authProxyUrl.
+  Step 2  Mint a session token (GetManagedEndpointSessionCredentials,
+          credentialType=TOKEN, durationInSeconds=43200).
+  Step 3  Connect with sc://{authProxyUrl}:443/;use_ssl=true;x-aws-proxy-auth=...
+          and run queries.
+
+EMRSparkSession.create() does all three. Note there is no fourth step starting a
+session: emr-containers has no StartSession/GetSession API, and Step 2's token comes
+back already active, so the managed endpoint is the whole remote resource — which is
+why session.session_id below is a managed endpoint ID.
+
+Unlike Serverless/EC2 — session-based backends whose token is refreshed in place —
+EMR on EKS has two layers on independent timers: the managed endpoint
+(sessionIdleTimeoutInMinutes) and the session token (durationInSeconds). While the
+endpoint is ACTIVE it is reused and only the token is reminted. Once the endpoint
+times out, a NEW endpoint is created before a new token can be minted, and it comes
+up on a new authProxyUrl host — so the gRPC channel must be rebuilt too.
+session.reconnect() does that; Test 5 exercises it.
+
+Prerequisites:
+    - Virtual cluster in RUNNING state on an EMR release that supports
+      SPARK_CONNECT managed endpoints.
+    - Job execution role trusted by EMR on EKS with access to your data.
+    - AWS Load Balancer Controller on the EKS cluster (the endpoint is fronted
+      by an ALB), and network reachability from this machine to that ALB.
+    - IAM: emr-containers:CreateManagedEndpoint, DescribeManagedEndpoint,
+      DeleteManagedEndpoint, GetManagedEndpointSessionCredentials.
+
+Usage:
+    python test_emreks.py
+
+    # Reuse an already-ACTIVE endpoint to skip the multi-minute create:
+    EP_ID=xxxxxxxxxxxxx python test_emreks.py
+"""
+
+import logging
+import os
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+logging.getLogger("emr_spark_connect").setLevel(logging.DEBUG)
+
+from emr_spark_connect import EMRSparkSession
+
+VIRTUAL_CLUSTER_ID = os.environ.get("VC_ID", "xxxxxxxxxxxx")
+EXECUTION_ROLE = os.environ.get(
+    "ROLE_ARN", "arn:aws:iam::ACCOUNTID:role/emr-on-eks-execution-role"
+)
+REGION = os.environ.get("AWS_REGION", "us-west-2")
+RELEASE_LABEL = os.environ.get("RELEASE_LABEL", "emr-7.14.0-latest")
+# Endpoint teardown timer
+IDLE_TIMEOUT_MINUTES = int(os.environ.get("IDLE_TIMEOUT_MINUTES", "60"))
+# session token timer
+TOKEN_TIMEOUT_SECONDS = int(os.environ.get("TOKEN_TIMEOUT_SECONDS", "43200"))
+# optional: how long to wait for the endpoint to become ACTIVE before giving up
+MAX_WAIT_SECONDS = int(os.environ.get("MAX_WAIT_SECONDS", "1800"))
+# Optional: reuse an existing ACTIVE endpoint instead of creating one.
+MANAGED_ENDPOINT_ID = os.environ.get("EP_ID") or None
+# Optional control-plane endpoint override (e.g. a beta endpoint). Leave
+# EMR_ENDPOINT_URL unset to use botocore's default resolution.
+ENDPOINT_URL = os.environ.get("EMR_ENDPOINT_URL") or None
+
+print(f"Connecting to EMR on EKS virtual cluster: {VIRTUAL_CLUSTER_ID}")
+print(f"Execution role: {EXECUTION_ROLE}")
+print(f"Region: {REGION}")
+print(f"Release label: {RELEASE_LABEL}")
+print(f"Idle timeout: {IDLE_TIMEOUT_MINUTES} min")
+print(f"Control plane: {ENDPOINT_URL or '<prod (botocore default)>'}")
+if MANAGED_ENDPOINT_ID:
+    print(f"Reusing managed endpoint: {MANAGED_ENDPOINT_ID}")
+else:
+    print("Creating a new SPARK_CONNECT endpoint")
+print()
+
+# Steps 1-3. Endpoint creation provisions an ALB, so allow well over the 900s
+# default that suffices for Serverless/EC2 sessions.
+session = EMRSparkSession.create(
+    resource_id=VIRTUAL_CLUSTER_ID,
+    execution_role_arn=EXECUTION_ROLE,
+    region=REGION,
+    session_name="spark-connect-demo",
+    idle_timeout_minutes=IDLE_TIMEOUT_MINUTES,
+    token_duration_seconds=TOKEN_TIMEOUT_SECONDS,
+    max_wait_seconds=MAX_WAIT_SECONDS,
+    release_label=RELEASE_LABEL,
+    spark_conf={
+        "spark.dynamicAllocation.enabled": "true",
+        "spark.dynamicAllocation.minExecutors": "0",
+    },
+    endpoint_url=ENDPOINT_URL,
+    managed_endpoint_id=MANAGED_ENDPOINT_ID,
+)
+
+try:
+    print(f"\n{'='*60}")
+    print(f"Connected! Managed endpoint ID: {session.session_id}")
+    print(f"Spark version: {session.spark.version}")
+    print(f"{'='*60}\n")
+
+    # Test 1: Simple SQL
+    print("Test 1: Simple SQL")
+    session.sql("SELECT 1 + 1 AS result").show()
+
+    # Test 2: DataFrame operations
+    print("Test 2: DataFrame operations")
+    df = session.range(10)
+    df.selectExpr("id", "id * id AS squared").show()
+
+    # Test 3: Current timestamp
+    print("Test 3: Current timestamp")
+    session.sql("SELECT current_timestamp() AS now, current_date() AS today").show(truncate=False)
+
+    # Test 4: Confirm the Spark configs from Step 1 reached the driver
+    print("Test 4: Spark config overrides applied")
+    for key in ("spark.dynamicAllocation.enabled", "spark.dynamicAllocation.minExecutors"):
+        print(f"  {key} = {session.conf.get(key, '<unset>')}")
+
+    # Test 5: reconnect(). The endpoint layer is reused while ACTIVE and replaced
+    # once it has hit sessionIdleTimeoutInMinutes, so on a healthy session this
+    # rebuilds the channel against the SAME endpoint — no second ALB.
+    if os.environ.get("TEST_RECONNECT") == "1":
+        print("\nTest 5: reconnect()")
+        old_endpoint = session.session_id
+        active_before = session.is_endpoint_active()
+        print(f"  endpoint active before: {active_before}")
+        session.reconnect()
+        print(f"  endpoint: {old_endpoint} -> {session.session_id}")
+        if active_before:
+            assert session.session_id == old_endpoint, (
+                "a live endpoint must be reused, not replaced"
+            )
+        else:
+            assert session.session_id != old_endpoint, (
+                "an expired endpoint must be replaced"
+            )
+        session.sql("SELECT 'reconnected' AS status").show()
+    else:
+        print("\nTest 5: skipped (set TEST_RECONNECT=1 to exercise reconnect())")
+
+    print("\n✅ All tests passed!")
+
+finally:
+    # Stop the Spark session but keep the endpoint alive for reuse; pass
+    # terminate=True to delete the managed endpoint as well.
+    session.stop(terminate=False)
+    print("Session stopped; endpoint left running for reuse.")

--- a/utilities/emr-spark-connect-client/test_emrs.py
+++ b/utilities/emr-spark-connect-client/test_emrs.py
@@ -1,0 +1,51 @@
+# // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# // SPDX-License-Identifier: MIT-0
+"""End-to-end test of EMRSparkSession with EMR Serverless."""
+
+import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+logging.getLogger("emr_spark_connect").setLevel(logging.DEBUG)
+
+from emr_spark_connect import EMRSparkSession
+
+APPLICATION_ID = "00abcdef01234567"
+EXECUTION_ROLE = "arn:aws:iam::123456789012:role/EMRServerlessS3RuntimeRole"
+REGION = "us-east-1"
+
+print(f"Connecting to EMR Serverless application: {APPLICATION_ID}")
+print(f"Execution role: {EXECUTION_ROLE}")
+print(f"Region: {REGION}")
+print()
+
+session = EMRSparkSession.create(
+    resource_id=APPLICATION_ID,
+    execution_role_arn=EXECUTION_ROLE,
+    region=REGION,
+    idle_timeout_minutes=15,
+)
+
+try:
+    print(f"\n{'='*60}")
+    print(f"Connected! Session ID: {session.session_id}")
+    print(f"Spark version: {session.spark.version}")
+    print(f"{'='*60}\n")
+
+    # Test 1: Simple SQL
+    print("Test 1: Simple SQL")
+    session.sql("SELECT 1 + 1 AS result").show()
+
+    # Test 2: DataFrame operations
+    print("Test 2: DataFrame operations")
+    df = session.range(10)
+    df.selectExpr("id", "id * id AS squared").show()
+
+    # Test 3: SQL with multiple columns
+    print("Test 3: Current timestamp")
+    session.sql("SELECT current_timestamp() AS now, current_date() AS today").show(truncate=False)
+
+    print("\n✅ All tests passed!")
+
+finally:
+    session.stop()
+    print("Session terminated.")


### PR DESCRIPTION
## What this adds

A new utility, `utilities/emr-spark-connect-client` — a Python package (`emr-spark-connect`) that gives a single PySpark Spark Connect interface across all three EMR deployment models, with automatic auth token refresh.

```python
from emr_spark_connect import EMRSparkSession

session = EMRSparkSession.create(
    resource_id="00abcdef01234567",   # backend auto-detected from ID format
    execution_role_arn="arn:aws:iam::123456789012:role/MyRole",
    region="us-east-1",
)
session.sql("SELECT 1 + 1 AS result").show()
session.stop()
```

## Features

- **One interface for all EMR backends** — auto-detects EMR Serverless, EMR on EC2, or EMR on EKS from the resource ID (application ID / cluster ID / virtual cluster ID)
- **Automatic token refresh** — a gRPC interceptor transparently remints the auth token before expiry, so sessions survive past the token TTL
- **Remote lifecycle management** — starts sessions (Serverless/EC2) or reuses/creates the `SPARK_CONNECT` managed endpoint (EKS, which has no session API); waits for ready; releases on `stop()`
- **EMR on EKS endpoint expiry handling** — the managed endpoint and its tokens expire on independent timers; a live endpoint is reused, an expired one is replaced automatically, and `reconnect()` reattaches the channel to the replacement
- **Session recovery** — `recreate()` starts a fresh session with the original settings when an idled-out Serverless/EC2 session cannot be revived
- **Standard SparkSession semantics** — `sql()`, `read`, `createDataFrame()`, context manager support

## Contents

- `src/emr_spark_connect/` — package (session facade, backend managers, gRPC interceptor)
- `examples/` — per-backend examples, a long-running-session example, and a demo notebook
- `test_emrs.py` / `test_ec2.py` / `test_emreks.py` — end-to-end test scripts per backend
- `README.md` / `TESTING.md` — usage and verification notes

## Testing

- EMR Serverless (emr-7.13.0, Spark 3.5.6) and EMR on EC2 (emr-spark-8.0.0, Spark 4.0.2) verified end-to-end, including token refresh scheduling
- EMR on EKS verified against the API contract with mocked clients (endpoint reuse/replacement, token minting, ownership-scoped delete); `test_emreks.py` is the live end-to-end script
- All code MIT-0 licensed with SPDX headers; no real account IDs or internal endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)