### PR TITLE
Add EMR 8.1 multi-catalog example (examples/emr-multi-catalog)

### DIFF
--- a/examples/emr-multi-catalog/.gitignore
+++ b/examples/emr-multi-catalog/.gitignore
@@ -1,0 +1,23 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+
+# Local scratch / generated policy docs
+/tmp/
+*.log
+*.gz
+
+# Editor / OS
+.DS_Store
+.idea/
+.vscode/
+*.swp
+
+# Never commit credentials
+*.pem
+*credentials*
+.aws/
+.env

--- a/examples/emr-multi-catalog/README.md
+++ b/examples/emr-multi-catalog/README.md
@@ -1,0 +1,128 @@
+# Multi-catalog support in Amazon EMR 8.1
+
+Companion demo for the AWS Big Data Blog post *"Simplify querying across AWS accounts and table
+formats with multi-catalog support in Amazon EMR."*
+
+Amazon EMR 8.1 introduces the **RedirectingSessionCatalog (RSC)**, a Spark default catalog that
+resolves multiple table formats and multiple metastores. This demo shows, end to end, how a single
+Spark query reads **Apache Iceberg, Delta Lake, Apache Hudi, and Apache Hive** tables through one
+catalog — and how a **named catalog** and the **GlueCatalogResolver** extend that across **AWS
+accounts** with no data copy.
+
+> **Requires Amazon EMR 8.1** (the RSC classes do not exist in EMR 7.x). Validated on **EMR
+> Serverless, Spark 4.1.1**. A single `run_demo.sh --phase all` created the four sample tables, ran
+> the four-format join, and both cross-account phases (declared named catalog and auto-wiring),
+> returning the remote account's rows joined to a local Iceberg table.
+
+## What it demonstrates
+
+| # | Capability | What it removes | Runs where |
+|---|---|---|---|
+| 1 | Multi-format | the *format* prefix | single account |
+| 2 | Multi-catalog (cross-account) | the *account* boundary | two accounts |
+| 3 | Auto-wiring | the *upfront configuration* | single + two accounts |
+
+## Contents
+
+```
+env.template                    # copy to .env; holds app id / role / bucket / region
+scripts/
+├── bootstrap.sh                # create Glue DB, upload the worker, check the app
+├── run_demo.sh                 # driver: sets Spark config per phase, submits to EMR Serverless
+├── cleanup.sh                  # drop tables/database and wipe the warehouse
+├── multicatalog_demo.py        # generic PySpark worker (issues SQL, reports PASS/FAIL)
+├── bootstrap_consumer.sh       # (cross-account) create/prepare the consumer-account resources
+├── bootstrap_producer.sh       # (cross-account) create the producer table + grants
+└── crossaccount_policies/      # example Lake Formation grants, Glue resource + S3 bucket policies
+```
+
+The Spark catalog configuration is supplied at `spark-submit` time by `run_demo.sh`; the worker only
+issues SQL, so the same script serves every phase. `bootstrap.sh`, `run_demo.sh`, and `cleanup.sh`
+read `APP_ID` / `ROLE_ARN` / `BUCKET` / `REGION` from a `.env` file (see `env.template`), so you do
+not repeat those flags on every command.
+
+## Prerequisites
+
+- An **Amazon EMR Serverless application on EMR 8.1** (Spark). The features also work on Amazon EMR
+  on EC2 and Amazon EMR on EKS.
+- An EMR Serverless **job execution role** with AWS Glue Data Catalog and Amazon S3 access.
+- An **S3 bucket** for scripts, warehouse, and logs (this demo uses
+  `s3://amzn-s3-demo-bucket/multicatalog/`).
+- For the cross-account phases: a second (producer) account, and the cross-account grants in
+  `scripts/crossaccount_policies/` (Lake Formation, Glue resource policy, S3 bucket policy, and a
+  customer-managed KMS key).
+
+## Quick start (single account, multi-format)
+
+```bash
+# 0) Configure once
+cp env.template .env
+# edit .env: APP_ID, ROLE_ARN, BUCKET, REGION
+
+# 1) Create the Glue database, upload the worker, check the application
+./scripts/bootstrap.sh
+
+# 2) Create one sample table per format (Iceberg, Delta, Hudi, Hive), 3 rows each
+./scripts/run_demo.sh --phase setup
+
+# 3) Run the four-format join through one catalog, no format prefixes
+./scripts/run_demo.sh --phase query
+```
+
+(`query` is an alias for the `multiformat` phase. All flags may still be passed explicitly —
+`--app-id`, `--role-arn`, `--bucket`, `--region` — to override `.env`.)
+
+Expected join output:
+
+```
++---+--------+------+------+------+
+| id| iceberg| delta| hudi | hive |
++---+--------+------+------+------+
+|  1| ice-1  | dl-1 | hu-1 | hv-1 |
+|  2| ice-2  | dl-2 | hu-2 | hv-2 |
+|  3| ice-3  | dl-3 | hu-3 | hv-3 |
++---+--------+------+------+------+
+```
+
+Each column comes from a different table format, joined in one query with no format-specific catalog
+configuration.
+
+## Phases
+
+`run_demo.sh --phase <phase>` supports:
+
+| Phase | What it does |
+|---|---|
+| `setup` | Create one sample table per format (Iceberg, Delta, Hudi, Hive), 3 rows each. |
+| `multiformat` | Join all four formats in one query, unqualified names. |
+| `named-local` | Single-account demo of the named-catalog mechanism (a named RSC pointed at this account). |
+| `producer-setup` | Create the producer Hive table (run with the producer account's app/role). |
+| `xacct-named` | Read the producer table through a declared named catalog, joined to local Iceberg. |
+| `xacct-autowire` | Read the producer table by its backtick-quoted account id — no catalog declaration. |
+| `cleanup` | Drop the demo tables/database and wipe the S3 warehouse. |
+| `all` | `setup` + `multiformat`, plus the two cross-account phases when `--producer-account` is given. |
+
+## Cross-account (optional)
+
+```bash
+# In the producer account (owns the data): create the table + grants
+./scripts/bootstrap_producer.sh --consumer-role <CONSUMER_ROLE_ARN>
+
+# In the consumer account (where EMR runs): read across the account boundary
+./scripts/run_demo.sh --phase xacct-autowire \
+  --app-id <APP_ID> --role-arn <ROLE_ARN> --bucket <BUCKET> \
+  --producer-account 111122223333 --producer-table fulfillment
+```
+
+Cross-account access is query-time resolution only — it does not copy data. It requires Lake
+Formation grants, a Glue resource policy, an S3 bucket policy, and (if encrypted) a customer-managed
+KMS key. See `scripts/crossaccount_policies/` for examples.
+
+## Clean up
+
+```bash
+./scripts/cleanup.sh
+```
+
+This drops the demo tables and database and wipes the S3 warehouse. Delete the EMR Serverless
+application and execution role separately if you created them only for this demo.

--- a/examples/emr-multi-catalog/env.template
+++ b/examples/emr-multi-catalog/env.template
@@ -1,0 +1,29 @@
+# Copy to .env and fill in. bootstrap.sh, run_demo.sh, and cleanup.sh source this
+# file so you do not repeat --cluster-id / --app-id / --bucket on every command.
+#
+#   cp env.template .env
+#   # then edit the values below
+
+# Deployment target: ec2 (default) or serverless
+TARGET=ec2
+
+# ---- EMR on EC2 (TARGET=ec2) ----------------------------------------------
+# A running Amazon EMR 8.1 cluster ID. The cluster must enable Iceberg via the
+# `iceberg-defaults` classification ({"iceberg.enabled":"true"}). Delta Lake and
+# Hudi are included with EMR.
+CLUSTER_ID=
+
+# ---- EMR Serverless (TARGET=serverless) -----------------------------------
+# EMR Serverless application ID (release EMR 8.1) and job execution role ARN.
+APP_ID=
+ROLE_ARN=
+
+# ---- common ----------------------------------------------------------------
+# S3 bucket for scripts, warehouse, and logs
+BUCKET=amzn-s3-demo-bucket
+# Region where your EMR cluster/application and Glue catalog live
+REGION=us-east-1
+
+# ---- optional: cross-account (cross-account phases) ------------------------
+PRODUCER_ACCOUNT=
+PRODUCER_REGION=us-east-1

--- a/examples/emr-multi-catalog/scripts/bootstrap.sh
+++ b/examples/emr-multi-catalog/scripts/bootstrap.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Bootstrap the single-account multi-catalog demo:
+#   1. create the AWS Glue database (via the Glue API, so it exists before the
+#      demo issues CREATE TABLE),
+#   2. upload the PySpark worker (multicatalog_demo.py) to S3,
+#   3. report the EMR Serverless application state.
+#
+# Reads APP_ID / ROLE_ARN / BUCKET / REGION from .env (or pass as flags).
+#
+# Usage:
+#   cp env.template .env      # then edit values
+#   ./scripts/bootstrap.sh
+#
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+for _envf in "./.env" "${SELF_DIR}/../.env" "${SELF_DIR}/.env"; do
+  [[ -f "$_envf" ]] && { set -a; . "$_envf"; set +a; break; }
+done
+
+DB="${DB:-salesdb}"; REGION="${REGION:-us-east-1}"; TARGET="${TARGET:-ec2}"
+CLUSTER_ID="${CLUSTER_ID:-}"; APP_ID="${APP_ID:-}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)     TARGET="$2"; shift 2;;
+    --cluster-id) CLUSTER_ID="$2"; shift 2;;
+    --app-id)     APP_ID="$2"; shift 2;;
+    --bucket)     BUCKET="$2"; shift 2;;
+    --region)     REGION="$2"; shift 2;;
+    --db)         DB="$2"; shift 2;;
+    *) echo "unknown flag: $1" >&2; exit 2;;
+  esac
+done
+
+: "${BUCKET:?set BUCKET in .env or pass --bucket}"
+PREFIX="s3://${BUCKET}/multicatalog"
+WAREHOUSE="${PREFIX}/warehouse"
+SCRIPTS="${PREFIX}/scripts"
+
+echo ">> creating Glue database '${DB}' (idempotent)"
+aws glue create-database --region "$REGION" \
+  --database-input "{\"Name\":\"${DB}\",\"LocationUri\":\"${WAREHOUSE}/${DB}.db\"}" 2>/dev/null \
+  || echo "   database '${DB}' already exists"
+
+echo ">> uploading PySpark worker to ${SCRIPTS}/"
+aws s3 cp "${SELF_DIR}/multicatalog_demo.py" "${SCRIPTS}/multicatalog_demo.py" --region "$REGION" >/dev/null
+
+if [[ "$TARGET" == "ec2" && -n "$CLUSTER_ID" ]]; then
+  ST=$(aws emr describe-cluster --region "$REGION" --cluster-id "$CLUSTER_ID" \
+        --query 'Cluster.Status.State' --output text 2>/dev/null || echo "UNKNOWN")
+  echo ">> EMR on EC2 cluster ${CLUSTER_ID} state=${ST}"
+elif [[ "$TARGET" == "serverless" && -n "$APP_ID" ]]; then
+  ST=$(aws emr-serverless get-application --region "$REGION" --application-id "$APP_ID" \
+        --query 'application.state' --output text 2>/dev/null || echo "UNKNOWN")
+  echo ">> EMR Serverless application ${APP_ID} state=${ST}"
+else
+  echo ">> (no cluster/app id set; skipping compute check)"
+fi
+
+echo ">> bootstrap complete. Next: ./scripts/run_demo.sh --phase setup"

