### PR TITLE
Add Authors section and remove internal package name (emr-al1-migration-skill)

### DIFF
--- a/utilities/emr-al1-migration-skill/README.md
+++ b/utilities/emr-al1-migration-skill/README.md
@@ -5,6 +5,12 @@
 
 Upgrades Amazon EMR clusters from **EMR 5.x (Amazon Linux 1)** to **EMR 7.x (Amazon Linux 2023)**, including all application code: Spark, Hive, Presto→Trino, MapReduce, Flink, Pig→PySpark, and Zeppelin notebooks.
 
+## Authors
+
+- Parul Saxena
+- Kshitija Dound
+- Keerthi Chadalavada
+
 ---
 
 ## Quick start

--- a/utilities/emr-al1-migration-skill/tests/dry_run_simulation.py
+++ b/utilities/emr-al1-migration-skill/tests/dry_run_simulation.py
@@ -305,9 +305,8 @@ def stage3_upgrade(gathered: Dict) -> Dict:
     if "Pig" in gathered["workload_types"]:
         print("\n  --- Stage 3F: Pig → PySpark Conversion ---")
 
-        # Check PigToSparkConversion MCP
-        # NOTE: PigToSparkConversion MCP does not exist — agent handles conversion directly
-        # using references/pig-to-spark-mapping.md
+        # Pig -> PySpark conversion is handled by the agent directly
+        # using references/pig-to-spark-mapping.md (no external tooling required)
         import os
         pig_mapping_exists = os.path.exists(os.path.join(os.path.dirname(os.path.dirname(__file__)), 
                                                           "references", "pig-to-spark-mapping.md"))


### PR DESCRIPTION
Follow-up cleanup to #207.

Removes an internal Amazon package name (`PigToSparkConversion`) from a code comment in `dry_run_simulation.py`. The comment previously named an internal-only MCP package while noting it is not used. Reworded to describe the mechanism (agent-driven Pig -> PySpark conversion via `references/pig-to-spark-mapping.md`) without referencing internal tooling.

No functional change — comment-only edit. The skill has never depended on or invoked that package; Pig conversion is handled directly by the agent using the public mapping reference.