--- a/examples/emr-multi-catalog/scripts/bootstrap_consumer.sh
+++ b/examples/emr-multi-catalog/scripts/bootstrap_consumer.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Cross-account demo bootstrap — CONSUMER side.
+# Run this with the CONSUMER account's credentials. It:
+#   1. creates an S3 bucket for scripts/warehouse/logs (if needed),
+#   2. creates an EMR Serverless execution role with the permissions the demo needs
+#      (Glue + S3 on this account, Lake Formation GetDataAccess, and — if
+#      --producer-account is given — cross-account Glue/S3 read),
+#   3. creates an EMR 8.1 Serverless application,
+#   and prints the --app-id / --role-arn / --bucket to pass to run_demo.sh.
+#
+# NOTE: requires the public EMR 8.1 release label to be available in your region.
+# Until EMR 8.1 is GA you can pass --release / --endpoint to target a preview.
+#
+# Usage:
+#   ./bootstrap_consumer.sh [--region us-east-1] [--bucket <bucket>]
+#       [--role-name EMRMultiCatalogDemoRole] [--app-name multicatalog-demo]
+#       [--producer-account 111122223333] [--producer-bucket <producer-bucket>]
+#       [--release emr-8.1.0] [--endpoint <emr-serverless-endpoint>]
+set -euo pipefail
+
+REGION="us-east-1" BUCKET="" ROLE_NAME="EMRMultiCatalogDemoRole"
+APP_NAME="multicatalog-demo" PRODUCER_ACCOUNT="" PRODUCER_BUCKET=""
+RELEASE="emr-8.1.0" ENDPOINT="" DRY_RUN=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --region)            REGION="$2"; shift 2;;
+    --bucket)            BUCKET="$2"; shift 2;;
+    --role-name)         ROLE_NAME="$2"; shift 2;;
+    --app-name)          APP_NAME="$2"; shift 2;;
+    --producer-account)  PRODUCER_ACCOUNT="$2"; shift 2;;
+    --producer-bucket)   PRODUCER_BUCKET="$2"; shift 2;;
+    --release)           RELEASE="$2"; shift 2;;
+    --endpoint)          ENDPOINT="$2"; shift 2;;
+    --dry-run)           DRY_RUN=true; shift;;
+    *) echo "unknown flag: $1" >&2; exit 2;;
+  esac
+done
+EP_FLAG=""; [[ -n "$ENDPOINT" ]] && EP_FLAG="--endpoint-url $ENDPOINT"
+$DRY_RUN && echo ">> DRY RUN — no resources will be created (read-only calls still run)"
+
+# run a MUTATING command, or just print it under --dry-run
+run() { if $DRY_RUN; then echo "  [dry-run] $*"; else "$@"; fi; }
+
+ACCOUNT=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)
+if [[ -z "$ACCOUNT" ]]; then
+  $DRY_RUN && ACCOUNT="<account-id>" || { echo "cannot determine caller account (invalid/expired creds?)" >&2; exit 1; }
+fi
+BUCKET="${BUCKET:-multicatalog-demo-${ACCOUNT}-${REGION//-/}}"
+echo ">> consumer account=${ACCOUNT} region=${REGION} bucket=${BUCKET}"
+
+# 1. bucket -------------------------------------------------------------------
+if ! aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+  if [[ "$REGION" == "us-east-1" ]]; then
+    run aws s3api create-bucket --bucket "$BUCKET" --region "$REGION"
+  else
+    run aws s3api create-bucket --bucket "$BUCKET" --region "$REGION" \
+      --create-bucket-configuration LocationConstraint="$REGION"
+  fi
+  echo "   created bucket ${BUCKET}"
+fi
+
+# 2. execution role -----------------------------------------------------------
+cat > /tmp/trust.json <<'EOF'
+{ "Version": "2012-10-17", "Statement": [{
+  "Effect": "Allow",
+  "Principal": {"Service": "emr-serverless.amazonaws.com"},
+  "Action": "sts:AssumeRole"
+}]}
+EOF
+if ! aws iam get-role --role-name "$ROLE_NAME" >/dev/null 2>&1; then
+  run aws iam create-role --role-name "$ROLE_NAME" \
+    --assume-role-policy-document file:///tmp/trust.json
+  echo "   created role ${ROLE_NAME}"
+fi
+ROLE_ARN=$(aws iam get-role --role-name "$ROLE_NAME" --query 'Role.Arn' --output text 2>/dev/null \
+           || echo "arn:aws:iam::${ACCOUNT}:role/${ROLE_NAME}")
+
+# base permissions: own Glue catalog + this bucket + Lake Formation data access
+XACCT_GLUE=""; XACCT_S3=""
+if [[ -n "$PRODUCER_ACCOUNT" ]]; then
+  XACCT_GLUE=",\"arn:aws:glue:${REGION}:${PRODUCER_ACCOUNT}:catalog\",\"arn:aws:glue:${REGION}:${PRODUCER_ACCOUNT}:database/*\",\"arn:aws:glue:${REGION}:${PRODUCER_ACCOUNT}:table/*/*\""
+  if [[ -n "$PRODUCER_BUCKET" ]]; then
+    XACCT_S3=",\"arn:aws:s3:::${PRODUCER_BUCKET}\",\"arn:aws:s3:::${PRODUCER_BUCKET}/*\""
+  fi
+fi
+cat > /tmp/exec-policy.json <<EOF
+{ "Version": "2012-10-17", "Statement": [
+  { "Sid": "GlueAccess", "Effect": "Allow",
+    "Action": ["glue:Get*","glue:BatchGet*","glue:CreateDatabase","glue:CreateTable",
+               "glue:UpdateTable","glue:DeleteTable","glue:UpdateDatabase"],
+    "Resource": ["arn:aws:glue:${REGION}:${ACCOUNT}:catalog",
+                 "arn:aws:glue:${REGION}:${ACCOUNT}:database/*",
+                 "arn:aws:glue:${REGION}:${ACCOUNT}:table/*/*"${XACCT_GLUE}] },
+  { "Sid": "S3Access", "Effect": "Allow",
+    "Action": ["s3:GetObject","s3:PutObject","s3:DeleteObject","s3:ListBucket"],
+    "Resource": ["arn:aws:s3:::${BUCKET}","arn:aws:s3:::${BUCKET}/*"${XACCT_S3}] },
+  { "Sid": "LakeFormation", "Effect": "Allow",
+    "Action": ["lakeformation:GetDataAccess"], "Resource": "*" }
+] }
+EOF
+run aws iam put-role-policy --role-name "$ROLE_NAME" \
+  --policy-name multicatalog-demo --policy-document file:///tmp/exec-policy.json
+echo "   attached inline policy to ${ROLE_NAME}"
+[[ -n "$PRODUCER_ACCOUNT" && -z "$PRODUCER_BUCKET" ]] && \
+  echo "   NOTE: pass --producer-bucket to allow cross-account S3 data reads."
+
+# 3. EMR Serverless application ----------------------------------------------
+APP_ID=$(aws emr-serverless list-applications $EP_FLAG --region "$REGION" \
+          --query "applications[?name=='${APP_NAME}'].id | [0]" --output text 2>/dev/null || echo "None")
+if [[ "$APP_ID" == "None" || -z "$APP_ID" ]]; then
+  if $DRY_RUN; then
+    echo "  [dry-run] aws emr-serverless create-application --name ${APP_NAME} --release-label ${RELEASE} --type SPARK"
+    APP_ID="<new-app-id>"
+  else
+    APP_ID=$(aws emr-serverless create-application $EP_FLAG --region "$REGION" \
+              --name "$APP_NAME" --release-label "$RELEASE" --type SPARK \
+              --query 'applicationId' --output text)
+    echo "   created EMR Serverless app ${APP_NAME} (${RELEASE})"
+  fi
+fi
+
+echo ""
+echo ">> DONE. Consumer setup complete."
+echo "   --app-id   ${APP_ID}"
+echo "   --role-arn ${ROLE_ARN}"
+echo "   --bucket   ${BUCKET}"
+echo "   Run the demo:"
+echo "     ./run_demo.sh --phase all --app-id ${APP_ID} --role-arn ${ROLE_ARN} --bucket ${BUCKET} --region ${REGION} \\"
+echo "        ${PRODUCER_ACCOUNT:+--producer-account ${PRODUCER_ACCOUNT} --producer-db salesdb --producer-table fulfillment}"

--- a/examples/emr-multi-catalog/scripts/bootstrap_producer.sh
+++ b/examples/emr-multi-catalog/scripts/bootstrap_producer.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Cross-account demo bootstrap — PRODUCER side.
+# Run this with the PRODUCER account's credentials. It:
+#   1. creates an S3 bucket for the producer data (if needed),
+#   2. uploads a tiny CSV and registers it as a Hive table in the Glue Data Catalog,
+#   3. grants the CONSUMER role read access across the four layers:
+#        - Lake Formation (IAM_ALLOWED_PRINCIPALS hybrid mode)
+#        - Glue Data Catalog resource policy (incl. database/default)
+#        - Amazon S3 bucket policy
+#   (KMS: this demo leaves the catalog unencrypted. If your catalog uses a
+#    customer-managed key, add kms:Decrypt for the consumer role to that key policy.
+#    The AWS-managed aws/glue key CANNOT be shared cross-account.)
+#
+# Usage:
+#   ./bootstrap_producer.sh --consumer-role arn:aws:iam::444455556666:role/<role> \
+#       [--region us-east-1] [--bucket <bucket>] [--db salesdb] [--table fulfillment]
+set -euo pipefail
+
+REGION="us-east-1" BUCKET="" DB="salesdb" TABLE="fulfillment" CONSUMER_ROLE="" DRY_RUN=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --consumer-role) CONSUMER_ROLE="$2"; shift 2;;
+    --region)        REGION="$2"; shift 2;;
+    --bucket)        BUCKET="$2"; shift 2;;
+    --db)            DB="$2"; shift 2;;
+    --table)         TABLE="$2"; shift 2;;
+    --dry-run)       DRY_RUN=true; shift;;
+    *) echo "unknown flag: $1" >&2; exit 2;;
+  esac
+done
+[[ -z "$CONSUMER_ROLE" ]] && { echo "missing --consumer-role" >&2; exit 2; }
+$DRY_RUN && echo ">> DRY RUN — no resources will be created or modified (read-only calls still run)"
+
+# run a MUTATING command, or just print it under --dry-run
+run() { if $DRY_RUN; then echo "  [dry-run] $*"; else "$@"; fi; }
+
+ACCOUNT=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)
+if [[ -z "$ACCOUNT" ]]; then
+  $DRY_RUN && ACCOUNT="<producer-account-id>" || { echo "cannot determine caller account (invalid/expired creds?)" >&2; exit 1; }
+fi
+BUCKET="${BUCKET:-xacct-demo-${ACCOUNT}-${REGION//-/}}"
+LOCATION="s3://${BUCKET}/${DB}/${TABLE}"
+echo ">> producer account=${ACCOUNT} region=${REGION} bucket=${BUCKET}"
+echo ">> table=${DB}.${TABLE} location=${LOCATION}"
+echo ">> granting consumer role: ${CONSUMER_ROLE}"
+
+# 1. bucket -------------------------------------------------------------------
+if ! aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+  if [[ "$REGION" == "us-east-1" ]]; then
+    run aws s3api create-bucket --bucket "$BUCKET" --region "$REGION"
+  else
+    run aws s3api create-bucket --bucket "$BUCKET" --region "$REGION" \
+      --create-bucket-configuration LocationConstraint="$REGION"
+  fi
+  echo "   created bucket ${BUCKET}"
+fi
+
+# 2. sample data + Glue table -------------------------------------------------
+TMP=$(mktemp)
+printf '1,prod-1\n2,prod-2\n3,prod-3\n' > "$TMP"
+run aws s3 cp "$TMP" "${LOCATION}/data.csv" --region "$REGION"
+rm -f "$TMP"
+
+if $DRY_RUN; then
+  echo "  [dry-run] aws glue create-database --database-input {\"Name\":\"${DB}\"}"
+else
+  aws glue create-database --region "$REGION" --database-input "{\"Name\":\"${DB}\"}" 2>/dev/null || true
+fi
+
+cat > /tmp/table-input.json <<EOF
+{
+  "Name": "${TABLE}",
+  "TableType": "EXTERNAL_TABLE",
+  "Parameters": {"classification": "csv", "EXTERNAL": "TRUE"},
+  "StorageDescriptor": {
+    "Columns": [{"Name": "id", "Type": "int"}, {"Name": "val", "Type": "string"}],
+    "Location": "${LOCATION}",
+    "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
+    "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+    "SerdeInfo": {
+      "SerializationLibrary": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+      "Parameters": {"field.delim": ","}
+    }
+  }
+}
+EOF
+run aws glue delete-table --database-name "$DB" --name "$TABLE" --region "$REGION" 2>/dev/null || true
+run aws glue create-table --database-name "$DB" --region "$REGION" \
+  --table-input file:///tmp/table-input.json
+echo "   registered ${DB}.${TABLE}"
+
+# 3. Lake Formation grant (IAM_ALLOWED_PRINCIPALS / hybrid mode) --------------
+run aws lakeformation grant-permissions --region "$REGION" \
+  --principal DataLakePrincipalIdentifier=IAM_ALLOWED_PRINCIPALS \
+  --resource "{\"Table\":{\"CatalogId\":\"${ACCOUNT}\",\"DatabaseName\":\"${DB}\",\"Name\":\"${TABLE}\"}}" \
+  --permissions SELECT DESCRIBE 2>/dev/null || echo "   (LF table grant skipped/existing)"
+run aws lakeformation grant-permissions --region "$REGION" \
+  --principal DataLakePrincipalIdentifier=IAM_ALLOWED_PRINCIPALS \
+  --resource "{\"Database\":{\"CatalogId\":\"${ACCOUNT}\",\"Name\":\"${DB}\"}}" \
+  --permissions DESCRIBE 2>/dev/null || echo "   (LF db grant skipped/existing)"
+
+# 4. Glue resource policy (MUST include database/default) ---------------------
+cat > /tmp/glue-resource-policy.json <<EOF
+{ "Version": "2012-10-17", "Statement": [{
+  "Effect": "Allow",
+  "Principal": {"AWS": "${CONSUMER_ROLE}"},
+  "Action": ["glue:GetCatalog","glue:GetDatabase","glue:GetDatabases",
+             "glue:GetTable","glue:GetTables","glue:GetPartition","glue:GetPartitions"],
+  "Resource": ["arn:aws:glue:${REGION}:${ACCOUNT}:catalog",
+               "arn:aws:glue:${REGION}:${ACCOUNT}:database/*",
+               "arn:aws:glue:${REGION}:${ACCOUNT}:table/*/*"]
+}]}
+EOF
+run aws glue put-resource-policy --region "$REGION" \
+  --policy-in-json file:///tmp/glue-resource-policy.json --enable-hybrid TRUE
+echo "   applied Glue resource policy"
+
+# 5. S3 bucket policy ---------------------------------------------------------
+cat > /tmp/s3-bucket-policy.json <<EOF
+{ "Version": "2012-10-17", "Statement": [{
+  "Sid": "AllowConsumerRead",
+  "Effect": "Allow",
+  "Principal": {"AWS": "${CONSUMER_ROLE}"},
+  "Action": ["s3:GetObject","s3:ListBucket"],
+  "Resource": ["arn:aws:s3:::${BUCKET}","arn:aws:s3:::${BUCKET}/*"]
+}]}
+EOF
+run aws s3api put-bucket-policy --bucket "$BUCKET" --region "$REGION" \
+  --policy file:///tmp/s3-bucket-policy.json
+echo "   applied S3 bucket policy"
+
+echo ""
+echo ">> DONE. Producer setup complete."
+echo "   Producer account : ${ACCOUNT}"
+echo "   Producer db.table: ${DB}.${TABLE}"
+echo "   Now run on the CONSUMER side:"
+echo "     ./run_demo.sh --phase xacct-autowire --app-id <app> --role-arn <role> \\"
+echo "        --bucket <consumer-bucket> --producer-account ${ACCOUNT} \\"
+echo "        --producer-db ${DB} --producer-table ${TABLE}"

--- a/examples/emr-multi-catalog/scripts/cleanup.sh
+++ b/examples/emr-multi-catalog/scripts/cleanup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Clean up the demo: drop the demo tables/database and wipe the S3 warehouse.
+# Delegates to the validated `run_demo.sh --phase cleanup` (reads .env for
+# APP_ID / ROLE_ARN / BUCKET / REGION; extra flags are forwarded).
+#
+# Usage:
+#   ./scripts/cleanup.sh
+#
+# Note: this does not delete the EMR Serverless application or the execution
+# role. Remove those separately if you created them only for this demo.
+#
+set -euo pipefail
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SELF_DIR}/run_demo.sh" --phase cleanup "$@"

--- a/examples/emr-multi-catalog/scripts/crossaccount_policies/glue-resource-policy.json
+++ b/examples/emr-multi-catalog/scripts/crossaccount_policies/glue-resource-policy.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowConsumerRoleReadCatalog",
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::444455556666:role/EMRExecutionRole" },
+      "Action": [
+        "glue:GetCatalog",
+        "glue:GetDatabase",
+        "glue:GetDatabases",
+        "glue:GetTable",
+        "glue:GetTables",
+        "glue:GetPartition",
+        "glue:GetPartitions"
+      ],
+      "Resource": [
+        "arn:aws:glue:us-east-1:111122223333:catalog",
+        "arn:aws:glue:us-east-1:111122223333:database/*",
+        "arn:aws:glue:us-east-1:111122223333:table/*/*"
+      ]
+    }
+  ]
+}

--- a/examples/emr-multi-catalog/scripts/crossaccount_policies/lakeformation-grants.sh
+++ b/examples/emr-multi-catalog/scripts/crossaccount_policies/lakeformation-grants.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Run in the PRODUCER account (111122223333). Grants the consumer read access.
+# This example uses hybrid access mode (IAM_ALLOWED_PRINCIPALS); on Lake Formation
+# cross-account version 3+ you can instead grant directly to the consumer role as a
+# named principal.
+set -euo pipefail
+
+PRODUCER_CATALOG="111122223333"
+DB="salesdb"
+TBL="fulfillment"
+
+aws lakeformation grant-permissions \
+  --principal DataLakePrincipalIdentifier=IAM_ALLOWED_PRINCIPALS \
+  --resource "{\"Table\":{\"CatalogId\":\"${PRODUCER_CATALOG}\",\"DatabaseName\":\"${DB}\",\"Name\":\"${TBL}\"}}" \
+  --permissions SELECT DESCRIBE
+
+aws lakeformation grant-permissions \
+  --principal DataLakePrincipalIdentifier=IAM_ALLOWED_PRINCIPALS \
+  --resource "{\"Database\":{\"CatalogId\":\"${PRODUCER_CATALOG}\",\"Name\":\"${DB}\"}}" \
+  --permissions DESCRIBE
+
+# Attach the Glue resource policy (must include database/default) and the S3 bucket policy:
+aws glue put-resource-policy --policy-in-json file://glue-resource-policy.json --enable-hybrid TRUE
+aws s3api put-bucket-policy --bucket producer-data-bucket --policy file://s3-bucket-policy.json

--- a/examples/emr-multi-catalog/scripts/crossaccount_policies/s3-bucket-policy.json
+++ b/examples/emr-multi-catalog/scripts/crossaccount_policies/s3-bucket-policy.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowConsumerRoleReadData",
+      "Effect": "Allow",
+      "Principal": { "AWS": "arn:aws:iam::444455556666:role/EMRExecutionRole" },
+      "Action": ["s3:GetObject", "s3:ListBucket"],
+      "Resource": [
+        "arn:aws:s3:::producer-data-bucket",
+        "arn:aws:s3:::producer-data-bucket/*"
+      ]
+    }
+  ]
+}

--- a/examples/emr-multi-catalog/scripts/multicatalog_demo.py
+++ b/examples/emr-multi-catalog/scripts/multicatalog_demo.py
@@ -1,0 +1,221 @@
+"""
+Multi-catalog demo for Amazon EMR 8.1 (release emr-8.1.0).
+
+A single, generic PySpark script that creates small sample tables and
+demonstrates the three multi-catalog capabilities of the redirecting session
+catalog (RSC). Spark catalog configuration is supplied at spark-submit time by
+the driver (run_demo.sh); this script only issues SQL and reports PASS/FAIL.
+
+Phases (--phase):
+  setup           Create one sample table per format (Iceberg, Delta, Hudi, Hive),
+                  3 rows each, in --db under --warehouse. Run in the account where
+                  your query engine lives (the "consumer").
+  multiformat     Join all four formats in one query, unqualified names.
+  producer-setup  Create ONE Hive sample table (--producer-table) with 3 rows,
+                  in --db under --warehouse. Run this in the PRODUCER account
+                  (point the driver at that account's app/role) so there is a
+                  cross-account table to read.
+  xacct-named     Read the producer table through a declared named catalog
+                  (--named-catalog, default 'prod') and join to local Iceberg.
+  xacct-autowire  Read the producer table via auto-wiring: reference it by its
+                  backtick-quoted account id, no catalog declaration.
+  all             setup + multiformat, plus the two xacct phases if
+                  --producer-account is provided.
+
+The cross-account phases assume the producer table exists and the cross-account
+grants are in place (Lake Formation + Glue resource policy incl. database/default
++ S3 bucket policy + a decryptable catalog). See ../README.md.
+"""
+import argparse
+import sys
+import traceback
+
+RESULTS = []
+
+
+def step(name, fn, *args):
+    try:
+        fn(*args)
+        RESULTS.append(("PASS", name, ""))
+        print(f"\n===== PASS: {name} =====\n")
+    except Exception as e:  # capture every failure as data
+        msg = f"{type(e).__name__}: {str(e).splitlines()[0] if str(e) else e}"
+        RESULTS.append(("FAIL", name, msg))
+        print(f"\n===== FAIL: {name} :: {msg} =====\n")
+        traceback.print_exc()
+
+
+# ---------- sample data ----------
+ROWS = {"iceberg": "ice", "delta": "dl", "hudi": "hu", "hive": "hv"}
+
+
+def _insert(spark, db, tbl, tag):
+    spark.sql(f"INSERT INTO {db}.{tbl} (id, val) VALUES "
+              f"(1,'{tag}-1'),(2,'{tag}-2'),(3,'{tag}-3')")
+
+
+def setup(spark, a):
+    def _db(spark):
+        spark.sql(f"CREATE DATABASE IF NOT EXISTS {a.db} LOCATION '{a.warehouse}/{a.db}.db'")
+        spark.sql(f"USE {a.db}")
+    step("create-database", _db, spark)
+
+    def _ice(spark):
+        spark.sql(f"DROP TABLE IF EXISTS {a.db}.orders_iceberg")
+        spark.sql(f"CREATE TABLE {a.db}.orders_iceberg (id INT, val STRING) USING iceberg "
+                  f"LOCATION '{a.warehouse}/orders_iceberg'")
+        _insert(spark, a.db, "orders_iceberg", "ice")
+    step("create-iceberg", _ice, spark)
+
+    def _delta(spark):
+        spark.sql(f"DROP TABLE IF EXISTS {a.db}.returns_delta")
+        spark.sql(f"CREATE TABLE {a.db}.returns_delta (id INT, val STRING) USING delta "
+                  f"LOCATION '{a.warehouse}/returns_delta'")
+        _insert(spark, a.db, "returns_delta", "dl")
+    step("create-delta", _delta, spark)
+
+    def _hudi(spark):
+        spark.sql(f"DROP TABLE IF EXISTS {a.db}.shipments_hudi")
+        spark.sql(f"CREATE TABLE {a.db}.shipments_hudi (id INT, val STRING) USING hudi "
+                  f"TBLPROPERTIES (primaryKey = 'id') LOCATION '{a.warehouse}/shipments_hudi'")
+        _insert(spark, a.db, "shipments_hudi", "hu")
+    step("create-hudi", _hudi, spark)
+
+    def _hive(spark):
+        spark.sql(f"DROP TABLE IF EXISTS {a.db}.products_hive")
+        spark.sql(f"CREATE TABLE {a.db}.products_hive (id INT, val STRING) USING parquet "
+                  f"LOCATION '{a.warehouse}/products_hive'")
+        _insert(spark, a.db, "products_hive", "hv")
+    step("create-hive-parquet", _hive, spark)
+
+
+def multiformat(spark, a):
+    def _join(spark):
+        spark.sql(f"USE {a.db}")
+        df = spark.sql("""
+            SELECT i.id, i.val AS iceberg, d.val AS delta, h.val AS hudi, p.val AS hive
+            FROM   orders_iceberg  i
+            JOIN   returns_delta   d ON i.id = d.id
+            JOIN   shipments_hudi  h ON i.id = h.id
+            JOIN   products_hive   p ON i.id = p.id
+            ORDER BY i.id
+        """)
+        df.show(truncate=False)
+        n = df.count()
+        assert n == 3, f"expected 3 rows, got {n}"
+    step("multiformat-four-way-join", _join, spark)
+
+
+def producer_setup(spark, a):
+    def _mk(spark):
+        spark.sql(f"CREATE DATABASE IF NOT EXISTS {a.db} LOCATION '{a.warehouse}/{a.db}.db'")
+        spark.sql(f"DROP TABLE IF EXISTS {a.db}.{a.producer_table}")
+        spark.sql(f"CREATE TABLE {a.db}.{a.producer_table} (id INT, val STRING) USING parquet "
+                  f"LOCATION '{a.warehouse}/{a.producer_table}'")
+        _insert(spark, a.db, a.producer_table, "prod")
+        spark.sql(f"SELECT * FROM {a.db}.{a.producer_table} ORDER BY id").show(truncate=False)
+    step("producer-create-hive-table", _mk, spark)
+
+
+def _xacct_join(spark, a, ref, label):
+    n = spark.sql(f"SELECT count(*) AS n FROM {ref}").collect()[0]["n"]
+    print(f"    -> {label} read OK, {ref} count={n}")
+    spark.sql(f"""
+        SELECT r.id, r.val AS remote_{a.producer_account}, i.val AS local_iceberg
+        FROM   {ref}                    r
+        JOIN   {a.db}.orders_iceberg    i ON r.id = i.id
+        ORDER BY r.id
+    """).show(truncate=False)
+    assert n == 3, f"expected 3 rows, got {n}"
+
+
+def named_local(spark, a):
+    # Single-account demonstration of the NAMED-CATALOG mechanism (no 2nd account
+    # needed). 'cat2' is a named redirecting catalog pointed at THIS account's own
+    # Glue catalog id (set at submit time). It proves that a named catalog resolves
+    # and routes just like spark_catalog. Requires the setup phase to have run.
+    ref = f"cat2.{a.db}.orders_iceberg"
+
+    def _r(spark):
+        n = spark.sql(f"SELECT count(*) AS n FROM {ref}").collect()[0]["n"]
+        print(f"    -> named-catalog (same account) read OK, {ref} count={n}")
+        spark.sql(f"""
+            SELECT c.id, c.val AS via_named_cat2, h.val AS via_spark_catalog
+            FROM   {ref}                          c
+            JOIN   spark_catalog.{a.db}.products_hive h ON c.id = h.id
+            ORDER BY c.id
+        """).show(truncate=False)
+        assert n == 3, f"expected 3 rows, got {n}"
+    step(f"named-local [{ref}]", _r, spark)
+
+
+def cleanup(spark, a):
+    def _c(spark):
+        for t in ("orders_iceberg", "returns_delta", "shipments_hudi", "products_hive"):
+            spark.sql(f"DROP TABLE IF EXISTS {a.db}.{t}")
+        spark.sql(f"DROP DATABASE IF EXISTS {a.db} CASCADE")
+        print(f"dropped demo tables and database '{a.db}'")
+    step("cleanup-drop-tables", _c, spark)
+
+
+def xacct_named(spark, a):
+    ref = f"{a.named_catalog}.{a.producer_db}.{a.producer_table}"
+    step(f"xacct-named [{ref}]", _xacct_join, spark, a, ref, "named-catalog")
+
+
+def xacct_autowire(spark, a):
+    # backtick-quote the producer account id (leading digit requires it)
+    ref = f"`{a.producer_account}`.{a.producer_db}.{a.producer_table}"
+    step(f"xacct-autowire [{ref}]", _xacct_join, spark, a, ref, "auto-wired")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="EMR 8.1 multi-catalog demo")
+    p.add_argument("--phase", required=True,
+                   choices=["setup", "multiformat", "named-local", "producer-setup",
+                            "xacct-named", "xacct-autowire", "cleanup", "all"])
+    p.add_argument("--warehouse", default="s3://amzn-s3-demo-bucket/multicatalog/warehouse")
+    p.add_argument("--db", default="salesdb")
+    p.add_argument("--producer-account", default=None, help="12-digit producer account id")
+    p.add_argument("--producer-db", default="salesdb")
+    p.add_argument("--producer-table", default="fulfillment")
+    p.add_argument("--named-catalog", default="prod")
+    return p.parse_args()
+
+
+def main():
+    a = parse_args()
+    from pyspark.sql import SparkSession
+    spark = SparkSession.builder.appName(f"multicatalog-demo-{a.phase}").getOrCreate()
+    print("=== Spark version:", spark.version)
+    print("=== phase:", a.phase)
+    print("=== spark_catalog =", spark.conf.get("spark.sql.catalog.spark_catalog", "<unset>"))
+    print("=== catalogResolver =", spark.conf.get("spark.sql.catalogResolver", "<unset>"))
+
+    if a.phase in ("setup", "all"):
+        setup(spark, a)
+    if a.phase in ("multiformat", "all"):
+        multiformat(spark, a)
+    if a.phase == "named-local":
+        named_local(spark, a)
+    if a.phase == "cleanup":
+        cleanup(spark, a)
+    if a.phase == "producer-setup":
+        producer_setup(spark, a)
+    if a.phase in ("xacct-named",) or (a.phase == "all" and a.producer_account):
+        xacct_named(spark, a)
+    if a.phase in ("xacct-autowire",) or (a.phase == "all" and a.producer_account):
+        xacct_autowire(spark, a)
+
+    print("\n\n########## RESULT SUMMARY ##########")
+    for status, name, msg in RESULTS:
+        print(f"{status:4}  {name}  {msg}")
+    print("####################################\n")
+
+    spark.stop()
+    if any(s == "FAIL" for s, _, _ in RESULTS):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/emr-multi-catalog/scripts/run_demo.sh
+++ b/examples/emr-multi-catalog/scripts/run_demo.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+#
+# Generic driver for the EMR 8.1 multi-catalog demo. Submits multicatalog_demo.py
+# to Amazon EMR (on EC2 or Serverless), waits for completion, and prints the
+# driver output (the PASS/FAIL summary and query results).
+#
+# Target EMR on EC2 (default):
+#   ./run_demo.sh --phase <phase> --cluster-id <j-XXX> --bucket <bucket> [--region us-east-1]
+#
+# Target EMR Serverless:
+#   ./run_demo.sh --target serverless --phase <phase> \
+#       --app-id <id> --role-arn <arn> --bucket <bucket> [--region us-east-1]
+#
+# Common optional flags: --producer-account 111122223333 --producer-db salesdb
+#   --producer-table fulfillment --named-catalog prod --db salesdb
+#
+# Phases: setup | multiformat (alias: query) | named-local | producer-setup |
+#         xacct-named | xacct-autowire | cleanup | all
+#
+# Values may also be supplied via a .env file (see env.template) so you do not
+# repeat --cluster-id / --app-id / --role-arn / --bucket on every command.
+set -euo pipefail
+
+# ---- load .env (if present) ------------------------------------------------
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+for _envf in "./.env" "${SELF_DIR}/../.env" "${SELF_DIR}/.env"; do
+  [[ -f "$_envf" ]] && { set -a; . "$_envf"; set +a; break; }
+done
+
+# ---- defaults / parse flags ------------------------------------------------
+TARGET="${TARGET:-ec2}"
+PHASE="" CLUSTER_ID="${CLUSTER_ID:-}" APP_ID="${APP_ID:-}" ROLE_ARN="${ROLE_ARN:-}"
+BUCKET="${BUCKET:-}" REGION="${REGION:-us-east-1}"
+DB="salesdb" PRODUCER_ACCOUNT="${PRODUCER_ACCOUNT:-}" PRODUCER_DB="salesdb" PRODUCER_TABLE="fulfillment"
+NAMED_CATALOG="prod" ENDPOINT="${ENDPOINT:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)            TARGET="$2"; shift 2;;
+    --phase)             PHASE="$2"; shift 2;;
+    --cluster-id)        CLUSTER_ID="$2"; shift 2;;
+    --app-id)            APP_ID="$2"; shift 2;;
+    --role-arn)          ROLE_ARN="$2"; shift 2;;
+    --bucket)            BUCKET="$2"; shift 2;;
+    --region)            REGION="$2"; shift 2;;
+    --db)                DB="$2"; shift 2;;
+    --producer-account)  PRODUCER_ACCOUNT="$2"; shift 2;;
+    --producer-db)       PRODUCER_DB="$2"; shift 2;;
+    --producer-table)    PRODUCER_TABLE="$2"; shift 2;;
+    --named-catalog)     NAMED_CATALOG="$2"; shift 2;;
+    --endpoint)          ENDPOINT="$2"; shift 2;;
+    *) echo "unknown flag: $1" >&2; exit 2;;
+  esac
+done
+
+# 'query' is a friendly alias for the multi-format join phase
+[[ "$PHASE" == "query" ]] && PHASE="multiformat"
+
+[[ -z "$PHASE" ]]  && { echo "missing --phase" >&2; exit 2; }
+[[ -z "$BUCKET" ]] && { echo "missing --bucket (or set BUCKET in .env)" >&2; exit 2; }
+case "$TARGET" in
+  ec2)        [[ -z "$CLUSTER_ID" ]] && { echo "missing --cluster-id (or CLUSTER_ID in .env)" >&2; exit 2; };;
+  serverless) for r in APP_ID ROLE_ARN; do [[ -z "${!r}" ]] && { echo "missing --${r,,} (serverless)" >&2; exit 2; }; done;;
+  *) echo "unknown --target: $TARGET (use ec2 or serverless)" >&2; exit 2;;
+esac
+
+PREFIX="s3://${BUCKET}/multicatalog"
+SCRIPTS="${PREFIX}/scripts"; WAREHOUSE="${PREFIX}/warehouse"; LOGS="${PREFIX}/logs"
+
+# ---- Spark conf ------------------------------------------------------------
+RSC="org.apache.spark.sql.connector.catalog.redirecting.RedirectingSessionCatalog"
+EXT="org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,io.delta.sql.DeltaSparkSessionExtension,org.apache.spark.sql.hudi.HoodieSparkSessionExtension"
+KRYO="org.apache.spark.serializer.KryoSerializer"
+GLUE_FACTORY="com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+
+CONF="--conf spark.sql.catalog.spark_catalog=${RSC}"
+CONF+=" --conf spark.sql.extensions=${EXT}"
+CONF+=" --conf spark.serializer=${KRYO}"
+CONF+=" --conf spark.hadoop.hive.metastore.client.factory.class=${GLUE_FACTORY}"
+CONF+=" --conf spark.sql.catalogImplementation=hive"
+
+case "$PHASE" in
+  named-local)
+    LOCAL_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+    CONF+=" --conf spark.sql.catalog.cat2=${RSC}"
+    CONF+=" --conf spark.sql.catalog.cat2.metastore.type=glue"
+    CONF+=" --conf spark.sql.catalog.cat2.metastore.hadoop.hive.metastore.glue.catalogid=${LOCAL_ACCOUNT}"
+    ;;
+  xacct-named)
+    [[ -z "$PRODUCER_ACCOUNT" ]] && { echo "--producer-account required for xacct-named" >&2; exit 2; }
+    CONF+=" --conf spark.sql.catalog.${NAMED_CATALOG}=${RSC}"
+    CONF+=" --conf spark.sql.catalog.${NAMED_CATALOG}.metastore.type=glue"
+    CONF+=" --conf spark.sql.catalog.${NAMED_CATALOG}.metastore.hadoop.hive.metastore.glue.catalogid=${PRODUCER_ACCOUNT}"
+    ;;
+  xacct-autowire)
+    [[ -z "$PRODUCER_ACCOUNT" ]] && { echo "--producer-account required for xacct-autowire" >&2; exit 2; }
+    CONF+=" --conf spark.sql.catalogResolver=com.amazonaws.glue.catalog.redirecting.GlueCatalogResolver"
+    CONF+=" --conf spark.sql.catalogResolver.region=${REGION}"
+    ;;
+  all)
+    if [[ -n "$PRODUCER_ACCOUNT" ]]; then
+      CONF+=" --conf spark.sql.catalog.${NAMED_CATALOG}=${RSC}"
+      CONF+=" --conf spark.sql.catalog.${NAMED_CATALOG}.metastore.type=glue"
+      CONF+=" --conf spark.sql.catalog.${NAMED_CATALOG}.metastore.hadoop.hive.metastore.glue.catalogid=${PRODUCER_ACCOUNT}"
+      CONF+=" --conf spark.sql.catalogResolver=com.amazonaws.glue.catalog.redirecting.GlueCatalogResolver"
+      CONF+=" --conf spark.sql.catalogResolver.region=${REGION}"
+    fi
+    ;;
+esac
+
+# ---- worker arguments ------------------------------------------------------
+# space-separated form (EC2 spark-submit CLI)
+PYARGS="--phase ${PHASE} --warehouse ${WAREHOUSE} --db ${DB} --producer-db ${PRODUCER_DB} --producer-table ${PRODUCER_TABLE} --named-catalog ${NAMED_CATALOG}"
+[[ -n "$PRODUCER_ACCOUNT" ]] && PYARGS+=" --producer-account ${PRODUCER_ACCOUNT}"
+# JSON array form (Serverless entryPointArguments)
+ARGS="[\"--phase\",\"${PHASE}\",\"--warehouse\",\"${WAREHOUSE}\",\"--db\",\"${DB}\""
+ARGS+=",\"--producer-db\",\"${PRODUCER_DB}\",\"--producer-table\",\"${PRODUCER_TABLE}\",\"--named-catalog\",\"${NAMED_CATALOG}\""
+[[ -n "$PRODUCER_ACCOUNT" ]] && ARGS+=",\"--producer-account\",\"${PRODUCER_ACCOUNT}\""
+ARGS+="]"
+
+# ---- clean warehouse before a fresh setup ----------------------------------
+if [[ "$PHASE" == "setup" || "$PHASE" == "all" ]]; then
+  echo ">> clearing warehouse for a clean setup: ${WAREHOUSE}"
+  aws s3 rm "${WAREHOUSE}" --recursive --region "$REGION" >/dev/null 2>&1 || true
+fi
+
+# ---- upload worker ---------------------------------------------------------
+echo ">> uploading multicatalog_demo.py to ${SCRIPTS}/"
+aws s3 cp "${SELF_DIR}/multicatalog_demo.py" "${SCRIPTS}/multicatalog_demo.py" --region "$REGION" >/dev/null
+
+# ============================================================================
+if [[ "$TARGET" == "ec2" ]]; then
+  # ---- EMR on EC2: submit a step that spark-submits and tees output to S3 ---
+  OUT_KEY="${LOGS}/${PHASE}-out.txt"
+  RUNNER_KEY="${SCRIPTS}/_ec2_run_${PHASE}.sh"
+  RUNNER="$(mktemp)"
+  cat > "$RUNNER" <<EOF
+#!/bin/bash
+set -x
+aws s3 cp ${SCRIPTS}/multicatalog_demo.py /tmp/multicatalog_demo.py
+spark-submit --deploy-mode client ${CONF} /tmp/multicatalog_demo.py ${PYARGS} > /tmp/mc_out.txt 2>&1
+echo "EXIT=\$?" >> /tmp/mc_out.txt
+aws s3 cp /tmp/mc_out.txt ${OUT_KEY}
+EOF
+  aws s3 cp "$RUNNER" "$RUNNER_KEY" --region "$REGION" >/dev/null
+  echo ">> submitting step to cluster ${CLUSTER_ID} (phase '${PHASE}')"
+  STEP=$(aws emr add-steps --cluster-id "$CLUSTER_ID" --region "$REGION" \
+    --steps "Type=CUSTOM_JAR,Name=multicatalog-${PHASE},Jar=command-runner.jar,ActionOnFailure=CONTINUE,Args=[bash,-c,aws s3 cp ${RUNNER_KEY} /tmp/r.sh && bash /tmp/r.sh]" \
+    --query 'StepIds[0]' --output text)
+  echo ">> stepId=${STEP}"
+  while true; do
+    ST=$(aws emr describe-step --cluster-id "$CLUSTER_ID" --step-id "$STEP" --region "$REGION" --query 'Step.Status.State' --output text)
+    echo "   state=${ST}"
+    case "$ST" in COMPLETED|FAILED|CANCELLED) break;; esac
+    sleep 15
+  done
+  echo ">> worker output (${OUT_KEY}):"
+  aws s3 cp "$OUT_KEY" - --region "$REGION" 2>/dev/null || echo "   (output not found; check step logs)"
+  RC=$(aws s3 cp "$OUT_KEY" - --region "$REGION" 2>/dev/null | grep -oE 'EXIT=[0-9]+' | tail -1 | cut -d= -f2)
+  [[ "$ST" == "COMPLETED" && "${RC:-1}" == "0" ]] || { echo ">> phase ${PHASE} did not succeed"; exit 1; }
+
+else
+  # ---- EMR Serverless: start a job run and fetch driver stdout --------------
+  EP_FLAG=""; [[ -n "$ENDPOINT" ]] && EP_FLAG="--endpoint-url $ENDPOINT"
+  echo ">> submitting phase '${PHASE}' to application ${APP_ID}"
+  JR=$(aws emr-serverless start-job-run $EP_FLAG --region "$REGION" \
+        --application-id "$APP_ID" --execution-role-arn "$ROLE_ARN" \
+        --name "multicatalog-demo-${PHASE}" \
+        --job-driver "{\"sparkSubmit\":{\"entryPoint\":\"${SCRIPTS}/multicatalog_demo.py\",\"entryPointArguments\":${ARGS},\"sparkSubmitParameters\":\"${CONF}\"}}" \
+        --configuration-overrides "{\"monitoringConfiguration\":{\"s3MonitoringConfiguration\":{\"logUri\":\"${LOGS}/\"}}}" \
+        --query 'jobRunId' --output text)
+  echo ">> jobRunId=${JR}"
+  while true; do
+    ST=$(aws emr-serverless get-job-run $EP_FLAG --region "$REGION" \
+          --application-id "$APP_ID" --job-run-id "$JR" --query 'jobRun.state' --output text)
+    echo "   state=${ST}"
+    case "$ST" in SUCCESS|FAILED|CANCELLED) break;; esac
+    sleep 15
+  done
+  OUT="${LOGS}/applications/${APP_ID}/jobs/${JR}/SPARK_DRIVER/stdout.gz"
+  echo ">> driver stdout (${OUT}):"
+  if aws s3 cp "$OUT" - --region "$REGION" 2>/dev/null | gunzip -c 2>/dev/null; then :; else
+    echo "   (stdout not found yet; fetch manually from ${OUT})"; fi
+  [[ "$ST" == "SUCCESS" ]] || { echo ">> job ${ST}"; exit 1; }
+fi
+
+# ---- cleanup phase also wipes the S3 warehouse -----------------------------
+if [[ "$PHASE" == "cleanup" ]]; then
+  echo ">> wiping ${WAREHOUSE}"
+  aws s3 rm "${WAREHOUSE}" --recursive --region "$REGION" >/dev/null 2>&1 || true
+fi


### PR DESCRIPTION
Companion demo for the AWS Big Data Blog on multi-catalog support in Amazon EMR 8.1. Adds examples/emr-multi-catalog with a PySpark worker + driver for the four-format join, named cross-account catalog, and GlueCatalogResolver auto-wiring on EMR Serverless or EMR on EC2. Introduces a new top-level examples/ directory.